### PR TITLE
fix: update endpoint names to match interface spec.

### DIFF
--- a/canister/candid.did
+++ b/canister/candid.did
@@ -69,11 +69,11 @@ type config = record {
 };
 
 service bitcoin: (init_payload) -> {
-  get_balance: (get_balance_request) -> (satoshi);
+  bitcoin_get_balance: (get_balance_request) -> (satoshi);
   
-  get_utxos: (get_utxos_request) -> (get_utxos_response);
+  bitcoin_get_utxos: (get_utxos_request) -> (get_utxos_response);
 
-  get_current_fee_percentiles: (get_current_fee_percentiles_request) -> (vec millisatoshi_per_byte);
+  bitcoin_get_current_fee_percentiles: (get_current_fee_percentiles_request) -> (vec millisatoshi_per_byte);
 
   get_config: () -> (config) query;
 

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -29,17 +29,17 @@ async fn heartbeat() {
 }
 
 #[update]
-pub fn get_balance(request: GetBalanceRequest) -> Satoshi {
+pub fn bitcoin_get_balance(request: GetBalanceRequest) -> Satoshi {
     ic_btc_canister::get_balance(request)
 }
 
 #[update]
-pub fn get_utxos(request: GetUtxosRequest) -> GetUtxosResponse {
+pub fn bitcoin_get_utxos(request: GetUtxosRequest) -> GetUtxosResponse {
     ic_btc_canister::get_utxos(request)
 }
 
 #[update]
-pub fn get_current_fee_percentiles(
+pub fn bitcoin_get_current_fee_percentiles(
     request: GetCurrentFeePercentilesRequest,
 ) -> Vec<MillisatoshiPerByte> {
     ic_btc_canister::get_current_fee_percentiles(request)

--- a/e2e-tests/scenario-1.sh
+++ b/e2e-tests/scenario-1.sh
@@ -23,7 +23,7 @@ dfx deploy --no-wallet bitcoin --argument "(record {
 wait_until_stable_height 3 60
 
 # Fetch the balance of an address we do not expect to have funds.
-BALANCE=$(dfx canister call bitcoin get_balance '(record {
+BALANCE=$(dfx canister call bitcoin bitcoin_get_balance '(record {
   network = variant { regtest };
   address = "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8"
 })')
@@ -34,7 +34,7 @@ if ! [[ $BALANCE = "(0 : nat64)" ]]; then
 fi
 
 # Fetch the balance of an address we expect to have funds.
-BALANCE=$(dfx canister call bitcoin get_balance '(record {
+BALANCE=$(dfx canister call bitcoin bitcoin_get_balance '(record {
   network = variant { regtest };
   address = "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf";
   min_confirmations = opt 2;
@@ -46,7 +46,7 @@ if ! [[ $BALANCE = "(5_000_000_000 : nat64)" ]]; then
   exit 1
 fi
 
-UTXOS=$(dfx canister call bitcoin get_utxos '(record {
+UTXOS=$(dfx canister call bitcoin bitcoin_get_utxos '(record {
   network = variant { regtest };
   address = "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf";
 })')
@@ -61,7 +61,7 @@ fi
 # We temporarily pause outputting the commands to the terminal as
 # this command would print thousands of UTXOs.
 set +x
-UTXOS=$(dfx canister call bitcoin get_utxos '(record {
+UTXOS=$(dfx canister call bitcoin bitcoin_get_utxos '(record {
   network = variant { regtest };
   address = "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh"
 })')
@@ -73,7 +73,7 @@ if ! [[ $(num_utxos "$UTXOS") = 10000 ]]; then
 fi
 set -x
 
-BALANCE=$(dfx canister call bitcoin get_balance '(record {
+BALANCE=$(dfx canister call bitcoin bitcoin_get_balance '(record {
   network = variant { regtest };
   address = "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh";
 })')
@@ -84,10 +84,10 @@ if ! [[ $BALANCE = "(5_000_000_000 : nat64)" ]]; then
 fi
 
 # Request the current fee percentiles. This is only for profiling purposes.
-dfx canister call bitcoin get_current_fee_percentiles '(record {
+dfx canister call bitcoin bitcoin_get_current_fee_percentiles '(record {
   network = variant { regtest };
 })'
-dfx canister call bitcoin get_current_fee_percentiles '(record {
+dfx canister call bitcoin bitcoin_get_current_fee_percentiles '(record {
   network = variant { regtest };
 })'
 

--- a/e2e-tests/scenario-2.sh
+++ b/e2e-tests/scenario-2.sh
@@ -26,7 +26,7 @@ dfx deploy --no-wallet bitcoin --argument "(record {
 # Wait until the ingestion of stable blocks is complete.
 wait_until_main_chain_height 4 60
 
-BALANCE=$(dfx canister call bitcoin get_balance '(record {
+BALANCE=$(dfx canister call bitcoin bitcoin_get_balance '(record {
   network = variant { regtest };
   address = "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8"
 })')
@@ -40,7 +40,7 @@ fi
 # We temporarily pause outputting the commands to the terminal as
 # this command would print thousands of UTXOs.
 set +x
-UTXOS=$(dfx canister call bitcoin get_utxos '(record {
+UTXOS=$(dfx canister call bitcoin bitcoin_get_utxos '(record {
   network = variant { regtest };
   address = "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8"
 })')


### PR DESCRIPTION
Endpoints need to be prefixed with `bitcoin_` to be fully compliant with the interface spec.