### PR TITLE
feat: [EXC-1283] script to compute the address balances and UTXOs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2543,7 +2543,10 @@ dependencies = [
  "byteorder",
  "clap",
  "ic-btc-canister",
+ "ic-stable-structures",
  "integer-encoding",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rusty-leveldb",
 ]
 

--- a/bootstrap/state-builder/Cargo.toml
+++ b/bootstrap/state-builder/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 name = "build-balances"
 path = "src/build_balances.rs"
 
+[[bin]]
+name = "build-address-utxos"
+path = "src/build_address_utxos.rs"
+
 [dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
 bitcoin = "0.28.1"

--- a/bootstrap/state-builder/Cargo.toml
+++ b/bootstrap/state-builder/Cargo.toml
@@ -3,11 +3,18 @@ name = "state-builder"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+name = "build-balances"
+path = "src/build_balances.rs"
+
 [dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
 bitcoin = "0.28.1"
 byteorder = "1.4.3"
 clap = { version = "4.0.11", features = ["derive"] }
 ic-btc-canister = { path = "../../canister" }
+ic-stable-structures = "0.1.0"
 integer-encoding = "3.0.4"
+rand = "0.8.5"
+rand_chacha = "0.3.1"
 rusty-leveldb = "1.0.4"

--- a/bootstrap/state-builder/src/build_address_utxos.rs
+++ b/bootstrap/state-builder/src/build_address_utxos.rs
@@ -41,7 +41,7 @@ fn main() {
 
     let memory = DefaultMemoryImpl::default();
     let mut address_utxos: StableBTreeMap<_, AddressUtxo, ()> =
-        StableBTreeMap::init(memory.clone(), 90, 0);
+        StableBTreeMap::init(memory.clone(), 126, 0);
 
     for (i, line) in reader.lines().enumerate() {
         let line = line.unwrap();

--- a/bootstrap/state-builder/src/build_address_utxos.rs
+++ b/bootstrap/state-builder/src/build_address_utxos.rs
@@ -1,0 +1,88 @@
+//! A script for building the Bitcoin canister's address UTXOs from a UTXO dump text file.
+//!
+//! Example run:
+//!
+//! cargo run --release --bin build-address-utxos -- \
+//!   --network testnet \
+//!   --output balances.bin \
+//!   --utxos-dump-path utxos-dump.csv
+use bitcoin::{Address, Txid as BitcoinTxid};
+use clap::Parser;
+use ic_btc_canister::types::{Address as OurAddress, AddressUtxo, Network, OutPoint, Txid};
+use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
+use std::{
+    fs::File,
+    io::{BufRead, BufReader, Write},
+    path::PathBuf,
+    str::FromStr,
+};
+
+#[derive(Parser, Debug)]
+struct Args {
+    /// The path of the UTXOs dump.
+    #[clap(long, value_hint = clap::ValueHint::DirPath)]
+    utxos_dump_path: PathBuf,
+
+    /// The path to store the output in.
+    #[clap(long, value_hint = clap::ValueHint::DirPath)]
+    output: PathBuf,
+
+    /// The bitcoin network.
+    #[clap(long)]
+    network: Network,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    // Read the UTXOs from the UTXOs dump.
+    let utxos_file = File::open(args.utxos_dump_path).unwrap();
+    let reader = BufReader::new(utxos_file);
+
+    let memory = DefaultMemoryImpl::default();
+    let mut address_utxos: StableBTreeMap<_, AddressUtxo, ()> =
+        StableBTreeMap::init(memory.clone(), 90, 0);
+
+    for (i, line) in reader.lines().enumerate() {
+        let line = line.unwrap();
+        let parts: Vec<_> = line.split(',').collect();
+
+        let txid = Txid::from(BitcoinTxid::from_str(parts[1]).unwrap().to_vec());
+        let vout: u32 = parts[2].parse().unwrap();
+        let address_str = parts[5];
+        let height: u32 = parts[9].parse().unwrap();
+
+        if i % 100_000 == 0 {
+            println!("Processed {} UTXOs", i);
+        }
+
+        if let Ok(address) = Address::from_str(address_str) {
+            let address: OurAddress = address.into();
+
+            address_utxos
+                .insert(
+                    AddressUtxo {
+                        address,
+                        height,
+                        outpoint: OutPoint {
+                            txid: txid.clone(),
+                            vout,
+                        },
+                    },
+                    (),
+                )
+                .unwrap();
+        }
+    }
+
+    println!("Writing stable structure to file...");
+    let mut file = match File::create(&args.output) {
+        Err(err) => panic!("couldn't create {}: {}", args.output.display(), err),
+        Ok(file) => file,
+    };
+
+    match file.write_all(&memory.borrow()) {
+        Err(err) => panic!("couldn't write to {}: {}", args.output.display(), err),
+        Ok(_) => println!("successfully wrote balances to {}", args.output.display()),
+    };
+}

--- a/bootstrap/state-builder/src/build_address_utxos.rs
+++ b/bootstrap/state-builder/src/build_address_utxos.rs
@@ -39,9 +39,10 @@ fn main() {
     let utxos_file = File::open(args.utxos_dump_path).unwrap();
     let reader = BufReader::new(utxos_file);
 
+    const ADDRESS_UTXO_SIZE: u32 = 126;
     let memory = DefaultMemoryImpl::default();
     let mut address_utxos: StableBTreeMap<_, AddressUtxo, ()> =
-        StableBTreeMap::init(memory.clone(), 126, 0);
+        StableBTreeMap::init(memory.clone(), ADDRESS_UTXO_SIZE, 0);
 
     for (i, line) in reader.lines().enumerate() {
         let line = line.unwrap();

--- a/bootstrap/state-builder/src/build_balances.rs
+++ b/bootstrap/state-builder/src/build_balances.rs
@@ -52,7 +52,7 @@ fn main() {
         let address_str = parts[5];
 
         if i % 100_000 == 0 {
-            println!("Processed {}", i);
+            println!("Processed {} UTXOS", i);
         }
 
         if let Ok(address) = BitcoinAddress::from_str(address_str) {

--- a/bootstrap/state-builder/src/build_balances.rs
+++ b/bootstrap/state-builder/src/build_balances.rs
@@ -52,7 +52,7 @@ fn main() {
         let address_str = parts[5];
 
         if i % 100_000 == 0 {
-            println!("Processed {} UTXOS", i);
+            println!("Processed {} UTXOs", i);
         }
 
         if let Ok(address) = BitcoinAddress::from_str(address_str) {

--- a/bootstrap/state-builder/src/build_balances.rs
+++ b/bootstrap/state-builder/src/build_balances.rs
@@ -1,0 +1,98 @@
+//! A script for building the Bitcoin canister's balances from a UTXO dump text file.
+//!
+//! Example run:
+//!
+//! cargo run --release --bin build-balances -- \
+//!   --network testnet \
+//!   --output balances.bin \
+//!   --utxos-dump-path utxos-dump.csv
+use bitcoin::Address as BitcoinAddress;
+use clap::Parser;
+use ic_btc_canister::types::{Address, Network};
+use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
+use rand::prelude::*;
+use rand_chacha::ChaCha8Rng;
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::{BufRead, BufReader, Write},
+    path::PathBuf,
+    str::FromStr,
+};
+
+#[derive(Parser, Debug)]
+struct Args {
+    /// The path of the UTXOs dump.
+    #[clap(long, value_hint = clap::ValueHint::DirPath)]
+    utxos_dump_path: PathBuf,
+
+    /// The path to store the output in.
+    #[clap(long, value_hint = clap::ValueHint::DirPath)]
+    output: PathBuf,
+
+    /// The bitcoin network.
+    #[clap(long)]
+    network: Network,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    // Read the UTXOs from the UTXOs dump.
+    let utxos_file = File::open(args.utxos_dump_path).unwrap();
+    let reader = BufReader::new(utxos_file);
+
+    // Compute the balances. We use a standard BTreeMap here for speed.
+    let mut balances: BTreeMap<Address, u64> = BTreeMap::new();
+    for (i, line) in reader.lines().enumerate() {
+        let line = line.unwrap();
+        let parts: Vec<_> = line.split(',').collect();
+
+        let amount: u64 = parts[3].parse().unwrap();
+        let address_str = parts[5];
+
+        if i % 100_000 == 0 {
+            println!("Processed {}", i);
+        }
+
+        if let Ok(address) = BitcoinAddress::from_str(address_str) {
+            let address: Address = address.into();
+
+            // Update the balance of the address.
+            if amount != 0 {
+                balances
+                    .entry(address.clone())
+                    .and_modify(|curr| *curr += amount)
+                    .or_insert(amount);
+            }
+        }
+    }
+
+    // Shuffle the balances. Based on anecdotal evidence, inserting the elements in a random
+    // order is ~40% more space efficient than inserting the elements in sorted order.
+    println!("Shuffling...");
+    let mut balances: Vec<_> = balances.into_iter().collect();
+    let mut rng = ChaCha8Rng::seed_from_u64(1);
+    balances.shuffle(&mut rng);
+
+    println!("Writing to stable structure...");
+    let memory = DefaultMemoryImpl::default();
+    let mut stable_balances: StableBTreeMap<_, Address, u64> =
+        StableBTreeMap::init(memory.clone(), 90, 8);
+
+    // Write the balances into a stable btreemap.
+    for (address, amount) in balances.into_iter() {
+        stable_balances.insert(address, amount).unwrap();
+    }
+
+    println!("Writing stable structure to file...");
+    let mut balances_file = match File::create(&args.output) {
+        Err(err) => panic!("couldn't create {}: {}", args.output.display(), err),
+        Ok(file) => file,
+    };
+
+    match balances_file.write_all(&memory.borrow()) {
+        Err(err) => panic!("couldn't write to {}: {}", args.output.display(), err),
+        Ok(_) => println!("successfully wrote balances to {}", args.output.display()),
+    };
+}

--- a/bootstrap/state-builder/src/build_balances.rs
+++ b/bootstrap/state-builder/src/build_balances.rs
@@ -76,9 +76,11 @@ fn main() {
     balances.shuffle(&mut rng);
 
     println!("Writing to stable structure...");
+    const ADDRESS_SIZE: u32 = 90;
+    const BALANCE_SIZE: u32 = 8;
     let memory = DefaultMemoryImpl::default();
     let mut stable_balances: StableBTreeMap<_, Address, u64> =
-        StableBTreeMap::init(memory.clone(), 90, 8);
+        StableBTreeMap::init(memory.clone(), ADDRESS_SIZE, BALANCE_SIZE);
 
     // Write the balances into a stable btreemap.
     for (address, amount) in balances.into_iter() {


### PR DESCRIPTION
Rather than computing the entire state from scratch by feeding all the blocks to the canister, we'll now rely on Bitcoin's chainstate database. This will allow us to compute the whole state in a matter of hours, as opposed to weeks or months.

This commit introduces two of several scripts that will be used to read data from the chainstate database and compute various parts of the canister's state.