### PR TITLE
fix: make `sort -n` consistent across machines

### DIFF
--- a/bootstrap/4_compute_utxo_dump.sh
+++ b/bootstrap/4_compute_utxo_dump.sh
@@ -23,6 +23,24 @@ echo "Removing the headers from the file..."
 tail -n +2 utxodump.csv > utxodump.csv.tmp && mv utxodump.csv.tmp utxodump.csv
 
 echo "Sorting the file..."
+
+# Set the locale to make `sort -n` deterministic.
+export LANG=C.UTF-8
+export LANGUAGE=
+export LC_CTYPE=C.UTF-8
+export LC_NUMERIC="C.UTF-8"
+export LC_TIME="C.UTF-8"
+export LC_COLLATE="C.UTF-8"
+export LC_MONETARY="C.UTF-8"
+export LC_MESSAGES="C.UTF-8"
+export LC_PAPER="C.UTF-8"
+export LC_NAME="C.UTF-8"
+export LC_ADDRESS="C.UTF-8"
+export LC_TELEPHONE="C.UTF-8"
+export LC_MEASUREMENT="C.UTF-8"
+export LC_IDENTIFICATION="C.UTF-8"
+export LC_ALL=
+
 sort -n -o utxodump.csv utxodump.csv
 
 echo "Computing sorted UTXO checksum..."

--- a/bootstrap/5_shuffle_utxo_dump.sh
+++ b/bootstrap/5_shuffle_utxo_dump.sh
@@ -4,6 +4,23 @@
 # the stable btreemaps in the canister.
 set -euo pipefail
 
+# Set the locale to make `sort -n` deterministic.
+export LANG=C.UTF-8
+export LANGUAGE=
+export LC_CTYPE=C.UTF-8
+export LC_NUMERIC="C.UTF-8"
+export LC_TIME="C.UTF-8"
+export LC_COLLATE="C.UTF-8"
+export LC_MONETARY="C.UTF-8"
+export LC_MESSAGES="C.UTF-8"
+export LC_PAPER="C.UTF-8"
+export LC_NAME="C.UTF-8"
+export LC_ADDRESS="C.UTF-8"
+export LC_TELEPHONE="C.UTF-8"
+export LC_MEASUREMENT="C.UTF-8"
+export LC_IDENTIFICATION="C.UTF-8"
+export LC_ALL=
+
 echo "Shuffling the UTXO dump..."
 awk 'BEGIN{srand(0);} {printf "%06d %s\n", rand()*1000000, $0;}' utxodump.csv | sort -n | cut -c8- > utxodump_shuffled.csv
 


### PR DESCRIPTION
In the instructions for bootstrapping the bitcoin state, we rely on `sort -n`. `sort -n`, it turns out, is dependent on the locale of the machine, so the scripts are updated to set a specific locale to make runs of `sort -n` deterministic.