### PR TITLE
fix: load all supported addresses from the utxo dump file

### DIFF
--- a/bootstrap/state-builder/src/build_address_utxos.rs
+++ b/bootstrap/state-builder/src/build_address_utxos.rs
@@ -6,7 +6,7 @@
 //!   --network testnet \
 //!   --output balances.bin \
 //!   --utxos-dump-path utxos-dump.csv
-use bitcoin::{Address as BitcoinAddress, Txid as BitcoinTxid, Script};
+use bitcoin::{Address as BitcoinAddress, Script, Txid as BitcoinTxid};
 use clap::Parser;
 use ic_btc_canister::types::{Address, AddressUtxo, Network, OutPoint, Txid};
 use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
@@ -61,13 +61,11 @@ fn main() {
         // we support, so if parsing the address itself fails, we try parsing the script directly.
         let address = if let Ok(address) = BitcoinAddress::from_str(address_str) {
             Some(address)
-        } else if let Some(address) = BitcoinAddress::from_script(
-            &Script::from(hex::decode(script).expect("script must be valid hex")),
-            args.network.into(),
-        ) {
-            Some(address)
         } else {
-            None
+            BitcoinAddress::from_script(
+                &Script::from(hex::decode(script).expect("script must be valid hex")),
+                args.network.into(),
+            )
         };
 
         if let Some(address) = address {

--- a/bootstrap/state-builder/src/build_address_utxos.rs
+++ b/bootstrap/state-builder/src/build_address_utxos.rs
@@ -6,9 +6,9 @@
 //!   --network testnet \
 //!   --output balances.bin \
 //!   --utxos-dump-path utxos-dump.csv
-use bitcoin::{Address, Txid as BitcoinTxid};
+use bitcoin::{Address as BitcoinAddress, Txid as BitcoinTxid, Script};
 use clap::Parser;
-use ic_btc_canister::types::{Address as OurAddress, AddressUtxo, Network, OutPoint, Txid};
+use ic_btc_canister::types::{Address, AddressUtxo, Network, OutPoint, Txid};
 use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
 use std::{
     fs::File,
@@ -50,14 +50,28 @@ fn main() {
         let txid = Txid::from(BitcoinTxid::from_str(parts[1]).unwrap().to_vec());
         let vout: u32 = parts[2].parse().unwrap();
         let address_str = parts[5];
-        let height: u32 = parts[9].parse().unwrap();
+        let height: u32 = parts[0].parse().unwrap();
+        let script = parts[6];
 
         if i % 100_000 == 0 {
             println!("Processed {} UTXOs", i);
         }
 
-        if let Ok(address) = Address::from_str(address_str) {
-            let address: OurAddress = address.into();
+        // Load the address. The UTXO dump tool we use doesn't output all the addresses
+        // we support, so if parsing the address itself fails, we try parsing the script directly.
+        let address = if let Ok(address) = BitcoinAddress::from_str(address_str) {
+            Some(address)
+        } else if let Some(address) = BitcoinAddress::from_script(
+            &Script::from(hex::decode(script).expect("script must be valid hex")),
+            args.network.into(),
+        ) {
+            Some(address)
+        } else {
+            None
+        };
+
+        if let Some(address) = address {
+            let address: Address = address.into();
 
             address_utxos
                 .insert(

--- a/bootstrap/state-builder/src/build_balances.rs
+++ b/bootstrap/state-builder/src/build_balances.rs
@@ -60,13 +60,11 @@ fn main() {
         // we support, so if parsing the address itself fails, we try parsing the script directly.
         let address = if let Ok(address) = BitcoinAddress::from_str(address_str) {
             Some(address)
-        } else if let Some(address) = BitcoinAddress::from_script(
-            &Script::from(hex::decode(script).expect("script must be valid hex")),
-            args.network.into(),
-        ) {
-            Some(address)
         } else {
-            None
+            BitcoinAddress::from_script(
+                &Script::from(hex::decode(script).expect("script must be valid hex")),
+                args.network.into(),
+            )
         };
 
         if let Some(address) = address {

--- a/bootstrap/state-builder/src/build_balances.rs
+++ b/bootstrap/state-builder/src/build_balances.rs
@@ -6,7 +6,7 @@
 //!   --network testnet \
 //!   --output balances.bin \
 //!   --utxos-dump-path utxos-dump.csv
-use bitcoin::Address as BitcoinAddress;
+use bitcoin::{Address as BitcoinAddress, Script};
 use clap::Parser;
 use ic_btc_canister::types::{Address, Network};
 use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
@@ -50,12 +50,26 @@ fn main() {
 
         let amount: u64 = parts[3].parse().unwrap();
         let address_str = parts[5];
+        let script = parts[6];
 
         if i % 100_000 == 0 {
             println!("Processed {} UTXOs", i);
         }
 
-        if let Ok(address) = BitcoinAddress::from_str(address_str) {
+        // Load the address. The UTXO dump tool we use doesn't output all the addresses
+        // we support, so if parsing the address itself fails, we try parsing the script directly.
+        let address = if let Ok(address) = BitcoinAddress::from_str(address_str) {
+            Some(address)
+        } else if let Some(address) = BitcoinAddress::from_script(
+            &Script::from(hex::decode(script).expect("script must be valid hex")),
+            args.network.into(),
+        ) {
+            Some(address)
+        } else {
+            None
+        };
+
+        if let Some(address) = address {
             let address: Address = address.into();
 
             // Update the balance of the address.

--- a/bootstrap/state-builder/src/build_utxos.rs
+++ b/bootstrap/state-builder/src/build_utxos.rs
@@ -85,7 +85,7 @@ fn main() {
             let vout: u32 = parts[2].parse().unwrap();
             let amount: u64 = parts[3].parse().unwrap();
             let script = parts[6];
-            let height: u32 = parts[9].parse().unwrap();
+            let height: u32 = parts[0].parse().unwrap();
             let address_str = parts[5];
 
             if i % 100_000 == 0 {
@@ -143,7 +143,7 @@ fn main() {
             .expect("failed to encode large utxos");
         match file.write_all(&bytes) {
             Err(err) => panic!("couldn't write to {}: {}", p.display(), err),
-            Ok(_) => println!("successfully wrote balances to {}", p.display()),
+            Ok(_) => println!("successfully wrote to {}", p.display()),
         };
     });
 }


### PR DESCRIPTION
When pre-computing the state we rely on a 3rd party tool that outputs a text dump of the UTXOs. Not all the addresses we support are emitted by this tool, so as a result we don't include all the addresses we support in our state.

This commit fixes this issue by adding a fallback mechanism. If parsing the address fails (e.g. it doesn't exist), we attempt to parse the script of the UTXO directly.