### PR TITLE
[Launch Branch] Disable Endpoints

### DIFF
--- a/canister/src/api/send_transaction.rs
+++ b/canister/src/api/send_transaction.rs
@@ -4,6 +4,7 @@ use crate::{
 use ic_btc_types::SendTransactionRequest;
 
 pub async fn send_transaction(request: SendTransactionRequest) {
+    panic!("not enabled yet");
     verify_network(request.network.into());
 
     charge_cycles(with_state(|s| {

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -87,16 +87,19 @@ pub fn init(config: Config) {
 pub fn get_current_fee_percentiles(
     request: GetCurrentFeePercentilesRequest,
 ) -> Vec<MillisatoshiPerByte> {
+    panic!("not enabled yet");
     verify_network(request.network.into());
     api::get_current_fee_percentiles()
 }
 
 pub fn get_balance(request: GetBalanceRequest) -> Satoshi {
+    panic!("not enabled yet");
     verify_network(request.network.into());
     api::get_balance(request.into())
 }
 
 pub fn get_utxos(request: GetUtxosRequest) -> GetUtxosResponse {
+    panic!("not enabled yet");
     verify_network(request.network.into());
     api::get_utxos(request.into())
 }


### PR DESCRIPTION
We'll first be deploying the bitcoin canister with the endpoints disabled. This commit
ensures all the endpoints are disabled until we've synced the canister to the tip.