### PR TITLE
chore: gzip canisters + minor enhancements

### DIFF
--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 
 [dependencies]
 bitcoin = {version = "0.28.1", features = ["use-serde"]}
-byteorder = "1.4.3"
 candid = "0.8.1"
 # NOTE: A specific commit of ciborium is used that includes efficient serializion/deserialization of
 #       blobs. At the time of this writing, a new version including this commit hasn't yet been released.
@@ -23,12 +22,13 @@ serde = "1.0.132"
 serde_bytes = "0.11"
 
 [[bin]]
-name = "bitcoin-canister"
+name = "ic-btc-canister"
 path = "src/main.rs"
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
 bitcoin = {version = "0.28.1", features = ["rand"]} # needed for generating secp256k1 keys.
+byteorder = "1.4.3"
 ic-btc-test-utils = { git = "https://github.com/dfinity/ic", rev = "c905ede6e62f167994de24c8ccf7ee37a4d8ac67" }
 maplit = "1.0.2"
 proptest = "0.9.4"

--- a/dfx.json
+++ b/dfx.json
@@ -4,8 +4,8 @@
     "bitcoin": {
       "type": "custom",
       "candid": "./canister/candid.did",
-      "wasm": "target/wasm32-unknown-unknown/release/bitcoin-canister.wasm",
-      "build": "./scripts/build-canister.sh bitcoin-canister"
+      "wasm": "target/wasm32-unknown-unknown/release/ic-btc-canister.wasm.gz",
+      "build": "./scripts/build-canister.sh ic-btc-canister"
     },
     "upgradablity-test": {
       "type": "custom",
@@ -16,27 +16,27 @@
       "type": "custom",
       "candid": "./e2e-tests/scenario-1/candid.did",
       "build": "./scripts/build-canister.sh scenario-1",
-      "wasm": "./target/wasm32-unknown-unknown/release/scenario-1.wasm"
+      "wasm": "./target/wasm32-unknown-unknown/release/scenario-1.wasm.gz"
     },
     "e2e-scenario-2": {
       "type": "custom",
       "candid": "./e2e-tests/scenario-2/candid.did",
       "build": "./scripts/build-canister.sh scenario-2",
       "package": "scenario-2",
-      "wasm": "./target/wasm32-unknown-unknown/release/scenario-2.wasm"
+      "wasm": "./target/wasm32-unknown-unknown/release/scenario-2.wasm.gz"
     },
     "e2e-scenario-3": {
       "type": "custom",
       "candid": "./e2e-tests/scenario-3/candid.did",
       "build": "./scripts/build-canister.sh scenario-3",
       "package": "scenario-3",
-      "wasm": "./target/wasm32-unknown-unknown/release/scenario-3.wasm"
+      "wasm": "./target/wasm32-unknown-unknown/release/scenario-3.wasm.gz"
     },
     "uploader": {
       "type": "custom",
       "candid": "./bootstrap/uploader/candid.did",
       "build": "./scripts/build-canister.sh uploader-canister",
-      "wasm": "./target/wasm32-unknown-unknown/release/uploader-canister.wasm"
+      "wasm": "./target/wasm32-unknown-unknown/release/uploader-canister.wasm.gz"
     }
   },
   "defaults": {

--- a/e2e-tests/profiling/scenario-1.txt
+++ b/e2e-tests/profiling/scenario-1.txt
@@ -1,11 +1,11 @@
 Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 34417, ins_remove_inputs: 1368, ins_insert_outputs: 30860, ins_txids: 788, ins_insert_utxos: 28965 }
 Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6455552582, ins_remove_inputs: 2736, ins_insert_outputs: 6455545694, ins_txids: 7940724, ins_insert_utxos: 6438754308 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16902342388, ins_remove_inputs: 10994860468, ins_insert_outputs: 5901212477, ins_txids: 10152524, ins_insert_utxos: 5879988221 }
-Ingest Block 3: BlockIngestionStats { num_rounds: 1, ins_total: 588918, ins_remove_inputs: 1368, ins_insert_outputs: 585361, ins_txids: 788, ins_insert_utxos: 583466 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 536619, ins_apply_unstable_blocks: 92341 }
-GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 442959, ins_apply_unstable_blocks: 47054 }
-GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 154555246, ins_apply_unstable_blocks: 34472614, ins_build_utxos_vec: 119460377 }
-GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 76466048, ins_apply_unstable_blocks: 71300707, ins_build_utxos_vec: 4534726 }
-GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 26541215, ins_apply_unstable_blocks: 26147091 }
-get_current_fee_percentiles: 38862558
-get_current_fee_percentiles: 291267
+Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16902342388, ins_remove_inputs: 10994860387, ins_insert_outputs: 5901212558, ins_txids: 10152524, ins_insert_utxos: 5879988302 }
+Ingest Block 3: BlockIngestionStats { num_rounds: 1, ins_total: 587495, ins_remove_inputs: 1368, ins_insert_outputs: 583938, ins_txids: 788, ins_insert_utxos: 582043 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 556296, ins_apply_unstable_blocks: 92385 }
+GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 445218, ins_apply_unstable_blocks: 47076 }
+GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 147845078, ins_apply_unstable_blocks: 34504900, ins_build_utxos_vec: 112710269 }
+GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 75972946, ins_apply_unstable_blocks: 71037498, ins_build_utxos_vec: 4303185 }
+GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 26542538, ins_apply_unstable_blocks: 26147135 }
+get_current_fee_percentiles: 38852426
+get_current_fee_percentiles: 291035

--- a/e2e-tests/profiling/scenario-2.txt
+++ b/e2e-tests/profiling/scenario-2.txt
@@ -2,5 +2,5 @@ Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 36610, ins_remov
 Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5237618420, ins_remove_inputs: 13681368, ins_insert_outputs: 5217673519, ins_txids: 8170886, ins_insert_utxos: 5198432200 }
 Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5809157217, ins_remove_inputs: 13681368, ins_insert_outputs: 5789212316, ins_txids: 8170886, ins_insert_utxos: 5769970997 }
 Ingest Block 3: BlockIngestionStats { num_rounds: 2, ins_total: 6067593952, ins_remove_inputs: 13681368, ins_insert_outputs: 6047649051, ins_txids: 8170886, ins_insert_utxos: 6028407732 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 26383066, ins_apply_unstable_blocks: 25931001 }
-GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 75359648, ins_apply_unstable_blocks: 69965170, ins_build_utxos_vec: 4747480 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 26383088, ins_apply_unstable_blocks: 25931001 }
+GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 75359364, ins_apply_unstable_blocks: 69965170, ins_build_utxos_vec: 4747480 }

--- a/scripts/build-canister.sh
+++ b/scripts/build-canister.sh
@@ -33,4 +33,6 @@ else
   false
 fi
 
+gzip -n -f "./target/$TARGET/release/$CANISTER.wasm"
+
 popd


### PR DESCRIPTION
* `build-canister.sh` now gzips all the canisters.
* The `byte_order` dependency is moved as a dev dependecy.
* The canister's binary is renamed to `ic-btc-canister`, which is more consistent with the naming of other canisters.