### PR TITLE
test: add unit tests for stability count confirmations.

### DIFF
--- a/canister/src/runtime.rs
+++ b/canister/src/runtime.rs
@@ -39,7 +39,7 @@ thread_local! {
     // Responses are returned in the order provided.
     static GET_SUCCESSORS_RESPONSES: RefCell<Vec<GetSuccessorsReply>> = RefCell::new(Vec::default());
 
-    static GET_SUCCESSORS_RESPONSES_INDEX: RefCell<usize> = RefCell::new(0);
+    pub static GET_SUCCESSORS_RESPONSES_INDEX: RefCell<usize> = RefCell::new(0);
 
     static PERFORMANCE_COUNTER: RefCell<u64> = RefCell::new(0);
 

--- a/canister/src/tests.rs
+++ b/canister/src/tests.rs
@@ -24,6 +24,7 @@ use ic_cdk::api::call::RejectionCode;
 use std::fs::File;
 use std::str::FromStr;
 use std::{collections::HashMap, io::BufReader, path::PathBuf};
+mod confirmation_counts;
 
 async fn process_chain(network: Network, blocks_file: &str, num_blocks: u32) {
     let mut chain: Vec<Block> = vec![];

--- a/canister/src/tests/confirmation_counts.rs
+++ b/canister/src/tests/confirmation_counts.rs
@@ -1,0 +1,179 @@
+use crate::{
+    api::get_utxos,
+    heartbeat,
+    runtime::{set_successors_responses, GetSuccessorsReply},
+    test_utils::BlockChainBuilder,
+    types::{
+        Block, GetSuccessorsCompleteResponse, GetSuccessorsResponse, GetUtxosRequest, Network,
+    },
+};
+use async_std::task::block_on;
+use ic_btc_types::UtxosFilter;
+use proptest::prelude::*;
+
+const ADDRESS: &str = "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8";
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10))]
+    #[test]
+    fn single_chain(
+        chain_len in 1..10u32,
+    ) {
+        crate::init(crate::Config {
+            stability_threshold: 10,
+            network: Network::Regtest,
+            ..Default::default()
+        });
+
+        // Creates a single chain.
+        let chain = BlockChainBuilder::new(chain_len).build();
+
+        ingest_blocks(chain.iter());
+
+        // Assert that the tip height/block is equivalent to the depth of the block, which is the
+        // standard way of counting confirmations.
+        let res = get_utxos(GetUtxosRequest {
+            address: ADDRESS.to_string(),
+            filter: None,
+        });
+
+        assert_eq!(res.tip_height, chain_len - 1);
+        assert_eq!(res.tip_block_hash, chain[chain_len as usize - 1].block_hash().to_vec());
+
+        for i in 1..chain_len {
+            let res = get_utxos(GetUtxosRequest {
+                address: ADDRESS.to_string(),
+                filter: Some(UtxosFilter::MinConfirmations(i)),
+            });
+
+            let block_depth = chain_len - i;
+            assert_eq!(res.tip_height, block_depth);
+            assert_eq!(res.tip_block_hash, chain[block_depth as usize].block_hash().to_vec());
+        }
+    }
+}
+
+proptest! {
+    // Tests how the presence of a fork impacts the confirmation count of the main chain.
+    //
+    // An arbitary main chain is created and a fork at a random location of the chain is created
+    // such that the fork is always shorted the main chain's tip.
+    #![proptest_config(ProptestConfig::with_cases(10))]
+    #[test]
+    #[ignore] // TODO(EXC-1319): Enable this test.
+    fn single_fork(
+        chain_len in 8..10u32,
+        fork_idx in 0..7usize,
+    ) {
+        let fork_len: u32 = 1;
+
+        // The height of the block present in the fork.
+        let fork_height: u32 = fork_idx as u32 + fork_len;
+
+        crate::init(crate::Config {
+            stability_threshold: 10,
+            network: Network::Regtest,
+            ..Default::default()
+        });
+
+        // Creates a chain with the fork.
+        let chain = BlockChainBuilder::new(chain_len).build();
+        let fork = BlockChainBuilder::fork(&chain[fork_idx], fork_len).build();
+
+        ingest_blocks(chain.iter().chain(fork.iter()));
+
+        // The tip of the chain should be that of the main chain.
+        let res = get_utxos(GetUtxosRequest {
+            address: ADDRESS.to_string(),
+            filter: None,
+        });
+
+        assert_eq!(res.tip_height, chain_len - 1);
+        assert_eq!(res.tip_block_hash, chain[chain_len as usize - 1].block_hash().to_vec());
+
+        for i in 1..chain_len {
+            let res = get_utxos(GetUtxosRequest {
+                address: ADDRESS.to_string(),
+                filter: Some(UtxosFilter::MinConfirmations(i)),
+            });
+
+            let block_depth = chain_len - i;
+
+            // For all the confirmations, we expect them to be the depth of the chain with the
+            // exception of the the height where the fork block is present. In that case, the
+            // tip height is expected to be the depth of the block - 1.
+            let expected_height = if block_depth == fork_height {
+                block_depth - 1
+            } else {
+                block_depth
+            };
+
+            assert_eq!(res.tip_height, expected_height);
+            assert_eq!(res.tip_block_hash, chain[expected_height as usize].block_hash().to_vec());
+        }
+    }
+}
+
+#[async_std::test]
+#[ignore] // TODO(EXC-1319): Enable this test.
+async fn multiple_forks() {
+    crate::init(crate::Config {
+        stability_threshold: 10,
+        network: Network::Regtest,
+        ..Default::default()
+    });
+
+    // Create a main chain that has two forks.
+    let a = BlockChainBuilder::new(7).build();
+    let b = BlockChainBuilder::fork(&a[1], 3).build();
+    let c = BlockChainBuilder::fork(&a[3], 2).build();
+
+    ingest_blocks(a.iter().chain(b.iter()).chain(c.iter()));
+
+    // The tip of the main chain should be the tip of the "a" chain (i.e. a[6])
+    let res = get_utxos(GetUtxosRequest {
+        address: ADDRESS.to_string(),
+        filter: None,
+    });
+
+    assert_eq!(res.tip_height, 6);
+    assert_eq!(res.tip_block_hash, a[6].block_hash().to_vec());
+
+    // With two confirmations the tip is expected to be a[3].
+    let res = get_utxos(GetUtxosRequest {
+        address: ADDRESS.to_string(),
+        filter: Some(UtxosFilter::MinConfirmations(2)),
+    });
+
+    assert_eq!(res.tip_height, 3);
+    assert_eq!(res.tip_block_hash, a[3].block_hash().to_vec());
+}
+
+fn ingest_blocks<'a>(blocks: impl Iterator<Item = &'a Block>) {
+    // Map the blocks into responses that are given to the hearbeat.
+    let responses: Vec<_> = blocks
+        .map(|block| {
+            let mut block_bytes = vec![];
+            Block::consensus_encode(block, &mut block_bytes).unwrap();
+            GetSuccessorsReply::Ok(GetSuccessorsResponse::Complete(
+                GetSuccessorsCompleteResponse {
+                    blocks: vec![block_bytes],
+                    next: vec![],
+                },
+            ))
+        })
+        .collect();
+
+    let responses_len = responses.len();
+
+    set_successors_responses(responses);
+
+    // Run the heartbeat until we process all the blocks.
+    loop {
+        block_on(async { heartbeat().await });
+
+        if crate::runtime::GET_SUCCESSORS_RESPONSES_INDEX.with(|i| *i.borrow()) > responses_len {
+            break;
+        }
+    }
+}


### PR DESCRIPTION
Adds unit tests for the upcoming changes where confirmation counts will be computed based on the stability count as opposed to the block depth.