### PR TITLE
feat: Add a flag to disable bitcoin apis

### DIFF
--- a/bootstrap/main-state-builder/src/main.rs
+++ b/bootstrap/main-state-builder/src/main.rs
@@ -11,7 +11,7 @@ use bitcoin::{consensus::Decodable, Block as BitcoinBlock};
 use clap::Parser;
 use ic_btc_canister::{
     pre_upgrade,
-    types::{Block, BlockHash, BlockHeaderBlob, Config, Network, OutPoint, TxOut},
+    types::{Block, BlockHash, BlockHeaderBlob, Config, Flag, Network, OutPoint, TxOut},
     unstable_blocks::{self, UnstableBlocks},
     with_state, with_state_mut,
 };
@@ -78,6 +78,7 @@ fn main() {
     ic_btc_canister::init(Config {
         network: args.network,
         stability_threshold: args.stability_threshold,
+        api_access: Flag::Disabled,
         ..Config::default()
     });
 

--- a/bootstrap/state-builder/src/build_utxos.rs
+++ b/bootstrap/state-builder/src/build_utxos.rs
@@ -9,7 +9,7 @@
 use bitcoin::{Address, Txid as BitcoinTxid};
 use clap::Parser;
 use ic_btc_canister::{
-    types::{Config, Network, OutPoint, TxOut, Txid},
+    types::{Config, Flag, Network, OutPoint, TxOut, Txid},
     with_state, with_state_mut,
 };
 use ic_stable_structures::{
@@ -73,6 +73,7 @@ fn main() {
 
     ic_btc_canister::init(Config {
         network: args.network,
+        api_access: Flag::Disabled,
         ..Config::default()
     });
 

--- a/bootstrap/state-builder/src/main.rs
+++ b/bootstrap/state-builder/src/main.rs
@@ -13,7 +13,7 @@ use clap::Parser;
 use ic_btc_canister::{
     heartbeat, pre_upgrade, runtime,
     state::main_chain_height,
-    types::{Config, GetSuccessorsCompleteResponse, GetSuccessorsResponse, Network},
+    types::{Config, Flag, GetSuccessorsCompleteResponse, GetSuccessorsResponse, Network},
     with_state,
 };
 use rusty_leveldb::{Options, DB};
@@ -147,6 +147,7 @@ async fn main() {
     ic_btc_canister::init(Config {
         stability_threshold: 0,
         network: args.network,
+        api_access: Flag::Disabled,
         ..Config::default()
     });
 

--- a/canister/candid.did
+++ b/canister/candid.did
@@ -32,6 +32,7 @@ type config = record {
   blocks_source: principal;
   syncing: flag;
   fees: fees;
+  api_access: flag;
 };
 
 type fees = record {

--- a/canister/src/api/send_transaction.rs
+++ b/canister/src/api/send_transaction.rs
@@ -1,39 +1,45 @@
 use crate::{
-    charge_cycles, runtime, types::SendTransactionInternalRequest, verify_network, with_state,
-    with_state_mut,
+    charge_cycles, runtime,
+    types::{Flag, SendTransactionInternalRequest},
+    verify_network, with_state, with_state_mut,
 };
 use bitcoin::{consensus::Decodable, Transaction};
 use ic_btc_types::SendTransactionRequest;
 
 pub async fn send_transaction(request: SendTransactionRequest) {
-    verify_network(request.network.into());
+    match with_state(|s| s.api_access) {
+        Flag::Disabled => panic!("`bitcoin_send_transaction` is disabled."),
+        Flag::Enabled => {
+            verify_network(request.network.into());
 
-    charge_cycles(with_state(|s| {
-        s.fees.send_transaction_base
-            + s.fees.send_transaction_per_byte * request.transaction.len() as u128
-    }));
+            charge_cycles(with_state(|s| {
+                s.fees.send_transaction_base
+                    + s.fees.send_transaction_per_byte * request.transaction.len() as u128
+            }));
 
-    // Decode the transaction as a sanity check that it's valid.
-    let tx = Transaction::consensus_decode(request.transaction.as_slice())
-        .expect("Cannot decode transaction");
+            // Decode the transaction as a sanity check that it's valid.
+            let tx = Transaction::consensus_decode(request.transaction.as_slice())
+                .expect("Cannot decode transaction");
 
-    runtime::print(&format!("[send_transaction] Tx ID: {}", tx.txid()));
+            runtime::print(&format!("[send_transaction] Tx ID: {}", tx.txid()));
 
-    // Bump the counter for the number of (valid) requests received.
-    with_state_mut(|s| {
-        s.metrics.send_transaction_count += 1;
-    });
+            // Bump the counter for the number of (valid) requests received.
+            with_state_mut(|s| {
+                s.metrics.send_transaction_count += 1;
+            });
 
-    // Use the internal endpoint to send the transaction to the bitcoin network.
-    runtime::call_send_transaction_internal(
-        with_state(|s| s.blocks_source),
-        SendTransactionInternalRequest {
-            network: request.network.into(),
-            transaction: request.transaction,
-        },
-    )
-    .await
-    .expect("Sending transaction bitcoin network must succeed");
+            // Use the internal endpoint to send the transaction to the bitcoin network.
+            runtime::call_send_transaction_internal(
+                with_state(|s| s.blocks_source),
+                SendTransactionInternalRequest {
+                    network: request.network.into(),
+                    transaction: request.transaction,
+                },
+            )
+            .await
+            .expect("Sending transaction bitcoin network must succeed");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -101,6 +107,27 @@ mod test {
                 ..Default::default()
             },
             network: Network::Mainnet,
+            ..Default::default()
+        });
+
+        send_transaction(SendTransactionRequest {
+            network: NetworkInRequest::Mainnet,
+            transaction: vec![1, 2, 3], // Invalid transaction
+        })
+        .await;
+    }
+
+    #[async_std::test]
+    #[should_panic(expected = "`bitcoin_send_transaction` is disabled.")]
+    async fn send_transaction_access_disabled() {
+        crate::init(Config {
+            fees: Fees {
+                send_transaction_base: 13,
+                send_transaction_per_byte: 27,
+                ..Default::default()
+            },
+            network: Network::Mainnet,
+            api_access: Flag::Disabled,
             ..Default::default()
         });
 

--- a/canister/src/api/set_config.rs
+++ b/canister/src/api/set_config.rs
@@ -23,6 +23,10 @@ fn set_config_no_verification(request: SetConfigRequest) {
                     .expect("stability threshold too large"),
             );
         }
+
+        if let Some(api_access) = request.api_access {
+            s.api_access = api_access;
+        }
     });
 }
 

--- a/canister/src/api/set_config.rs
+++ b/canister/src/api/set_config.rs
@@ -132,4 +132,21 @@ mod test {
             with_state(|s| assert_eq!(s.fees, fees));
         });
     }
