### PR TITLE
feat: keep block in `unstable_blocks` until it is fully ingested.

### DIFF
--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -87,6 +87,14 @@ pub fn insert_block(state: &mut State, block: Block) -> Result<(), BlockDoesNotE
 ///
 /// Returns a bool indicating whether or not the state has changed.
 pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
+    fn pop_block(state: &mut State, ingested_block_hash: bitcoin::BlockHash) {
+        // Pop the stable block.
+        let popped_block = unstable_blocks::pop(&mut state.unstable_blocks);
+
+        // Sanity check that we just popped the same block that was ingested.
+        assert_eq!(popped_block.unwrap().block_hash(), ingested_block_hash);
+    }
+
     let prev_state = (
         state.utxos.next_height(),
         &state.utxos.partial_stable_block.clone(),
@@ -98,19 +106,20 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
     // Finish ingesting the stable block that's partially ingested, if that exists.
     match state.utxos.ingest_block_continue() {
         Slicing::Paused(()) => return has_state_changed(state),
-        Slicing::Done => {}
+        Slicing::Done(None) => {}
+        Slicing::Done(Some(ingested_block_hash)) => pop_block(state, ingested_block_hash),
     }
 
     // Check if there are any stable blocks and ingest those into the UTXO set.
-    while let Some(new_stable_block) = unstable_blocks::pop(&mut state.unstable_blocks) {
+    while let Some(new_stable_block) = unstable_blocks::peek(&state.unstable_blocks) {
         // Store the block's header.
         state
             .stable_block_headers
-            .insert(&new_stable_block, state.utxos.next_height());
+            .insert(new_stable_block, state.utxos.next_height());
 
-        match state.utxos.ingest_block(new_stable_block) {
+        match state.utxos.ingest_block(new_stable_block.clone()) {
             Slicing::Paused(()) => return has_state_changed(state),
-            Slicing::Done => {}
+            Slicing::Done(ingested_block_hash) => pop_block(state, ingested_block_hash),
         }
     }
 

--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -619,9 +619,9 @@ pub struct HttpResponse {
 /// A type used to facilitate time-slicing.
 #[must_use]
 #[derive(Debug, PartialEq, Eq)]
-pub enum Slicing<T> {
+pub enum Slicing<T, U> {
     Paused(T),
-    Done,
+    Done(U),
 }
 
 /// An unspent transaction output.

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -54,55 +54,28 @@ impl UnstableBlocks {
     }
 }
 
+/// Returns a reference to the `anchor` block iff ∃ a child `C` of `anchor` that is stable.
+pub fn peek(blocks: &UnstableBlocks) -> Option<&Block> {
+    get_stable_child(blocks).map(|_| &blocks.tree.root)
+}
+
 /// Pops the `anchor` block iff ∃ a child `C` of the `anchor` block that
 /// is stable. The child `C` becomes the new `anchor` block, and all its
 /// siblings are discarded.
 pub fn pop(blocks: &mut UnstableBlocks) -> Option<Block> {
-    // Take all the children of the anchor.
-    let mut anchor_child_trees = std::mem::take(&mut blocks.tree.children);
-
-    // Sort them by depth.
-    anchor_child_trees.sort_by_key(blocktree::depth);
-
-    match anchor_child_trees.last() {
-        Some(deepest_child_tree) => {
-            // The deepest child tree must have a depth >= stability_threshold.
-            if blocktree::depth(deepest_child_tree) < blocks.stability_threshold {
-                // Need a depth of at least >= stability_threshold
-                blocks.tree.children = anchor_child_trees;
-                return None;
-            }
-
-            // If there is more than one child, the difference in depth
-            // between the deepest child and all the others must be >= stability_threshold.
-            if anchor_child_trees.len() >= 2 {
-                if let Some(second_deepest_child_tree) =
-                    anchor_child_trees.get(anchor_child_trees.len() - 2)
-                {
-                    if blocktree::depth(deepest_child_tree)
-                        - blocktree::depth(second_deepest_child_tree)
-                        < blocks.stability_threshold
-                    {
-                        // Difference must be >= stability_threshold
-                        blocks.tree.children = anchor_child_trees;
-                        return None;
-                    }
-                }
-            }
-
-            // The root of the deepest child tree is stable. This deepest
-            // child tree becomes the new tree, with its root being the new
-            // `anchor` block. All the tree's siblings are discarded.
-            let deepest_child_tree = anchor_child_trees.pop().unwrap();
+    match get_stable_child(blocks) {
+        Some(stable_child_idx) => {
             let old_anchor = blocks.tree.root.clone();
-            blocks.tree = deepest_child_tree;
+
+            // Replace the unstable block tree with that of the stable child.
+            blocks.tree = blocks.tree.children.swap_remove(stable_child_idx);
+
+            // Remove the outpoints of the old anchor from the cache.
             blocks.outpoints_cache.remove(&old_anchor);
+
             Some(old_anchor)
         }
-        None => {
-            // The anchor has no children. Nothing to return.
-            None
-        }
+        None => None,
     }
 }
 
@@ -188,6 +161,48 @@ pub fn get_chain_with_tip<'a, 'b>(
     blocktree::get_chain_with_tip(&blocks.tree, tip)
 }
 
+// Returns the index of the `anchor`'s stable child if it exists.
+fn get_stable_child(blocks: &UnstableBlocks) -> Option<usize> {
+    // Compute the depth of all the children.
+    let mut depths: Vec<_> = blocks
+        .tree
+        .children
+        .iter()
+        .enumerate()
+        .map(|(idx, child)| (blocktree::depth(child), idx))
+        .collect();
+
+    // Sort by depth.
+    depths.sort_by_key(|(depth, _child_idx)| *depth);
+
+    match depths.last() {
+        Some((deepest_depth, child_idx)) => {
+            // The deepest child tree must have a depth >= stability_threshold.
+            if *deepest_depth < blocks.stability_threshold {
+                // Need a depth of at least >= stability_threshold
+                return None;
+            }
+
+            // If there is more than one child, the difference in depth
+            // between the deepest child and all the others must be >= stability_threshold.
+            if depths.len() >= 2 {
+                if let Some((second_deepest_depth, _)) = depths.get(depths.len() - 2) {
+                    if deepest_depth - second_deepest_depth < blocks.stability_threshold {
+                        // Difference must be >= stability_threshold
+                        return None;
+                    }
+                }
+            }
+
+            Some(*child_idx)
+        }
+        None => {
+            // The anchor has no children. Nothing to return.
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -198,6 +213,7 @@ mod test {
         let anchor = BlockBuilder::genesis().build();
         let utxos = UtxoSet::new(Network::Mainnet);
         let mut forest = UnstableBlocks::new(&utxos, 1, anchor);
+        assert_eq!(peek(&forest), None);
         assert_eq!(pop(&mut forest), None);
     }
 
@@ -211,16 +227,19 @@ mod test {
         let mut forest = UnstableBlocks::new(&utxos, 1, block_0.clone());
 
         push(&mut forest, &utxos, block_1).unwrap();
+        assert_eq!(peek(&forest), None);
         assert_eq!(pop(&mut forest), None);
 
         push(&mut forest, &utxos, block_2).unwrap();
 
         // Block 0 (the anchor) now has one stable child (Block 1).
         // Block 0 should be returned when calling `pop`.
+        assert_eq!(peek(&forest), Some(&block_0));
         assert_eq!(pop(&mut forest), Some(block_0));
 
         // Block 1 is now the anchor. It doesn't have children yet,
         // so calling `pop` should return `None`.
+        assert_eq!(peek(&forest), None);
         assert_eq!(pop(&mut forest), None);
     }
 
@@ -237,6 +256,7 @@ mod test {
         push(&mut forest, &utxos, forked_block.clone()).unwrap();
 
         // Neither forks are 1-stable, so we shouldn't get anything.
+        assert_eq!(peek(&forest), None);
         assert_eq!(pop(&mut forest), None);
 
         // Extend fork2 by another block.
@@ -249,10 +269,12 @@ mod test {
 
         // Now fork2 should be 1-stable. The anchor should be returned on `pop`
         // and fork2 becomes the new anchor.
+        assert_eq!(peek(&forest), Some(&genesis_block));
         assert_eq!(pop(&mut forest), Some(genesis_block));
         assert_eq!(forest.tree.root, forked_block);
 
         // No stable children for fork 2
+        assert_eq!(peek(&forest), None);
         assert_eq!(pop(&mut forest), None);
     }
 
@@ -267,8 +289,11 @@ mod test {
         push(&mut forest, &utxos, block_1.clone()).unwrap();
         push(&mut forest, &utxos, block_2).unwrap();
 
+        assert_eq!(peek(&forest), Some(&block_0));
         assert_eq!(pop(&mut forest), Some(block_0));
+        assert_eq!(peek(&forest), Some(&block_1));
         assert_eq!(pop(&mut forest), Some(block_1));
+        assert_eq!(peek(&forest), None);
         assert_eq!(pop(&mut forest), None);
     }
 

--- a/e2e-tests/profiling/scenario-1.txt
+++ b/e2e-tests/profiling/scenario-1.txt
@@ -1,10 +1,10 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 29823, ins_remove_inputs: 1009, ins_insert_outputs: 27510, ins_txids: 788, ins_insert_utxos: 25642 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5248617964, ins_remove_inputs: 2018, ins_insert_outputs: 5248613672, ins_txids: 8988801, ins_insert_utxos: 5231044215 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 4, ins_total: 15346331794, ins_remove_inputs: 9809274746, ins_insert_outputs: 5529354051, ins_txids: 11449223, ins_insert_utxos: 5507104401 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 595104, ins_apply_unstable_blocks: 137767 }
-GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 508686, ins_apply_unstable_blocks: 92510 }
-GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 128840072, ins_apply_unstable_blocks: 29748551, ins_build_utxos_vec: 98424369 }
-GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 75580756, ins_apply_unstable_blocks: 67687524, ins_build_utxos_vec: 7241302 }
-GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 27992989, ins_apply_unstable_blocks: 27581305 }
-get_current_fee_percentiles: 39604891
-get_current_fee_percentiles: 313585
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 29846, ins_remove_inputs: 1009, ins_insert_outputs: 27533, ins_txids: 788, ins_insert_utxos: 25665 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5625780661, ins_remove_inputs: 2018, ins_insert_outputs: 5625776369, ins_txids: 12683801, ins_insert_utxos: 5604511912 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 15815732635, ins_remove_inputs: 10121766448, ins_insert_outputs: 5686261745, ins_txids: 12600000, ins_insert_utxos: 5662860037 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 593493, ins_apply_unstable_blocks: 137701 }
+GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 506778, ins_apply_unstable_blocks: 92490 }
+GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 130591825, ins_apply_unstable_blocks: 29211138, ins_build_utxos_vec: 100739011 }
+GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 74563413, ins_apply_unstable_blocks: 66682673, ins_build_utxos_vec: 7235047 }
+GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 27952232, ins_apply_unstable_blocks: 27541220 }
+get_current_fee_percentiles: 39585339
+get_current_fee_percentiles: 314877

