### PR TITLE
chore: reduce max UTXOs per response to 1k.

### DIFF
--- a/canister/src/api/get_utxos.rs
+++ b/canister/src/api/get_utxos.rs
@@ -13,13 +13,13 @@ use std::str::FromStr;
 // `GetUtxosResponse`.
 //
 // Given the size of a `Utxo` is 48 bytes, this means that the size of a single
-// response can be ~500KiB (considering the size of remaining fields and
-// potential overhead for the candid serialization). This is still quite below
+// response can be ~50KiB (considering the size of remaining fields and potential
+// overhead for the candid serialization). This is still quite below
 // the max response payload size of 2MiB that the IC needs to respect.
-
+//
 // The value also conforms to the interface spec which requires that no more
-// than 100_000 `Utxo`s are returned in a single response.
-const MAX_UTXOS_PER_RESPONSE: usize = 10_000;
+// than 10_000 `Utxo`s are returned in a single response.
+const MAX_UTXOS_PER_RESPONSE: usize = 1_000;
 
 // Various profiling stats for tracking the performance of `get_utxos`.
 #[derive(Default, Debug)]

--- a/e2e-tests/profiling/scenario-1.txt
+++ b/e2e-tests/profiling/scenario-1.txt
@@ -1,10 +1,10 @@
 Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 32090, ins_remove_inputs: 1368, ins_insert_outputs: 28533, ins_txids: 788, ins_insert_utxos: 26638 }
 Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6454181277, ins_remove_inputs: 2736, ins_insert_outputs: 6454174389, ins_txids: 7942734, ins_insert_utxos: 6437380993 }
 Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16897611485, ins_remove_inputs: 10992210970, ins_insert_outputs: 5899131472, ins_txids: 10188586, ins_insert_utxos: 5877872020 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 615745, ins_apply_unstable_blocks: 137770 }
-GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 509640, ins_apply_unstable_blocks: 92511 }
-GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 132372266, ins_apply_unstable_blocks: 29622807, ins_build_utxos_vec: 102103067 }
-GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 74879478, ins_apply_unstable_blocks: 67598479, ins_build_utxos_vec: 6632217 }
-GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 27994736, ins_apply_unstable_blocks: 27581318 }
-get_current_fee_percentiles: 39678397
-get_current_fee_percentiles: 316075
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 616875, ins_apply_unstable_blocks: 137770 }
+GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 510636, ins_apply_unstable_blocks: 92511 }
+GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 132915940, ins_apply_unstable_blocks: 29623794, ins_build_utxos_vec: 102644413 }
+GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 71595185, ins_apply_unstable_blocks: 67598618, ins_build_utxos_vec: 3346361 }
+GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 27996068, ins_apply_unstable_blocks: 27581318 }
+get_current_fee_percentiles: 39679112
+get_current_fee_percentiles: 316824

--- a/e2e-tests/profiling/scenario-2.txt
+++ b/e2e-tests/profiling/scenario-2.txt
@@ -1,5 +1,5 @@
 Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 37104, ins_remove_inputs: 1368, ins_insert_outputs: 33547, ins_txids: 1275, ins_insert_utxos: 31165 }
 Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5236074273, ins_remove_inputs: 13681368, ins_insert_outputs: 5216129372, ins_txids: 8170886, ins_insert_utxos: 5196888053 }
 Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5807016217, ins_remove_inputs: 13681368, ins_insert_outputs: 5787071316, ins_txids: 8170886, ins_insert_utxos: 5767829997 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 54689219, ins_apply_unstable_blocks: 54228324 }
-GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 156729268, ins_apply_unstable_blocks: 144156329, ins_build_utxos_vec: 11936207 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 54691031, ins_apply_unstable_blocks: 54228357 }
+GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 153827201, ins_apply_unstable_blocks: 144175005, ins_build_utxos_vec: 9014956 }

--- a/e2e-tests/scenario-1.sh
+++ b/e2e-tests/scenario-1.sh
@@ -74,8 +74,8 @@ UTXOS=$(dfx canister call bitcoin bitcoin_get_utxos '(record {
   address = "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh"
 })')
 
-# The address has 10000 UTXOs.
-if ! [[ $(num_utxos "$UTXOS") = 10000 ]]; then
+# The address has 10000 UTXOs, but the response is capped to 1000 UTXOs.
+if ! [[ $(num_utxos "$UTXOS") = 1000 ]]; then
   echo "FAIL"
   exit 1
 fi

--- a/e2e-tests/scenario-2.sh
+++ b/e2e-tests/scenario-2.sh
@@ -53,8 +53,8 @@ UTXOS=$(dfx canister call bitcoin bitcoin_get_utxos '(record {
   address = "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8"
 })')
 
-# The address has 40k UTXOs. The first call to get_utxos should return 10,000.
-if ! [[ $(num_utxos "$UTXOS") = 10000 ]]; then
+# The address has 40k UTXOs. The first call to get_utxos should return 1,000.
+if ! [[ $(num_utxos "$UTXOS") = 1000 ]]; then
   echo "FAIL"
   exit 1
 fi


### PR DESCRIPTION
This change is in line with the new pricing we're introducing.