+
+    #[test]
+    fn set_api_access() {
+        init(Config::default());
+
+        for flag in &[Flag::Enabled, Flag::Disabled] {
+            set_config_no_verification(SetConfigRequest {
+                api_access: Some(*flag),
+                ..Default::default()
+            });
+
+            assert_eq!(
+                with_state(|s| s.api_access),
+                *flag
+            );
+        }
+    }
 }

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -201,7 +201,7 @@ fn verify_network(network: Network) {
 fn verify_api_access() {
     with_state(|state| {
         if state.api_access == Flag::Disabled {
-            panic!("bitcoin API is disabled");
+            panic!("Bitcoin API is disabled");
         }
     });
 }
@@ -335,7 +335,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "bitcoin API is disabled")]
+    #[should_panic(expected = "Bitcoin API is disabled")]
     fn get_balance_access_disabled() {
         init(Config {
             stability_threshold: 0,
@@ -351,7 +351,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "bitcoin API is disabled")]
+    #[should_panic(expected = "Bitcoin API is disabled")]
     fn get_utxos_access_disabled() {
         init(Config {
             stability_threshold: 0,
@@ -367,7 +367,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "bitcoin API is disabled")]
+    #[should_panic(expected = "Bitcoin API is disabled")]
     fn get_current_fee_percentiles_access_disabled() {
         init(Config {
             stability_threshold: 0,

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -44,6 +44,10 @@ pub struct State {
 
     /// Metrics for the various endpoints.
     pub metrics: Metrics,
+
+    /// Flag to control access to the apis provided by the canister.
+    #[serde(default)]
+    pub api_access: Flag,
 }
 
 impl State {
@@ -65,6 +69,7 @@ impl State {
             stable_block_headers: BlockHeaderStore::init(),
             fees: Fees::default(),
             metrics: Metrics::default(),
+            api_access: Flag::Enabled,
         }
     }
 

--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -38,6 +38,9 @@ pub struct Config {
     pub syncing: Flag,
 
     pub fees: Fees,
+
+    /// Flag to control access to the apis provided by the canister.
+    pub api_access: Flag,
 }
 
 impl Default for Config {
@@ -48,6 +51,7 @@ impl Default for Config {
             blocks_source: Principal::management_canister(),
             syncing: Flag::Enabled,
             fees: Fees::default(),
+            api_access: Flag::Enabled,
         }
     }
 }
@@ -865,6 +869,12 @@ pub enum Flag {
     Disabled,
 }
 
+impl Default for Flag {
+    fn default() -> Self {
+        Flag::Enabled
+    }
+}
+
 /// A request to update the canister's config.
 #[derive(CandidType, Deserialize, Default)]
 pub struct SetConfigRequest {
@@ -875,6 +885,9 @@ pub struct SetConfigRequest {
 
     /// The fees to charge for the various endpoints.
     pub fees: Option<Fees>,
+
+    /// Whether or not to enable/disable the bitcoin apis.
+    pub api_access: Option<Flag>,
 }
 
 #[test]

--- a/e2e-tests/profiling/scenario-1.txt
+++ b/e2e-tests/profiling/scenario-1.txt
@@ -1,10 +1,10 @@
 Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 32644, ins_remove_inputs: 1368, ins_insert_outputs: 29087, ins_txids: 788, ins_insert_utxos: 27192 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6456571449, ins_remove_inputs: 2736, ins_insert_outputs: 6456564561, ins_txids: 7943065, ins_insert_utxos: 6439770834 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16897591440, ins_remove_inputs: 10992210844, ins_insert_outputs: 5899111553, ins_txids: 10188586, ins_insert_utxos: 5877852101 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 603128, ins_apply_unstable_blocks: 137770 }
-GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 525425, ins_apply_unstable_blocks: 92511 }
-GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 132859524, ins_apply_unstable_blocks: 29614949, ins_build_utxos_vec: 102600381 }
-GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 71512586, ins_apply_unstable_blocks: 67519202, ins_build_utxos_vec: 3345730 }
-GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 27994343, ins_apply_unstable_blocks: 27581318 }
-get_current_fee_percentiles: 39643705
-get_current_fee_percentiles: 315500
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6451405358, ins_remove_inputs: 2736, ins_insert_outputs: 6451398470, ins_txids: 7946035, ins_insert_utxos: 6434601773 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16897593081, ins_remove_inputs: 10992212566, ins_insert_outputs: 5899111472, ins_txids: 10188586, ins_insert_utxos: 5877852020 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 620916, ins_apply_unstable_blocks: 137770 }
+GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 509260, ins_apply_unstable_blocks: 92511 }
+GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 132880243, ins_apply_unstable_blocks: 29620553, ins_build_utxos_vec: 102614765 }
+GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 71588256, ins_apply_unstable_blocks: 67593291, ins_build_utxos_vec: 3345201 }
+GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 27995448, ins_apply_unstable_blocks: 27581318 }
+get_current_fee_percentiles: 39645152
+get_current_fee_percentiles: 315245

