### PR TITLE
Add candid interface

### DIFF
--- a/candid.did
+++ b/candid.did
@@ -1,1 +1,14 @@
-// An empty candid interface (for now).
+type network = variant {
+  mainnet;
+  testnet;
+  regtest;
+};
+
+type init_payload = record {
+  stability_threshold: nat;
+  network: network;
+};
+
+service bitcoin: (init_payload) -> {
+
+}

--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.11.1-beta.2",
+  "dfx": "0.11.1",
   "canisters": {
     "bitcoin": {
       "type": "custom",

--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -235,7 +235,6 @@ fn contains(block_tree: &BlockTree, block: &Block) -> bool {
 #[derive(Debug)]
 pub struct BlockDoesNotExtendTree(pub Block);
 
-
 // A method for serde to serialize a block.
 // Serialization relies on converting the block into a blob using the
 // Bitcoin standard format.

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,12 +13,14 @@ use std::convert::TryInto;
 /// The payload used to initialize the canister.
 #[derive(CandidType, Deserialize)]
 pub struct InitPayload {
-    pub stability_threshold: u32,
+    pub stability_threshold: u128,
     pub network: Network,
 }
 
 /// A reference to a transaction output.
-#[derive(CandidType, Clone, Debug, Deserialize, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize)]
+#[derive(
+    CandidType, Clone, Debug, Deserialize, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize,
+)]
 pub struct OutPoint {
     #[serde(with = "serde_bytes")]
     pub txid: Vec<u8>,
@@ -58,8 +60,11 @@ impl From<&BitcoinTxOut> for TxOut {
 
 #[derive(CandidType, Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum Network {
+    #[serde(rename = "mainnet")]
     Mainnet,
+    #[serde(rename = "testnet")]
     Testnet,
+    #[serde(rename = "regtest")]
     Regtest,
 }
 

--- a/src/unstable_blocks.rs
+++ b/src/unstable_blocks.rs
@@ -1,6 +1,6 @@
 use crate::blocktree::{self, BlockChain, BlockDoesNotExtendTree, BlockTree};
 use bitcoin::{Block, BlockHash};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// A data structure for maintaining all unstable blocks.
 ///


### PR DESCRIPTION
The candid interface doesn't include any methods yet. There were some minor
modifications done to the interface:

1. The `network` variant is lower-case, to be consistent with other interfaces that we have.
2. The `stability_threshold` is represented as a `nat`, which is the recommended way of encoding numbers per the candid experts.