--- a/e2e-tests/profiling/scenario-2.txt
+++ b/e2e-tests/profiling/scenario-2.txt
@@ -1,5 +1,5 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 34651, ins_remove_inputs: 1009, ins_insert_outputs: 32338, ins_txids: 1275, ins_insert_utxos: 29983 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 4797125307, ins_remove_inputs: 10091009, ins_insert_outputs: 4779332787, ins_txids: 8757574, ins_insert_utxos: 4759774786 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5325013715, ins_remove_inputs: 10091009, ins_insert_outputs: 5307221195, ins_txids: 9091436, ins_insert_utxos: 5287329332 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 54672737, ins_apply_unstable_blocks: 54228346 }
-GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 157861535, ins_apply_unstable_blocks: 144491636, ins_build_utxos_vec: 12700427 }
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 34576, ins_remove_inputs: 1009, ins_insert_outputs: 32263, ins_txids: 1275, ins_insert_utxos: 29908 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5039766222, ins_remove_inputs: 10091009, ins_insert_outputs: 5021973702, ins_txids: 12600000, ins_insert_utxos: 4998573275 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5609151521, ins_remove_inputs: 10091009, ins_insert_outputs: 5591359001, ins_txids: 12600000, ins_insert_utxos: 5567958574 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 54585229, ins_apply_unstable_blocks: 54148236 }
+GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 155466789, ins_apply_unstable_blocks: 142362323, ins_build_utxos_vec: 12456681 }


### PR DESCRIPTION
Prior to this commit, the way stable blocks in `unstable_blocks` were moved to the stable `UtxoSet` was as follows:

1. Take a (newly stable) block from `unstable_blocks`.
2. Ingest the block into the `UtxoSet`.

Because of our time-slicing, steps 1 and 2 are not atomic, and the canister can be in a state where the block is no longer part of the `unstable_blocks`, and it hasn't been fully ingested yet.

This commit paves the way to make steps 1 and 2 atomic. It modifies the flow to the following.

1. Take a _reference_ to a block from the `unstable_blocks`.
2. Ingest the block into the `UtxoSet`.
3. Remove the block from `unstable_blocks`.

This flow as it currently stands is still not atomic, but to pave the way for atomicity, I'd like the block to remain in `unstable_blocks` until it is fully ingested by the `UtxoSet`. In a follow-up commit, changes to the `UtxoSet` will guarantee the atomicity of these three operations.