--- a/e2e-tests/profiling/scenario-1.txt
+++ b/e2e-tests/profiling/scenario-1.txt
@@ -1,10 +1,10 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 32507, ins_remove_inputs: 1368, ins_insert_outputs: 28950, ins_txids: 788, ins_insert_utxos: 27055 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6451559963, ins_remove_inputs: 2736, ins_insert_outputs: 6451553075, ins_txids: 7943416, ins_insert_utxos: 6434758997 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16897611485, ins_remove_inputs: 10992210889, ins_insert_outputs: 5899131553, ins_txids: 10188586, ins_insert_utxos: 5877872101 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 620934, ins_apply_unstable_blocks: 137764 }
-GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 511115, ins_apply_unstable_blocks: 92507 }
-GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 133010082, ins_apply_unstable_blocks: 29622734, ins_build_utxos_vec: 102740266 }
-GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 71543231, ins_apply_unstable_blocks: 67548468, ins_build_utxos_vec: 3347295 }
-GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 27995722, ins_apply_unstable_blocks: 27581302 }
-get_current_fee_percentiles: 39643295
-get_current_fee_percentiles: 317050
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 32644, ins_remove_inputs: 1368, ins_insert_outputs: 29087, ins_txids: 788, ins_insert_utxos: 27192 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6456571449, ins_remove_inputs: 2736, ins_insert_outputs: 6456564561, ins_txids: 7943065, ins_insert_utxos: 6439770834 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16897591440, ins_remove_inputs: 10992210844, ins_insert_outputs: 5899111553, ins_txids: 10188586, ins_insert_utxos: 5877852101 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 603128, ins_apply_unstable_blocks: 137770 }
+GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 525425, ins_apply_unstable_blocks: 92511 }
+GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 132859524, ins_apply_unstable_blocks: 29614949, ins_build_utxos_vec: 102600381 }
+GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 71512586, ins_apply_unstable_blocks: 67519202, ins_build_utxos_vec: 3345730 }
+GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 27994343, ins_apply_unstable_blocks: 27581318 }
+get_current_fee_percentiles: 39643705
+get_current_fee_percentiles: 315500

