### PR TITLE
feat: add endpoint to know if a block is being ingested.

### DIFF
--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -95,6 +95,10 @@ pub fn get_utxos(request: GetUtxosRequest) -> GetUtxosResponse {
     api::get_utxos(request.into())
 }
 
+pub fn is_ingesting_block() -> bool {
+    with_state(|s| s.utxos.is_ingesting_block())
+}
+
 pub fn pre_upgrade() {
     // Serialize the state.
     let mut state_bytes = vec![];

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -45,6 +45,11 @@ pub fn get_current_fee_percentiles(
     ic_btc_canister::get_current_fee_percentiles(request)
 }
 
+#[update]
+pub fn is_ingesting_block() -> bool {
+    ic_btc_canister::is_ingesting_block()
+}
+
 fn main() {}
 
 /*

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -196,6 +196,11 @@ impl UtxoSet {
         self.next_height
     }
 
+    /// Returns true if a block is in the process of being ingested, false otherwise.
+    pub fn is_ingesting_block(&self) -> bool {
+        self.ingesting_block.is_some()
+    }
+
     // Ingests a transaction into the given UTXO set.
     //
     // NOTE: This method does a form of time-slicing to stay within the instruction limit, and


### PR DESCRIPTION
This change is temporary to allow us to upgrade the canister with the atomicity changes safely.

To include the atomicity changes safely, we need to upgrade the canister when it is _not_ in the middle of ingesting a block.

This commit introduces an endpoint for us to know if that is the case so that we can upgrade correctly.

Once the upgrade is done, this change will be reverted.