### PR TITLE
fix: fix build scripts for e2e scenarios on mac.

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -8,14 +8,15 @@
       "build": "./canister/build.sh"
     },
     "e2e-scenario-1": {
-      "type": "rust",
+      "type": "custom",
       "candid": "./e2e-tests/scenario-1/candid.did",
-      "package": "scenario-1",
+      "build": "./e2e-tests/build.sh scenario-1",
       "wasm": "./target/wasm32-unknown-unknown/release/scenario-1.wasm"
     },
     "e2e-scenario-2": {
-      "type": "rust",
+      "type": "custom",
       "candid": "./e2e-tests/scenario-2/candid.did",
+      "build": "./e2e-tests/build.sh scenario-2",
       "package": "scenario-2",
       "wasm": "./target/wasm32-unknown-unknown/release/scenario-2.wasm"
     },

--- a/e2e-tests/build.sh
+++ b/e2e-tests/build.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 pushd "$SCRIPT_DIR"
 
-# NOTE: On macOS a specific version of llvm-ar and clang need to be set here.
+# NOTE: On macs a specific version of llvm-ar and clang need to be set here.
 # Otherwise the wasm compilation of rust-secp256k1 will fail.
 if [ "$(uname)" == "Darwin" ]; then
   LLVM_PATH=$(brew --prefix llvm)

--- a/e2e-tests/build.sh
+++ b/e2e-tests/build.sh
@@ -11,7 +11,7 @@ pushd "$SCRIPT_DIR"
 if [ "$(uname)" == "Darwin" ]; then
   LLVM_PATH=$(brew --prefix llvm)
   # On macs we need to use the brew versions
-  AR="${LLVM_PATH}/bin/llvm-ar" CC="${LLVM_PATH}/bin/clang" cargo build -p $1 --target $TARGET --release
+  AR="${LLVM_PATH}/bin/llvm-ar" CC="${LLVM_PATH}/bin/clang" cargo build -p "$1" --target $TARGET --release
 else
-  cargo build -p $1 --target $TARGET --release
+  cargo build -p "$1" --target $TARGET --release
 fi

--- a/e2e-tests/build.sh
+++ b/e2e-tests/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET="wasm32-unknown-unknown"
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+pushd "$SCRIPT_DIR"
+
+# NOTE: On macOS a specific version of llvm-ar and clang need to be set here.
+# Otherwise the wasm compilation of rust-secp256k1 will fail.
+if [ "$(uname)" == "Darwin" ]; then
+  LLVM_PATH=$(brew --prefix llvm)
+  # On macs we need to use the brew versions
+  AR="${LLVM_PATH}/bin/llvm-ar" CC="${LLVM_PATH}/bin/clang" cargo build -p $1 --target $TARGET --release
+else
+  cargo build -p $1 --target $TARGET --release
+fi


### PR DESCRIPTION
Fix building e2e scenarios on macs. Prior to this commit building on macs was possible by first building the bitcoin canister.

Now the build scripts are more robust so that they can compile on a mac under all situations.