--- a/e2e-tests/profiling/scenario-2.txt
+++ b/e2e-tests/profiling/scenario-2.txt
@@ -1,5 +1,5 @@
 Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 37102, ins_remove_inputs: 1368, ins_insert_outputs: 33545, ins_txids: 1275, ins_insert_utxos: 31163 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5236054228, ins_remove_inputs: 13681368, ins_insert_outputs: 5216109327, ins_txids: 8170886, ins_insert_utxos: 5196868008 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5236054273, ins_remove_inputs: 13681368, ins_insert_outputs: 5216109372, ins_txids: 8170886, ins_insert_utxos: 5196868053 }
 Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5806996217, ins_remove_inputs: 13681368, ins_insert_outputs: 5787051316, ins_txids: 8170886, ins_insert_utxos: 5767809997 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 54680187, ins_apply_unstable_blocks: 54228324 }
-GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 153730165, ins_apply_unstable_blocks: 144139992, ins_build_utxos_vec: 8951283 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 54697025, ins_apply_unstable_blocks: 54228368 }
+GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 153810771, ins_apply_unstable_blocks: 144153078, ins_build_utxos_vec: 9018084 }

--- a/e2e-tests/profiling/scenario-2.txt
+++ b/e2e-tests/profiling/scenario-2.txt
@@ -1,5 +1,5 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 37104, ins_remove_inputs: 1368, ins_insert_outputs: 33547, ins_txids: 1275, ins_insert_utxos: 31165 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5236074273, ins_remove_inputs: 13681368, ins_insert_outputs: 5216129372, ins_txids: 8170886, ins_insert_utxos: 5196888053 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5807016217, ins_remove_inputs: 13681368, ins_insert_outputs: 5787071316, ins_txids: 8170886, ins_insert_utxos: 5767829997 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 54691622, ins_apply_unstable_blocks: 54228344 }
-GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 153761534, ins_apply_unstable_blocks: 144138694, ins_build_utxos_vec: 8987040 }
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 37102, ins_remove_inputs: 1368, ins_insert_outputs: 33545, ins_txids: 1275, ins_insert_utxos: 31163 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5236054228, ins_remove_inputs: 13681368, ins_insert_outputs: 5216109327, ins_txids: 8170886, ins_insert_utxos: 5196868008 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5806996217, ins_remove_inputs: 13681368, ins_insert_outputs: 5787051316, ins_txids: 8170886, ins_insert_utxos: 5767809997 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 54680187, ins_apply_unstable_blocks: 54228324 }
+GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 153730165, ins_apply_unstable_blocks: 144139992, ins_build_utxos_vec: 8951283 }

--- a/e2e-tests/scenario-1.sh
+++ b/e2e-tests/scenario-1.sh
@@ -28,7 +28,8 @@ dfx deploy --no-wallet bitcoin --argument "(record {
     get_current_fee_percentiles_maximum = 0;
     send_transaction_base = 0;
     send_transaction_per_byte = 0;
-  }
+  };
+  api_access = variant { enabled }
 })"
 
 # Wait until the ingestion of stable blocks is complete.

--- a/e2e-tests/scenario-2.sh
+++ b/e2e-tests/scenario-2.sh
@@ -32,7 +32,8 @@ dfx deploy --no-wallet bitcoin --argument "(record {
     get_current_fee_percentiles_maximum = 0;
     send_transaction_base = 0;
     send_transaction_per_byte = 0;
-  }
+  };
+  api_access = variant { enabled }
 })"
 
 # Wait until the ingestion of stable blocks is complete.

--- a/e2e-tests/scenario-3.sh
+++ b/e2e-tests/scenario-3.sh
@@ -28,7 +28,8 @@ dfx deploy --no-wallet bitcoin --argument "(record {
     get_current_fee_percentiles_maximum = 0;
     send_transaction_base = 0;
     send_transaction_per_byte = 0;
-  }
+  };
+  api_access = variant { enabled }
 })"
 
 # Send transaction valid transaction


### PR DESCRIPTION
This PR adds a flag that allows us to enable/disable access to the bitcoin apis provided by the canister. The flag is set to have a default value of `true` to not disrupt the current operations of the canister. It's also added in the canister's `Config` so that it can eventually be set through a proposal that triggers the `set_config` endpoint of the canister. For now, if we need to disable the apis, we can set the flag to `Disabled` in the canister's post upgrade hook.