### PR TITLE
feat: compute block difficulty

### DIFF
--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -131,8 +131,8 @@ impl Block {
     //
     // NOTE: This is dead code temporarily and will be used in an upcoming PR.
     #[allow(dead_code)]
-    fn compute_difficulty(network: Network, block_target: Uint256) -> u64 {
-        (ic_btc_validation::max_target(&network.into()) / block_target).low_u64()
+    fn target_difficulty(network: Network, target: Uint256) -> u64 {
+        (ic_btc_validation::max_target(&network.into()) / target).low_u64()
     }
 }
 
@@ -989,10 +989,10 @@ fn address_handles_script_edge_case() {
 }
 
 #[test]
-fn compute_difficulty() {
+fn target_difficulty() {
     // Example found in https://en.bitcoin.it/wiki/Difficulty#How_is_difficulty_calculated.3F_What_is_the_difference_between_bdiff_and_pdiff.3F
     assert_eq!(
-        Block::compute_difficulty(
+        Block::target_difficulty(
             Network::Mainnet,
             bitcoin::BlockHeader::u256_from_compact_target(0x1b0404cb)
         ),
@@ -1002,7 +1002,7 @@ fn compute_difficulty() {
     // Block 768362.
     // Data pulled from https://www.blockchain.com/explorer/blocks/btc/768362
     assert_eq!(
-        Block::compute_difficulty(
+        Block::target_difficulty(
             Network::Mainnet,
             bitcoin::BlockHeader::u256_from_compact_target(386397584)
         ),
@@ -1012,7 +1012,7 @@ fn compute_difficulty() {
     // Block 700000.
     // Data pulled from https://www.blockchain.com/explorer/blocks/btc/700000
     assert_eq!(
-        Block::compute_difficulty(
+        Block::target_difficulty(
             Network::Mainnet,
             bitcoin::BlockHeader::u256_from_compact_target(386877668)
         ),
@@ -1021,7 +1021,7 @@ fn compute_difficulty() {
 
     // Regtest blocks by the BlockBuilder should have a difficulty of 1.
     assert_eq!(
-        Block::compute_difficulty(
+        Block::target_difficulty(
             Network::Regtest,
             crate::test_utils::BlockBuilder::genesis()
                 .build()

--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -999,7 +999,7 @@ fn target_difficulty() {
         16307
     );
 
-    // Block 768362.
+    // Mainnet block 768362.
     // Data pulled from https://www.blockchain.com/explorer/blocks/btc/768362
     assert_eq!(
         Block::target_difficulty(
@@ -1009,7 +1009,7 @@ fn target_difficulty() {
         35364065900457
     );
 
-    // Block 700000.
+    // Mainnet block 700000.
     // Data pulled from https://www.blockchain.com/explorer/blocks/btc/700000
     assert_eq!(
         Block::target_difficulty(
@@ -1017,6 +1017,26 @@ fn target_difficulty() {
             bitcoin::BlockHeader::u256_from_compact_target(386877668)
         ),
         18415156832118
+    );
+
+    // Testnet block 2412153.
+    // Data pulled from https://www.blockchain.com/explorer/blocks/btc-testnet/2412153
+    assert_eq!(
+        Block::target_difficulty(
+            Network::Testnet,
+            bitcoin::BlockHeader::u256_from_compact_target(422681968)
+        ),
+        86564599
+    );
+
+    // Testnet block 1500000.
+    // Data pulled from https://www.blockchain.com/explorer/blocks/btc-testnet/1500000
+    assert_eq!(
+        Block::target_difficulty(
+            Network::Testnet,
+            bitcoin::BlockHeader::u256_from_compact_target(457142912)
+        ),
+        1032
     );
 
     // Regtest blocks by the BlockBuilder should have a difficulty of 1.

--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -996,7 +996,7 @@ fn target_difficulty() {
             Network::Mainnet,
             bitcoin::BlockHeader::u256_from_compact_target(0x1b0404cb)
         ),
-        16307
+        16_307
     );
 
     // Mainnet block 768362.
@@ -1006,7 +1006,7 @@ fn target_difficulty() {
             Network::Mainnet,
             bitcoin::BlockHeader::u256_from_compact_target(386397584)
         ),
-        35364065900457
+        35_364_065_900_457
     );
 
     // Mainnet block 700000.
@@ -1016,7 +1016,7 @@ fn target_difficulty() {
             Network::Mainnet,
             bitcoin::BlockHeader::u256_from_compact_target(386877668)
         ),
-        18415156832118
+        18_415_156_832_118
     );
 
     // Testnet block 2412153.
@@ -1026,7 +1026,7 @@ fn target_difficulty() {
             Network::Testnet,
             bitcoin::BlockHeader::u256_from_compact_target(422681968)
         ),
-        86564599
+        86_564_599
     );
 
     // Testnet block 1500000.
@@ -1036,7 +1036,7 @@ fn target_difficulty() {
             Network::Testnet,
             bitcoin::BlockHeader::u256_from_compact_target(457142912)
         ),
-        1032
+        1_032
     );
 
     // Regtest blocks by the BlockBuilder should have a difficulty of 1.

--- a/validation/src/lib.rs
+++ b/validation/src/lib.rs
@@ -1,6 +1,7 @@
 mod constants;
 mod header;
 
+pub use crate::constants::max_target;
 pub use crate::header::{validate_header, HeaderStore, ValidateHeaderError};
 
 type BlockHeight = u32;


### PR DESCRIPTION
Computing the block difficulty is needed for computing the difficulty-based stability threshold that will be introduced in an upcoming commit.

We are not relying on the [difficulty](https://docs.rs/bitcoin/latest/bitcoin/blockdata/block/struct.BlockHeader.html#method.difficulty) method in the bitcoin crate, as it produces incorrect results for testnet and regtest.