### PR TITLE
chore: add a separate type for `BlockHash`

### DIFF
--- a/canister/src/address_utxoset.rs
+++ b/canister/src/address_utxoset.rs
@@ -46,14 +46,14 @@ impl<'a> AddressUtxoSet<'a> {
     pub fn apply_block(&mut self, block: &Block) {
         for outpoint in self
             .unstable_blocks
-            .get_removed_outpoints(&block.block_hash().to_vec(), &self.address)
+            .get_removed_outpoints(&block.block_hash(), &self.address)
         {
             self.removed_outpoints.insert(outpoint.clone());
         }
 
         for outpoint in self
             .unstable_blocks
-            .get_added_outpoints(&block.block_hash().to_vec(), &self.address)
+            .get_added_outpoints(&block.block_hash(), &self.address)
         {
             let (txout, height) = self
                 .unstable_blocks

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -36,7 +36,7 @@ fn get_current_fee_percentiles_internal(
     number_of_transactions: u32,
 ) -> Vec<MillisatoshiPerByte> {
     let main_chain = unstable_blocks::get_main_chain(&state.unstable_blocks);
-    let tip_block_hash = main_chain.tip().block_hash().to_vec();
+    let tip_block_hash = main_chain.tip().block_hash();
 
     // If fee percentiles were already cached, then return the cached results.
     if let Some(cache) = &state.fee_percentiles_cache {

--- a/canister/src/api/get_balance.rs
+++ b/canister/src/api/get_balance.rs
@@ -59,7 +59,7 @@ fn get_balance_internal(request: GetBalanceRequest) -> Result<Satoshi, GetBalanc
 
             for outpoint in state
                 .unstable_blocks
-                .get_added_outpoints(&block.block_hash().to_vec(), &address)
+                .get_added_outpoints(&block.block_hash(), &address)
             {
                 let (txout, _) = state.unstable_blocks.get_tx_out(outpoint).unwrap();
                 balance += txout.value;
@@ -67,7 +67,7 @@ fn get_balance_internal(request: GetBalanceRequest) -> Result<Satoshi, GetBalanc
 
             for outpoint in state
                 .unstable_blocks
-                .get_removed_outpoints(&block.block_hash().to_vec(), &address)
+                .get_removed_outpoints(&block.block_hash(), &address)
             {
                 let (txout, _) = state.unstable_blocks.get_tx_out(outpoint).unwrap();
                 balance -= txout.value;

--- a/canister/src/api/get_utxos.rs
+++ b/canister/src/api/get_utxos.rs
@@ -208,7 +208,7 @@ fn get_utxos_from_chain(
     let rest = utxos.split_off(utxos.len().min(utxo_limit as usize));
     let next_page = rest.first().map(|next| {
         Page {
-            tip_block_hash,
+            tip_block_hash: tip_block_hash.clone(),
             height: next.height,
             outpoint: OutPoint::new(Txid::from(next.outpoint.txid.clone()), next.outpoint.vout),
         }

--- a/canister/src/block_header_store.rs
+++ b/canister/src/block_header_store.rs
@@ -42,7 +42,7 @@ impl BlockHeaderStore {
     }
 
     pub fn insert(&mut self, block: &Block, height: Height) {
-        let block_hash = block.block_hash().to_vec();
+        let block_hash = block.block_hash();
         let mut header_bytes = vec![];
         block
             .header()

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -1,5 +1,4 @@
-use crate::types::Block;
-use bitcoin::BlockHash;
+use crate::types::{Block, BlockHash};
 use std::fmt;
 mod serde;
 
@@ -103,11 +102,11 @@ pub fn extend(block_tree: &mut BlockTree, block: Block) -> Result<(), BlockDoesN
     }
 
     // Check if the block is a successor to any of the blocks in the tree.
-    match find_mut(block_tree, &block.header().prev_blockhash) {
+    match find_mut(block_tree, &block.header().prev_blockhash.into()) {
         Some((block_subtree, _)) => {
             assert_eq!(
-                block_subtree.root.block_hash(),
-                block.header().prev_blockhash
+                block_subtree.root.block_hash().to_vec(),
+                block.header().prev_blockhash.to_vec()
             );
             // Add the block as a successor.
             block_subtree.children.push(BlockTree::new(block));
@@ -316,7 +315,10 @@ mod test {
 
             // All blocks should be correctly chained to one another.
             for i in 1..chain.len() {
-                assert_eq!(chain[i - 1].block_hash(), chain[i].header().prev_blockhash)
+                assert_eq!(
+                    chain[i - 1].block_hash().to_vec(),
+                    chain[i].header().prev_blockhash.to_vec()
+                )
             }
         }
     }
@@ -352,7 +354,10 @@ mod test {
 
                 // All blocks should be correctly chained to one another.
                 for i in 1..chain.len() {
-                    assert_eq!(chain[i - 1].block_hash(), chain[i].header().prev_blockhash)
+                    assert_eq!(
+                        chain[i - 1].block_hash().to_vec(),
+                        chain[i].header().prev_blockhash.to_vec()
+                    )
                 }
             }
 

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -192,7 +192,7 @@ fn maybe_get_successors_request() -> Option<GetSuccessorsRequest> {
             // No response is present. Send an initial request for new blocks.
             let mut processed_block_hashes: Vec<BlockHash> = state::get_unstable_blocks(state)
                 .iter()
-                .map(|b| b.block_hash().to_vec())
+                .map(|b| b.block_hash())
                 .collect();
 
             // We are guaranteed that there's always at least one block.

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -96,7 +96,7 @@ pub fn insert_block(state: &mut State, block: Block) -> Result<(), BlockDoesNotE
 ///
 /// Returns a bool indicating whether or not the state has changed.
 pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
-    fn pop_block(state: &mut State, ingested_block_hash: bitcoin::BlockHash) {
+    fn pop_block(state: &mut State, ingested_block_hash: BlockHash) {
         // Pop the stable block.
         let popped_block = unstable_blocks::pop(&mut state.unstable_blocks);
 

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -1,10 +1,9 @@
 mod outpoints_cache;
 use crate::{
     blocktree::{self, BlockChain, BlockDoesNotExtendTree, BlockTree},
-    types::{Address, Block, OutPoint, TxOut},
+    types::{Address, Block, BlockHash, OutPoint, TxOut},
     UtxoSet,
 };
-use bitcoin::BlockHash;
 use ic_btc_types::Height;
 use outpoints_cache::OutPointsCache;
 use serde::{Deserialize, Serialize};
@@ -42,13 +41,13 @@ impl UnstableBlocks {
     }
 
     /// Retrieves the list of outpoints that were added for the given address in the given block.
-    pub fn get_added_outpoints(&self, block_hash: &Vec<u8>, address: &Address) -> &[OutPoint] {
+    pub fn get_added_outpoints(&self, block_hash: &BlockHash, address: &Address) -> &[OutPoint] {
         self.outpoints_cache
             .get_added_outpoints(block_hash, address)
     }
 
     /// Retrieves the list of outpoints that were removed for the given address in the given block.
-    pub fn get_removed_outpoints(&self, block_hash: &Vec<u8>, address: &Address) -> &[OutPoint] {
+    pub fn get_removed_outpoints(&self, block_hash: &BlockHash, address: &Address) -> &[OutPoint] {
         self.outpoints_cache
             .get_removed_outpoints(block_hash, address)
     }
@@ -94,7 +93,7 @@ pub fn push(
     block: Block,
 ) -> Result<(), BlockDoesNotExtendTree> {
     let (parent_block_tree, depth) =
-        blocktree::find_mut(&mut blocks.tree, &block.header().prev_blockhash)
+        blocktree::find_mut(&mut blocks.tree, &block.header().prev_blockhash.into())
             .ok_or_else(|| BlockDoesNotExtendTree(block.clone()))?;
 
     let height = utxos.next_height() + depth + 1;

--- a/canister/src/unstable_blocks/outpoints_cache.rs
+++ b/canister/src/unstable_blocks/outpoints_cache.rs
@@ -155,9 +155,9 @@ impl OutPointsCache {
         }
 
         self.added_outpoints
-            .insert(block.block_hash().to_vec(), added_outpoints);
+            .insert(block.block_hash(), added_outpoints);
         self.removed_outpoints
-            .insert(block.block_hash().to_vec(), removed_outpoints);
+            .insert(block.block_hash(), removed_outpoints);
 
         Ok(())
     }
@@ -205,7 +205,7 @@ impl OutPointsCache {
             }
         }
 
-        let block_hash = block.block_hash().to_vec();
+        let block_hash = block.block_hash();
         self.added_outpoints.remove(&block_hash);
         self.removed_outpoints.remove(&block_hash);
     }
@@ -313,16 +313,16 @@ mod test {
                     }
                 },
                 added_outpoints: maplit::btreemap! {
-                    block_0.block_hash().to_vec() => maplit::btreemap! {
+                    block_0.block_hash() => maplit::btreemap! {
                         address_1.clone() => vec![OutPoint::new(tx_0.txid(), 0)]
                     },
-                    block_1.block_hash().to_vec() => maplit::btreemap! {
+                    block_1.block_hash() => maplit::btreemap! {
                         address_2.clone() => vec![OutPoint::new(tx_1.txid(), 0)]
                     },
                 },
                 removed_outpoints: maplit::btreemap! {
-                    block_0.block_hash().to_vec() => maplit::btreemap! {},
-                    block_1.block_hash().to_vec() => maplit::btreemap! {
+                    block_0.block_hash() => maplit::btreemap! {},
+                    block_1.block_hash() => maplit::btreemap! {
                         address_1.clone() => vec![OutPoint::new(tx_0.txid(), 0)]
                     },
                 },
@@ -347,12 +347,12 @@ mod test {
                     }
                 },
                 added_outpoints: maplit::btreemap! {
-                    block_1.block_hash().to_vec() => maplit::btreemap! {
+                    block_1.block_hash() => maplit::btreemap! {
                         address_2 => vec![OutPoint::new(tx_1.txid(), 0)]
                     },
                 },
                 removed_outpoints: maplit::btreemap! {
-                    block_1.block_hash().to_vec() => maplit::btreemap! {
+                    block_1.block_hash() => maplit::btreemap! {
                         address_1 => vec![OutPoint::new(tx_0.txid(), 0)]
                     },
                 },
@@ -468,12 +468,12 @@ mod test {
                     },
                 },
                 added_outpoints: maplit::btreemap! {
-                    block_0.block_hash().to_vec() => maplit::btreemap! {
+                    block_0.block_hash() => maplit::btreemap! {
                         address_1 => vec![OutPoint::new(tx_0.txid(), 0)]
                     },
                 },
                 removed_outpoints: maplit::btreemap! {
-                    block_0.block_hash().to_vec() => maplit::btreemap! {}
+                    block_0.block_hash() => maplit::btreemap! {}
                 },
             }
         );

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -4,11 +4,11 @@ use crate::{
     runtime::{inc_performance_counter, performance_counter, print},
     state::OUTPOINT_SIZE,
     types::{
-        Address, AddressUtxo, Block, Network, OutPoint, Slicing, Storable, Transaction, TxOut,
-        Txid, Utxo,
+        Address, AddressUtxo, Block, BlockHash, Network, OutPoint, Slicing, Storable, Transaction,
+        TxOut, Txid, Utxo,
     },
 };
-use bitcoin::{BlockHash, Script, TxOut as BitcoinTxOut};
+use bitcoin::{Script, TxOut as BitcoinTxOut};
 use ic_btc_types::{Height, Satoshi};
 use ic_stable_structures::{StableBTreeMap, Storable as _};
 use serde::{Deserialize, Serialize};

--- a/e2e-tests/profiling/scenario-1.txt
+++ b/e2e-tests/profiling/scenario-1.txt
@@ -1,10 +1,10 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 31030, ins_remove_inputs: 1416, ins_insert_outputs: 27573, ins_txids: 788, ins_insert_utxos: 25678 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6428948312, ins_remove_inputs: 2832, ins_insert_outputs: 6428941550, ins_txids: 7943878, ins_insert_utxos: 6412147010 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16809393653, ins_remove_inputs: 10953649979, ins_insert_outputs: 5850215001, ins_txids: 12717607, ins_insert_utxos: 5826426528 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 597360, ins_apply_unstable_blocks: 137779 }
-GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 506806, ins_apply_unstable_blocks: 92517 }
-GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 132924320, ins_apply_unstable_blocks: 29618835, ins_build_utxos_vec: 102647364 }
-GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 74871782, ins_apply_unstable_blocks: 67560709, ins_build_utxos_vec: 6665559 }
-GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 27993592, ins_apply_unstable_blocks: 27581327 }
-get_current_fee_percentiles: 39640348
-get_current_fee_percentiles: 315618
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 31460, ins_remove_inputs: 1368, ins_insert_outputs: 27903, ins_txids: 788, ins_insert_utxos: 26008 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6448211476, ins_remove_inputs: 2736, ins_insert_outputs: 6448204588, ins_txids: 7938531, ins_insert_utxos: 6431415395 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16886474692, ins_remove_inputs: 10985205572, ins_insert_outputs: 5895000077, ins_txids: 10172829, ins_insert_utxos: 5873756382 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 598853, ins_apply_unstable_blocks: 137797 }
+GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 525134, ins_apply_unstable_blocks: 92535 }
+GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 132861407, ins_apply_unstable_blocks: 29620615, ins_build_utxos_vec: 102595853 }
+GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 74906087, ins_apply_unstable_blocks: 67593477, ins_build_utxos_vec: 6663393 }
+GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 27995452, ins_apply_unstable_blocks: 27581345 }
+get_current_fee_percentiles: 39639561
+get_current_fee_percentiles: 316106

--- a/e2e-tests/profiling/scenario-2.txt
+++ b/e2e-tests/profiling/scenario-2.txt
@@ -1,5 +1,5 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 35566, ins_remove_inputs: 1416, ins_insert_outputs: 32109, ins_txids: 1275, ins_insert_utxos: 29727 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5207875261, ins_remove_inputs: 14161416, ins_insert_outputs: 5188190460, ins_txids: 8170886, ins_insert_utxos: 5168949141 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5777089406, ins_remove_inputs: 14161416, ins_insert_outputs: 5757404605, ins_txids: 8170886, ins_insert_utxos: 5738163286 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 54674513, ins_apply_unstable_blocks: 54228363 }
-GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 156745653, ins_apply_unstable_blocks: 144150396, ins_build_utxos_vec: 11960639 }
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 36862, ins_remove_inputs: 1368, ins_insert_outputs: 33305, ins_txids: 1275, ins_insert_utxos: 30923 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5231944215, ins_remove_inputs: 13681368, ins_insert_outputs: 5211999314, ins_txids: 8170886, ins_insert_utxos: 5192757995 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5802886075, ins_remove_inputs: 13681368, ins_insert_outputs: 5782941174, ins_txids: 8170886, ins_insert_utxos: 5763699855 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 54692837, ins_apply_unstable_blocks: 54228392 }
+GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 156824938, ins_apply_unstable_blocks: 144149232, ins_build_utxos_vec: 12039217 }


### PR DESCRIPTION
Rather than using a `Vec<u8>` for a block hash, we now use a proper type. This step paves the way to upgrading the version of `stable-structures` we use to the latest version.