### PR TITLE
feat: start profiling the bitcoin canister

### DIFF
--- a/canister/src/api/get_balance.rs
+++ b/canister/src/api/get_balance.rs
@@ -1,12 +1,25 @@
-use crate::{store, types::GetBalanceRequest, with_state};
+use crate::{
+    runtime::{performance_counter, print},
+    store,
+    types::GetBalanceRequest,
+    with_state,
+};
 use ic_btc_types::Satoshi;
 
 /// Retrieves the balance of the given Bitcoin address.
 pub fn get_balance(request: GetBalanceRequest) -> Satoshi {
-    with_state(|state| {
+    let res = with_state(|state| {
         let min_confirmations = request.min_confirmations.unwrap_or(0);
         store::get_balance(state, &request.address, min_confirmations).expect("get_balance failed")
-    })
+    });
+
+    // Print the number of instructions it took to process this request.
+    print(&format!(
+        "[INSTRUCTION COUNT] ({:?}): {}",
+        request,
+        performance_counter()
+    ));
+    res
 }
 
 #[cfg(test)]

--- a/e2e-tests/instructions_count.txt
+++ b/e2e-tests/instructions_count.txt
@@ -1,0 +1,2 @@
+(GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None ): 799012167
+(GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: None ): 469716791

--- a/e2e-tests/profile.sh
+++ b/e2e-tests/profile.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -Eexuo pipefail
+LOG_FILE=$(mktemp)
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+INSTRUCTION_COUNT_FILE="$SCRIPT_DIR"/instructions_count.txt
+
+# Run the syncing test, storing the output into a log file.
+bash "$SCRIPT_DIR"/syncing_test.sh 2>&1 | tee "$LOG_FILE"
+
+# Search for the instruction counts in the test and update the instructions count file.
+sed -n 's/.*INSTRUCTION COUNT] \(.*\)}/\1/p' "$LOG_FILE" > "$INSTRUCTION_COUNT_FILE"


### PR DESCRIPTION
This MR kicks off the work for profiling the bitcoin canister. It adds a script `profile.sh`
that runs the e2e test, and outputs some instruction counts into a file.

The idea is that this profiling will, in the few upcoming MRs, capture the number of
instructions consumed by various operations (getting fee percentiles, ingesting blocks, etc).

On every commit, the instruction counts file will be updated so that it's clear to the reviewers
and in our history the impact of any change we make on the instructions count. A CI test will
be added to enforce that the instruction coutns in `e2e-tests/instructions_count.txt` are
always up-to-date.