### PR TITLE
feat: [EXC-1286] Validate the bytes passed to the uploader canister.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,6 +2460,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha256"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e334db67871c14c18fc066ad14af13f9fdf5f9a91c61af432d1e3a39c8c6a141"
+dependencies = [
+ "hex",
+ "sha2 0.9.9",
+]
+
+[[package]]
 name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,6 +2849,7 @@ dependencies = [
  "ic-cdk 0.5.7",
  "ic-cdk-macros 0.5.7",
  "serde",
+ "sha256",
  "url",
 ]
 

--- a/bootstrap/uploader/Cargo.toml
+++ b/bootstrap/uploader/Cargo.toml
@@ -14,10 +14,15 @@ path = "src/main.rs"
 name = "upload"
 path = "src/upload.rs"
 
+[[example]]
+name = "compute_hashes"
+path = "src/compute_hashes.rs"
+
 [dependencies]
 candid = "0.7.4"
 ic-cdk = "0.5.6"
 ic-cdk-macros = "0.5.6"
+sha256 = "1.1.1"
 serde = "1.0.132"
 
 [dev-dependencies]

--- a/bootstrap/uploader/candid.did
+++ b/bootstrap/uploader/candid.did
@@ -1,4 +1,4 @@
-service: (nat64) -> {
+service: (nat64, vec text) -> {
   upload_chunk: (chunk_start: nat64, bytes: blob) -> ();
 
   get_missing_chunk_indices: () -> (vec nat64) query;

--- a/bootstrap/uploader/src/compute_hashes.rs
+++ b/bootstrap/uploader/src/compute_hashes.rs
@@ -1,0 +1,35 @@
+//! A script for computing the hashes of the chunks of a file.
+//!
+//! The size of the chunk is hard-coded in `CHUNK_SIZE_IN_BYTES`.
+use clap::Parser;
+use std::{fs::File, io::Read, path::PathBuf};
+use uploader::*;
+
+#[derive(Parser, Debug)]
+struct Args {
+    /// The path of the file to compute its hashes.
+    #[clap(long, value_hint = clap::ValueHint::DirPath)]
+    file: PathBuf,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    // Read file in chunks, and print the sha256 hash of each of these chunks.
+    let mut file = File::open(args.file).expect("opening file must succeed");
+    let mut chunk = vec![0; CHUNK_SIZE_IN_BYTES as usize];
+    loop {
+        let bytes_read = file.read(&mut chunk).unwrap();
+
+        if bytes_read == 0 {
+            break;
+        }
+
+        let hash = sha256::digest(&chunk[0..bytes_read]);
+        println!("{}", hash);
+
+        if bytes_read < CHUNK_SIZE_IN_BYTES as usize {
+            break;
+        }
+    }
+}


### PR DESCRIPTION
To ensure the correctness of the bytes uploaded via the `uploader` canister, the `uploader` canister is now initialized with a list of the sha2 hashes of each chunk that'll be uploaded. The `uploader` then verifies the hash of each chunk prior to writing it into stable memory.

A script for compute the chunk hashes is also included.