### PR TITLE
chore: update byte representation of `(TxOut, Height)`.

### DIFF
--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -349,9 +349,9 @@ impl BoundedStorable for OutPoint {
 impl Storable for (TxOut, Height) {
     fn to_bytes(&self) -> Vec<u8> {
         vec![
-            self.0.value.to_bytes().to_vec(),    // Store the value (8 bytes)
-            self.0.script_pubkey.clone(),        // Then the script (size varies)
-            Storable::to_bytes(&self.1),         // Then the height (4 bytes)
+            self.0.value.to_bytes().to_vec(), // Store the value (8 bytes)
+            self.0.script_pubkey.clone(),     // Then the script (size varies)
+            Storable::to_bytes(&self.1),      // Then the height (4 bytes)
         ]
         .into_iter()
         .flatten()

--- a/e2e-tests/profiling/scenario-1.txt
+++ b/e2e-tests/profiling/scenario-1.txt
@@ -1,10 +1,10 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 31363, ins_remove_inputs: 1368, ins_insert_outputs: 27806, ins_txids: 788, ins_insert_utxos: 25911 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6448287910, ins_remove_inputs: 2736, ins_insert_outputs: 6448281022, ins_txids: 7938531, ins_insert_utxos: 6431491829 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16888465389, ins_remove_inputs: 10986313929, ins_insert_outputs: 5895882217, ins_txids: 10137210, ins_insert_utxos: 5874673708 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 616847, ins_apply_unstable_blocks: 137779 }
-GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 510639, ins_apply_unstable_blocks: 92517 }
-GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 132373293, ins_apply_unstable_blocks: 29622807, ins_build_utxos_vec: 102103067 }
-GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 74879961, ins_apply_unstable_blocks: 67598437, ins_build_utxos_vec: 6632109 }
-GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 27995522, ins_apply_unstable_blocks: 27581327 }
-get_current_fee_percentiles: 39640350
-get_current_fee_percentiles: 316386
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 32090, ins_remove_inputs: 1368, ins_insert_outputs: 28533, ins_txids: 788, ins_insert_utxos: 26638 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6454181277, ins_remove_inputs: 2736, ins_insert_outputs: 6454174389, ins_txids: 7942734, ins_insert_utxos: 6437380993 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16897611440, ins_remove_inputs: 10992210925, ins_insert_outputs: 5899131472, ins_txids: 10188586, ins_insert_utxos: 5877872020 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 600257, ins_apply_unstable_blocks: 137779 }
+GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 510856, ins_apply_unstable_blocks: 92517 }
+GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 132856106, ins_apply_unstable_blocks: 29639822, ins_build_utxos_vec: 102568983 }
+GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 74959037, ins_apply_unstable_blocks: 67633051, ins_build_utxos_vec: 6675487 }
+GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 27996324, ins_apply_unstable_blocks: 27581327 }
+get_current_fee_percentiles: 39638865
+get_current_fee_percentiles: 316342

--- a/e2e-tests/profiling/scenario-2.txt
+++ b/e2e-tests/profiling/scenario-2.txt
@@ -1,5 +1,5 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 36875, ins_remove_inputs: 1368, ins_insert_outputs: 33318, ins_txids: 1275, ins_insert_utxos: 30936 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5233234273, ins_remove_inputs: 13681368, ins_insert_outputs: 5213289372, ins_txids: 8170886, ins_insert_utxos: 5194048053 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5804176217, ins_remove_inputs: 13681368, ins_insert_outputs: 5784231316, ins_txids: 8170886, ins_insert_utxos: 5764989997 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 54673860, ins_apply_unstable_blocks: 54228374 }
-GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 156746133, ins_apply_unstable_blocks: 144170243, ins_build_utxos_vec: 11938565 }
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 37104, ins_remove_inputs: 1368, ins_insert_outputs: 33547, ins_txids: 1275, ins_insert_utxos: 31165 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5236074273, ins_remove_inputs: 13681368, ins_insert_outputs: 5216129372, ins_txids: 8170886, ins_insert_utxos: 5196888053 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5807016217, ins_remove_inputs: 13681368, ins_insert_outputs: 5787071316, ins_txids: 8170886, ins_insert_utxos: 5767829997 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 54690778, ins_apply_unstable_blocks: 54228374 }
+GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 156767408, ins_apply_unstable_blocks: 144148213, ins_build_utxos_vec: 11983917 }


### PR DESCRIPTION
Updates the byte representation of the `(TxOut, Height)` type. The motivation behind this change is that we'll add support for encoding tuples in the `stable-structures` crate soon, and this update makes it compatible with the way we'll be encoding tuples there.