### PR TITLE
chore: update profiling metrics

### DIFF
--- a/e2e-tests/profiling/scenario-1.txt
+++ b/e2e-tests/profiling/scenario-1.txt
@@ -1,10 +1,11 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 32644, ins_remove_inputs: 1368, ins_insert_outputs: 29087, ins_txids: 788, ins_insert_utxos: 27192 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6451405358, ins_remove_inputs: 2736, ins_insert_outputs: 6451398470, ins_txids: 7946035, ins_insert_utxos: 6434601773 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16897593081, ins_remove_inputs: 10992212566, ins_insert_outputs: 5899111472, ins_txids: 10188586, ins_insert_utxos: 5877852020 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 620916, ins_apply_unstable_blocks: 137770 }
-GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 509260, ins_apply_unstable_blocks: 92511 }
-GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 132880243, ins_apply_unstable_blocks: 29620553, ins_build_utxos_vec: 102614765 }
-GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 71588256, ins_apply_unstable_blocks: 67593291, ins_build_utxos_vec: 3345201 }
-GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 27995448, ins_apply_unstable_blocks: 27581318 }
-get_current_fee_percentiles: 39645152
-get_current_fee_percentiles: 315245
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 34417, ins_remove_inputs: 1368, ins_insert_outputs: 30860, ins_txids: 788, ins_insert_utxos: 28965 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6455552582, ins_remove_inputs: 2736, ins_insert_outputs: 6455545694, ins_txids: 7940724, ins_insert_utxos: 6438754308 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16902342388, ins_remove_inputs: 10994860468, ins_insert_outputs: 5901212477, ins_txids: 10152524, ins_insert_utxos: 5879988221 }
+Ingest Block 3: BlockIngestionStats { num_rounds: 1, ins_total: 588918, ins_remove_inputs: 1368, ins_insert_outputs: 585361, ins_txids: 788, ins_insert_utxos: 583466 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 536619, ins_apply_unstable_blocks: 92341 }
+GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 442959, ins_apply_unstable_blocks: 47054 }
+GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 154555246, ins_apply_unstable_blocks: 34472614, ins_build_utxos_vec: 119460377 }
+GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 76466048, ins_apply_unstable_blocks: 71300707, ins_build_utxos_vec: 4534726 }
+GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 26541215, ins_apply_unstable_blocks: 26147091 }
+get_current_fee_percentiles: 38862558
+get_current_fee_percentiles: 291267

--- a/e2e-tests/profiling/scenario-2.txt
+++ b/e2e-tests/profiling/scenario-2.txt
@@ -1,5 +1,6 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 37102, ins_remove_inputs: 1368, ins_insert_outputs: 33545, ins_txids: 1275, ins_insert_utxos: 31163 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5236054273, ins_remove_inputs: 13681368, ins_insert_outputs: 5216109372, ins_txids: 8170886, ins_insert_utxos: 5196868053 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5806996217, ins_remove_inputs: 13681368, ins_insert_outputs: 5787051316, ins_txids: 8170886, ins_insert_utxos: 5767809997 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 54697025, ins_apply_unstable_blocks: 54228368 }
-GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 153810771, ins_apply_unstable_blocks: 144153078, ins_build_utxos_vec: 9018084 }
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 36610, ins_remove_inputs: 1368, ins_insert_outputs: 33053, ins_txids: 788, ins_insert_utxos: 31158 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5237618420, ins_remove_inputs: 13681368, ins_insert_outputs: 5217673519, ins_txids: 8170886, ins_insert_utxos: 5198432200 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5809157217, ins_remove_inputs: 13681368, ins_insert_outputs: 5789212316, ins_txids: 8170886, ins_insert_utxos: 5769970997 }
+Ingest Block 3: BlockIngestionStats { num_rounds: 2, ins_total: 6067593952, ins_remove_inputs: 13681368, ins_insert_outputs: 6047649051, ins_txids: 8170886, ins_insert_utxos: 6028407732 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 26383066, ins_apply_unstable_blocks: 25931001 }
+GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 75359648, ins_apply_unstable_blocks: 69965170, ins_build_utxos_vec: 4747480 }


### PR DESCRIPTION
We didn't update the profiling metrics in #126, so this commit updates the profiling metrics.

There's a notable improvement in the `get_balance` and get_utxos` requests (see scenario 2).