### PR TITLE
prettify cycles print

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,6 +1222,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "tempfile",
+ "thousands",
 ]
 
 [[package]]
@@ -2664,6 +2665,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "time"

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -20,6 +20,7 @@ ic-stable-structures = "0.3.0"
 lazy_static = "1.4.0"
 serde = "1.0.132"
 serde_bytes = "0.11"
+thousands = "0.2.0"
 
 [[bin]]
 name = "canister"

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -148,7 +148,7 @@ mod test {
     use crate::{
         genesis_block, state,
         test_utils::{random_p2pkh_address, BlockBuilder, TransactionBuilder},
-        types::{Config, Fees, Network, OutPoint},
+        types::{Config, Cycles, Fees, Network, OutPoint},
         with_state,
     };
     use ic_btc_types::Satoshi;
@@ -508,7 +508,7 @@ mod test {
     fn charges_cycles() {
         crate::init(Config {
             fees: Fees {
-                get_current_fee_percentiles: 10,
+                get_current_fee_percentiles: Cycles::new(10),
                 ..Default::default()
             },
             ..Default::default()

--- a/canister/src/api/get_balance.rs
+++ b/canister/src/api/get_balance.rs
@@ -103,7 +103,7 @@ mod test {
     use crate::{
         genesis_block, state,
         test_utils::{random_p2pkh_address, BlockBuilder, TransactionBuilder},
-        types::{Config, Fees, Network, OutPoint},
+        types::{Config, Cycles, Fees, Network, OutPoint},
         with_state_mut,
     };
 
@@ -276,7 +276,7 @@ mod test {
     fn charges_cycles() {
         crate::init(Config {
             fees: Fees {
-                get_balance: 10,
+                get_balance: Cycles::new(10),
                 ..Default::default()
             },
             ..Default::default()

--- a/canister/src/api/get_utxos.rs
+++ b/canister/src/api/get_utxos.rs
@@ -80,7 +80,7 @@ pub fn get_utxos(request: GetUtxosRequest) -> GetUtxosResponse {
     with_state(|s| {
         let fee = std::cmp::min(
             s.fees.get_utxos_base
-                + (stats.ins_total / 10) as u128 * s.fees.get_utxos_cycles_per_ten_instructions,
+                + s.fees.get_utxos_cycles_per_ten_instructions * (stats.ins_total / 10),
             s.fees.get_utxos_maximum,
         );
         charge_cycles(fee);
@@ -245,7 +245,7 @@ mod test {
     use crate::{
         genesis_block, runtime, state,
         test_utils::{random_p2pkh_address, random_p2tr_address, BlockBuilder, TransactionBuilder},
-        types::{Block, Config, Fees, Network},
+        types::{Block, Config, Cycles, Fees, Network},
         with_state_mut,
     };
     use ic_btc_types::{OutPoint, Utxo};
@@ -1133,8 +1133,8 @@ mod test {
     fn charges_cycles() {
         crate::init(Config {
             fees: Fees {
-                get_utxos_base: 10,
-                get_utxos_maximum: 100,
+                get_utxos_base: Cycles::new(10),
+                get_utxos_maximum: Cycles::new(100),
                 ..Default::default()
             },
             ..Default::default()
@@ -1152,9 +1152,9 @@ mod test {
     fn charges_cycles_capped_at_maximum() {
         crate::init(Config {
             fees: Fees {
-                get_utxos_base: 10,
-                get_utxos_cycles_per_ten_instructions: 10,
-                get_utxos_maximum: 100,
+                get_utxos_base: Cycles::new(10),
+                get_utxos_cycles_per_ten_instructions: Cycles::new(10),
+                get_utxos_maximum: Cycles::new(100),
                 ..Default::default()
             },
             ..Default::default()
@@ -1176,9 +1176,9 @@ mod test {
     fn charges_cycles_per_instructions() {
         crate::init(Config {
             fees: Fees {
-                get_utxos_base: 10,
-                get_utxos_cycles_per_ten_instructions: 10,
-                get_utxos_maximum: 100_000,
+                get_utxos_base: Cycles::new(10),
+                get_utxos_cycles_per_ten_instructions: Cycles::new(10),
+                get_utxos_maximum: Cycles::new(100_000),
                 ..Default::default()
             },
             ..Default::default()

--- a/canister/src/api/send_transaction.rs
+++ b/canister/src/api/send_transaction.rs
@@ -9,8 +9,7 @@ pub async fn send_transaction(request: SendTransactionRequest) {
     verify_network(request.network.into());
 
     charge_cycles(with_state(|s| {
-        s.fees.send_transaction_base
-            + s.fees.send_transaction_per_byte * request.transaction.len() as u128
+        s.fees.send_transaction_base + s.fees.send_transaction_per_byte * request.transaction.len()
     }));
 
     // Decode the transaction as a sanity check that it's valid.
@@ -39,7 +38,7 @@ pub async fn send_transaction(request: SendTransactionRequest) {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::types::{Config, Fees, Network};
+    use crate::types::{Config, Cycles, Fees, Network};
     use ic_btc_types::NetworkInRequest;
 
     fn empty_transaction() -> Vec<u8> {
@@ -62,8 +61,8 @@ mod test {
     async fn charges_cycles() {
         crate::init(Config {
             fees: Fees {
-                send_transaction_base: 13,
-                send_transaction_per_byte: 27,
+                send_transaction_base: Cycles::new(13),
+                send_transaction_per_byte: Cycles::new(27),
                 ..Default::default()
             },
             network: Network::Mainnet,
@@ -96,8 +95,8 @@ mod test {
     async fn invalid_tx_panics() {
         crate::init(Config {
             fees: Fees {
-                send_transaction_base: 13,
-                send_transaction_per_byte: 27,
+                send_transaction_base: Cycles::new(13),
+                send_transaction_per_byte: Cycles::new(27),
                 ..Default::default()
             },
             network: Network::Mainnet,

--- a/canister/src/api/set_config.rs
+++ b/canister/src/api/set_config.rs
@@ -52,7 +52,7 @@ mod test {
     use super::*;
     use crate::{
         init,
-        types::{Config, Fees, Flag},
+        types::{Config, Cycles, Fees, Flag},
         with_state,
     };
     use proptest::prelude::*;
@@ -101,23 +101,23 @@ mod test {
             get_utxos_base in 0..1_000_000_000_000u128,
             get_utxos_maximum in 0..1_000_000_000_000u128,
             get_utxos_cycles_per_ten_instructions in 0..100u128,
-            get_balance_maximum in 0..1_000_000_000_000u128,
             get_balance in 0..1_000_000_000_000u128,
+            get_balance_maximum in 0..1_000_000_000_000u128,
             get_current_fee_percentiles in 0..1_000_000_000_000u128,
             get_current_fee_percentiles_maximum in 0..1_000_000_000_000u128,
             send_transaction_base in 0..1_000_000_000_000u128,
             send_transaction_per_byte in 0..1_000_000_000_000u128,
         )| {
             let fees = Fees {
-                get_utxos_base,
-                get_utxos_maximum,
-                get_utxos_cycles_per_ten_instructions,
-                get_balance_maximum,
-                get_balance,
-                get_current_fee_percentiles,
-                get_current_fee_percentiles_maximum,
-                send_transaction_base,
-                send_transaction_per_byte
+                get_utxos_base: Cycles::new(get_utxos_base),
+                get_utxos_cycles_per_ten_instructions: Cycles::new(get_utxos_cycles_per_ten_instructions),
+                get_utxos_maximum: Cycles::new(get_utxos_maximum),
+                get_balance: Cycles::new(get_balance),
+                get_balance_maximum: Cycles::new(get_balance_maximum),
+                get_current_fee_percentiles: Cycles::new(get_current_fee_percentiles),
+                get_current_fee_percentiles_maximum: Cycles::new(get_current_fee_percentiles_maximum),
+                send_transaction_base: Cycles::new(send_transaction_base),
+                send_transaction_per_byte: Cycles::new(send_transaction_per_byte),
             };
 
             set_config_no_verification(SetConfigRequest {

--- a/canister/src/runtime.rs
+++ b/canister/src/runtime.rs
@@ -170,9 +170,13 @@ pub fn msg_cycles_available() -> u64 {
     ic_cdk::api::call::msg_cycles_available()
 }
 
+/// Returns cycles available.
+///
+/// Non-wasm32 targets return a hardcoded value of `u64::MAX / 2` only for tests
+/// to check behavior both below and above the available limit.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn msg_cycles_available() -> u64 {
-    u64::MAX
+    u64::MAX / 2
 }
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
This PR prettifies cycles in error messages.

Before: `Received 1234567890 cycles. 999234567890 cycles are required.`
After: `Received 1_234_567_890 cycles. 999_234_567_890 cycles are required.`