### PR TITLE
Make E2E test more robust.

### DIFF
--- a/e2e-tests/syncing_single_block.sh
+++ b/e2e-tests/syncing_single_block.sh
@@ -2,7 +2,28 @@
 set -Eexuo pipefail
 
 # Run dfx stop if we run into errors.
-trap "dfx stop" ERR
+trap "dfx stop" ERR EXIT
+
+# Waits until the main chain of the bitcoin canister has reached a certain height.
+wait_until_height () {
+  HEIGHT=$1
+  ATTEMPTS=$2
+
+  BITCOIN_CANISTER_ID=$(dfx canister id bitcoin)
+
+  while
+    METRICS=$(curl "http://127.0.0.1:8000/metrics?canisterId=$BITCOIN_CANISTER_ID")
+    ! [[ "$METRICS" == *"main_chain_height $HEIGHT"* ]]; do
+      ((ATTEMPTS-=1))
+
+      if [[ $ATTEMPTS -eq 0 ]]; then
+	echo "TIMED OUT"
+	exit 1
+      fi
+
+      sleep 1
+  done
+}
 
 rm -rf .dfx
 dfx start --background
@@ -17,15 +38,13 @@ dfx deploy --no-wallet bitcoin --argument "(record {
   blocks_source = principal \"$(dfx canister id management-canister-mock)\"
 })"
 
-# Wait a few seconds for the block to be ingested.
-sleep 5
+# Wait until the chain is at height 1 (and for at most 5 seconds).
+wait_until_height 1 5
 
 # Fetch the balance of an address we expect to have funds.
 BALANCE=$(dfx canister call bitcoin get_balance '(record {
   address = "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8"
 })')
-
-dfx stop
 
 # Verify that the balance is 50 BTC.
 if [[ $BALANCE = "(5_000_000_000 : nat64)" ]]; then


### PR DESCRIPTION
Instead of waiting for some arbitrary number of seconds and assume that
the block has been ingested, the test now queries the metrics and
verifies that the block has been ingested before querying the account's
balance.