### PR TITLE
Refactor time-slicing code

### DIFF
--- a/canister/src/utxoset.rs
+++ b/canister/src/utxoset.rs
@@ -1,13 +1,12 @@
 use crate::address_utxoset::AddressUtxoSet;
 use crate::{
     runtime::performance_counter,
+    state::PartialStableBlock,
     state::UtxoSet,
     types::{OutPoint, Slicing, Storable},
 };
-use bitcoin::{Address, Script, Transaction, TxOut, Txid};
+use bitcoin::{Address, Block, Script, Transaction, TxOut, Txid};
 use std::str::FromStr;
-
-type Height = u32;
 
 lazy_static::lazy_static! {
     static ref DUPLICATE_TX_IDS: [Vec<u8>; 2] = [
@@ -25,16 +24,79 @@ pub fn get_utxos<'a>(utxo_set: &'a UtxoSet, address: &'a str) -> AddressUtxoSet<
     AddressUtxoSet::new(address.to_string(), utxo_set)
 }
 
-/// Ingests a transaction into the given UTXO set at the given height.
+/// Ingests a block into the `UtxoSet`.
 ///
-/// NOTE: This method does a form of time-slicing to stay within the instruction limit, and
-/// multiple calls may be required for the transaction to be ingested.
+/// The inputs of all the transactions in the block are removed and the outputs are inserted.
+/// The block is assumed to be valid, and so a failure of any of these operations causes a panic.
 ///
-/// Returns a `Slicing` struct with a tuple containing (# inputs removed, # outputs inserted).
-pub fn ingest_tx_with_slicing(
+/// Returns `Slicing::Done` if ingestion is complete, or `Slicing::Paused` if ingestion hasn't
+/// fully completed due to instruction limits. In the latter case, one or more calls to
+/// `ingest_block_continue` are necessary to finish the block ingestion.
+pub fn ingest_block(utxo_set: &mut UtxoSet, block: Block) -> Slicing<()> {
+    assert!(
+        utxo_set.partial_stable_block.is_none(),
+        "Cannot ingest new block while previous block (height {}) isn't fully ingested",
+        utxo_set.next_height
+    );
+
+    ingest_block_helper(utxo_set, block, 0, 0, 0)
+}
+
+/// Continue ingesting a block.
+pub fn ingest_block_continue(utxo_set: &mut UtxoSet) -> Slicing<()> {
+    match utxo_set.partial_stable_block.take() {
+        Some(p) => ingest_block_helper(
+            utxo_set,
+            p.block,
+            p.next_tx_idx,
+            p.next_input_idx,
+            p.next_output_idx,
+        ),
+        None => {
+            // No partially ingested block found. Nothing to do.
+            Slicing::Done
+        }
+    }
+}
+
+// Ingests a block starting from the given transaction and input/output indices.
+fn ingest_block_helper(
+    utxo_set: &mut UtxoSet,
+    block: Block,
+    next_tx_idx: usize,
+    next_input_idx: usize,
+    next_output_idx: usize,
+) -> Slicing<()> {
+    for (tx_idx, tx) in block.txdata.iter().enumerate().skip(next_tx_idx) {
+        if let Slicing::Paused((next_input_idx, next_output_idx)) =
+            ingest_tx_with_slicing(utxo_set, tx, next_input_idx, next_output_idx)
+        {
+            // Getting close to the the instructions limit. Pause execution.
+            utxo_set.partial_stable_block = Some(PartialStableBlock {
+                block,
+                next_tx_idx: tx_idx,
+                next_input_idx,
+                next_output_idx,
+            });
+
+            return Slicing::Paused(());
+        }
+    }
+
+    // Block ingestion complete.
+    utxo_set.next_height += 1;
+    Slicing::Done
+}
+
+// Ingests a transaction into the given UTXO set.
+//
+// NOTE: This method does a form of time-slicing to stay within the instruction limit, and
+// multiple calls may be required for the transaction to be ingested.
+//
+// Returns a `Slicing` struct with a tuple containing (# inputs removed, # outputs inserted).
+fn ingest_tx_with_slicing(
     utxo_set: &mut UtxoSet,
     tx: &Transaction,
-    height: Height,
     start_input_idx: usize,
     start_output_idx: usize,
 ) -> Slicing<(usize, usize)> {
@@ -42,7 +104,7 @@ pub fn ingest_tx_with_slicing(
         return Slicing::Paused((input_idx, 0));
     }
 
-    if let Slicing::Paused(output_idx) = insert_outputs(utxo_set, tx, height, start_output_idx) {
+    if let Slicing::Paused(output_idx) = insert_outputs(utxo_set, tx, start_output_idx) {
         return Slicing::Paused((tx.input.len(), output_idx));
     }
 
@@ -89,12 +151,7 @@ fn remove_inputs(utxo_set: &mut UtxoSet, tx: &Transaction, start_idx: usize) -> 
 }
 
 // Iterates over transaction outputs, starting from `start_idx`, and inserts them into the UTXO set.
-fn insert_outputs(
-    utxo_set: &mut UtxoSet,
-    tx: &Transaction,
-    height: Height,
-    start_idx: usize,
-) -> Slicing<usize> {
+fn insert_outputs(utxo_set: &mut UtxoSet, tx: &Transaction, start_idx: usize) -> Slicing<usize> {
     for (vout, output) in tx.output.iter().enumerate().skip(start_idx) {
         if performance_counter() >= MAX_INSTRUCTIONS_THRESHOLD {
             return Slicing::Paused(vout);
@@ -105,7 +162,6 @@ fn insert_outputs(
                 utxo_set,
                 OutPoint::new(tx.txid().to_vec(), vout as u32),
                 output.clone(),
-                height,
             );
         }
     }
@@ -113,14 +169,9 @@ fn insert_outputs(
     Slicing::Done
 }
 
-// Inserts a UTXO at a given height into the given UTXO set.
+// Inserts a UTXO into the given UTXO set.
 // A UTXO is represented by the the tuple: (outpoint, output)
-pub(crate) fn insert_utxo(
-    utxo_set: &mut UtxoSet,
-    outpoint: OutPoint,
-    output: TxOut,
-    height: Height,
-) {
+fn insert_utxo(utxo_set: &mut UtxoSet, outpoint: OutPoint, output: TxOut) {
     // Insert the outpoint.
     if let Some(address) = Address::from_script(&output.script_pubkey, utxo_set.network.into()) {
         let address_str = address.to_string();
@@ -136,14 +187,17 @@ pub(crate) fn insert_utxo(
             // Add the address to the index if we can parse it.
             utxo_set
                 .address_to_outpoints
-                .insert((address_str, height, outpoint.clone()).to_bytes(), vec![])
+                .insert(
+                    (address_str, utxo_set.next_height, outpoint.clone()).to_bytes(),
+                    vec![],
+                )
                 .expect("insertion must succeed");
         }
     }
 
     let outpoint_already_exists = utxo_set
         .utxos
-        .insert(outpoint.clone(), ((&output).into(), height));
+        .insert(outpoint.clone(), ((&output).into(), utxo_set.next_height));
 
     // Verify that we aren't overwriting a previously seen outpoint.
     // NOTE: There was a bug where there were duplicate transactions. These transactions
@@ -155,7 +209,7 @@ pub(crate) fn insert_utxo(
     if outpoint_already_exists && !DUPLICATE_TX_IDS.contains(&outpoint.txid.to_vec()) {
         panic!(
             "Cannot insert outpoint {:?} because it was already inserted. Block height: {}",
-            outpoint, height
+            outpoint, utxo_set.next_height
         );
     }
 }
@@ -168,15 +222,12 @@ mod test {
     use bitcoin::blockdata::{opcodes::all::OP_RETURN, script::Builder};
     use bitcoin::{Network as BitcoinNetwork, OutPoint as BitcoinOutPoint, TxOut};
     use ic_btc_test_utils::TransactionBuilder;
-    use ic_btc_types::Address as AddressStr;
+    use ic_btc_types::{Address as AddressStr, Height};
     use std::collections::BTreeSet;
 
     // A succinct wrapper around `ingest_tx_with_slicing` for tests that don't need slicing.
-    fn ingest_tx(utxo_set: &mut UtxoSet, tx: &Transaction, height: Height) {
-        assert_eq!(
-            ingest_tx_with_slicing(utxo_set, tx, height, 0, 0),
-            Slicing::Done
-        );
+    fn ingest_tx(utxo_set: &mut UtxoSet, tx: &Transaction) {
+        assert_eq!(ingest_tx_with_slicing(utxo_set, tx, 0, 0), Slicing::Done);
     }
 
     #[test]
@@ -202,7 +253,7 @@ mod test {
             .build();
 
         let mut utxo = UtxoSet::new(network);
-        ingest_tx(&mut utxo, &coinbase_tx, 0);
+        ingest_tx(&mut utxo, &coinbase_tx);
 
         assert_eq!(utxo.utxos.len(), 1);
         assert_eq!(
@@ -226,7 +277,7 @@ mod test {
             // no output coinbase
             let mut coinbase_empty_tx = TransactionBuilder::coinbase().build();
             coinbase_empty_tx.output.clear();
-            ingest_tx(&mut utxo, &coinbase_empty_tx, 0);
+            ingest_tx(&mut utxo, &coinbase_empty_tx);
 
             assert!(utxo.utxos.is_empty());
             assert!(utxo.address_to_outpoints.is_empty());
@@ -248,7 +299,7 @@ mod test {
                 version: 1,
                 lock_time: 0,
             };
-            ingest_tx(&mut utxo, &coinbase_op_return_tx, 0);
+            ingest_tx(&mut utxo, &coinbase_op_return_tx);
 
             assert!(utxo.utxos.is_empty());
             assert!(utxo.address_to_outpoints.is_empty());
@@ -279,7 +330,7 @@ mod test {
         let coinbase_tx = TransactionBuilder::coinbase()
             .with_output(&address_1, 1000)
             .build();
-        ingest_tx(&mut utxo, &coinbase_tx, 0);
+        ingest_tx(&mut utxo, &coinbase_tx);
 
         let expected = vec![ic_btc_types::Utxo {
             outpoint: ic_btc_types::OutPoint {
@@ -304,12 +355,14 @@ mod test {
             }
         );
 
+        utxo.next_height += 1;
+
         // Spend the output to address 2.
         let tx = TransactionBuilder::new()
             .with_input(BitcoinOutPoint::new(coinbase_tx.txid(), 0))
             .with_output(&address_2, 1000)
             .build();
-        ingest_tx(&mut utxo, &tx, 1);
+        ingest_tx(&mut utxo, &tx);
 
         assert_eq!(
             get_utxos(&utxo, &address_1.to_string()).into_vec(None),
@@ -387,10 +440,10 @@ mod test {
 
         let outpoint = OutPoint::new(vec![], 0);
 
-        insert_utxo(&mut utxo_set, outpoint.clone(), tx_out_1, 1);
+        insert_utxo(&mut utxo_set, outpoint.clone(), tx_out_1);
 
         // Should panic, as we are trying to insert a UTXO with the same outpoint.
-        insert_utxo(&mut utxo_set, outpoint, tx_out_2, 2);
+        insert_utxo(&mut utxo_set, outpoint, tx_out_2);
     }
 
     #[test]
@@ -406,13 +459,13 @@ mod test {
 
         let mut utxo_set = UtxoSet::new(Network::Testnet);
 
-        let tx_out_1 = TransactionBuilder::coinbase()
+        let tx_out = TransactionBuilder::coinbase()
             .with_output(&address, 1000)
             .build()
             .output[0]
             .clone();
 
-        insert_utxo(&mut utxo_set, OutPoint::new(vec![0; 32], 0), tx_out_1, 1);
+        insert_utxo(&mut utxo_set, OutPoint::new(vec![0; 32], 0), tx_out);
 
         // Verify that this invalid address was not inserted into the address outpoints.
         assert!(utxo_set.address_to_outpoints.is_empty());


### PR DESCRIPTION
Move most of the time-slicing logic inside `UtxoSet`, as that component
can fully encapsulate the time-slicing of block ingestion.