### PR TITLE
chore: [EXC-1232] add metric to track errors when fetching new blocks.

### DIFF
--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -187,11 +187,12 @@ fn maybe_get_successors_request() -> Option<GetSuccessorsRequest> {
 mod test {
     use super::*;
     use crate::{
-        genesis_block, init, runtime,
+        genesis_block, init,
+        runtime::{self, GetSuccessorsReply},
         test_utils::{random_p2pkh_address, BlockBuilder, TransactionBuilder},
         types::{
             Address, BlockBlob, Config, GetSuccessorsCompleteResponse,
-            GetSuccessorsPartialResponse, GetSuccessorsReply, Network,
+            GetSuccessorsPartialResponse, Network,
         },
         utxo_set::IngestingBlock,
     };

--- a/canister/src/metrics.rs
+++ b/canister/src/metrics.rs
@@ -54,7 +54,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         w.encode_counter(
             "num_get_successors_rejects",
             state.syncing_state.num_get_successors_rejects,
-            "The number of times an error is received when calling GetSuccessors.",
+            "The number of rejects received when calling GetSuccessors.",
         )?;
         Ok(())
     })

--- a/canister/src/runtime.rs
+++ b/canister/src/runtime.rs
@@ -2,12 +2,13 @@
 //!
 //! Alternative implementations are available in non-wasm environments to
 //! facilitate testing.
-use crate::types::{GetSuccessorsReply, GetSuccessorsRequest, GetSuccessorsResponse};
+use crate::types::{GetSuccessorsRequest, GetSuccessorsResponse};
+use ic_cdk::api::call::RejectionCode;
 use ic_cdk::{api::call::CallResult, export::Principal};
+use serde::Deserialize;
 #[cfg(not(target_arch = "wasm32"))]
 use std::cell::RefCell;
 use std::future::Future;
-
 #[cfg(not(target_arch = "wasm32"))]
 const INSTRUCTIONS_LIMIT: u64 = 5_000_000_000;
 
@@ -19,6 +20,17 @@ pub fn print(msg: &str) {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn print(msg: &str) {
     println!("{}", msg);
+}
+
+/// A reply from the Bitcoin network containing either GetSuccessorsResponse or Rejection.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub enum GetSuccessorsReply {
+    /// A response containing the successor blocks.
+    Ok(GetSuccessorsResponse),
+
+    /// Rejection from the caller.
+    Err(RejectionCode, String),
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -192,7 +192,7 @@ pub struct SyncingState {
     /// A response that needs to be processed.
     pub response_to_process: Option<ResponseToProcess>,
 
-    /// A number of times an error is received when calling GetSuccessors.
+    /// A number of rejects received when calling GetSuccessors.
     pub num_get_successors_rejects: u64,
 }
 

--- a/canister/src/tests.rs
+++ b/canister/src/tests.rs
@@ -1,11 +1,12 @@
 use crate::{
     api::{get_balance, get_utxos},
-    genesis_block, heartbeat, runtime,
+    genesis_block, heartbeat,
+    runtime::{self, GetSuccessorsReply},
     state::main_chain_height,
     test_utils::{BlockBuilder, TransactionBuilder},
     types::{
-        BlockBlob, GetBalanceRequest, GetSuccessorsCompleteResponse, GetSuccessorsReply,
-        GetSuccessorsResponse, GetUtxosRequest, Network,
+        BlockBlob, GetBalanceRequest, GetSuccessorsCompleteResponse, GetSuccessorsResponse,
+        GetUtxosRequest, Network,
     },
     utxo_set::{IngestingBlock, DUPLICATE_TX_IDS},
     with_state,
@@ -509,11 +510,7 @@ async fn time_slices_large_block_with_multiple_transactions() {
 
 #[async_std::test]
 async fn test_rejections_counting() {
-    crate::init(crate::Config {
-        stability_threshold: 2,
-        network: Network::Testnet,
-        ..Default::default()
-    });
+    crate::init(crate::Config::default());
 
     let counter_prior = crate::with_state(|state| state.syncing_state.num_get_successors_rejects);
 

--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -8,7 +8,6 @@ use ic_btc_types::{
     GetUtxosRequest as PublicGetUtxosRequest, Height, NetworkInRequest, Satoshi, UtxosFilter,
     UtxosFilterInRequest,
 };
-use ic_cdk::api::call::RejectionCode;
 use ic_cdk::export::{candid::CandidType, Principal};
 use ic_stable_structures::Storable as StableStructuresStorable;
 use serde::{Deserialize, Serialize};
@@ -517,16 +516,6 @@ pub enum GetSuccessorsResponse {
     /// A follow-up response containing a blob of bytes to be appended to the partial response.
     #[serde(rename = "follow_up")]
     FollowUp(BlockBlob),
-}
-
-/// A reply from the Bitcoin network containing either GetSuccessorsResponse or Rejection
-#[derive(Clone, Debug, Deserialize, Hash, PartialEq, Eq)]
-pub enum GetSuccessorsReply {
-    /// A response containing the successors block
-    Ok(GetSuccessorsResponse),
-
-    /// Rejection from the Bitcoin network
-    Err(RejectionCode, String),
 }
 
 #[derive(CandidType, Clone, Debug, Default, Deserialize, Hash, PartialEq, Eq, Serialize)]


### PR DESCRIPTION
[EXC-1232] Implemented tracking of the number of times an error is received when calling GetSuccessors.