### PR TITLE
chore: revert pretty cycles in error message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,7 +1222,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "tempfile",
- "thousands",
 ]
 
 [[package]]
@@ -2665,12 +2664,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "thousands"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "time"

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -20,7 +20,6 @@ ic-stable-structures = "0.3.0"
 lazy_static = "1.4.0"
 serde = "1.0.132"
 serde_bytes = "0.11"
-thousands = "0.2.0"
 
 [[bin]]
 name = "canister"

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -33,7 +33,6 @@ pub use memory::get_memory;
 use serde_bytes::ByteBuf;
 use std::cell::RefCell;
 use std::convert::TryInto;
-use thousands::Separable;
 use utxo_set::UtxoSet;
 
 thread_local! {
@@ -176,11 +175,10 @@ pub(crate) fn verify_has_enough_cycles(amount: u128) {
     let amount: u64 = amount.try_into().expect("amount must be u64");
 
     if msg_cycles_available() < amount {
-        // Use `separate_with_underscores` to pretty printing with underscore thousand separator.
         panic!(
             "Received {} cycles. {} cycles are required.",
-            msg_cycles_available().separate_with_underscores(),
-            amount.separate_with_underscores()
+            msg_cycles_available(),
+            amount
         );
     }
 }
@@ -316,7 +314,7 @@ mod test {
 
     #[test]
     #[should_panic(
-        expected = "Received 9_223_372_036_854_775_807 cycles. 18_446_744_073_709_551_615 cycles are required."
+        expected = "Received 9223372036854775807 cycles. 18446744073709551615 cycles are required."
     )]
     fn test_verify_has_enough_cycles_panics_with_not_enough_cycles() {
         verify_has_enough_cycles(u64::MAX as u128);


### PR DESCRIPTION
This PR reverts pretty cycles in error message from #119, since it's a breaking change (any canister parsing this message will break), but keeps adding tests.

Before: `Received 1_234_567_890 cycles. 999_234_567_890 cycles are required`.
After: `Received 1234567890 cycles. 999234567890 cycles are required`.
