### PR TITLE
chore: make the network field in `UnstableBlocks` non-optional

### DIFF
--- a/canister/src/address_utxoset.rs
+++ b/canister/src/address_utxoset.rs
@@ -138,7 +138,7 @@ mod test {
             .with_transaction(coinbase_tx.clone())
             .build();
 
-        let unstable_blocks = UnstableBlocks::new(&utxo_set, 2, block_0.clone(), Some(network));
+        let unstable_blocks = UnstableBlocks::new(&utxo_set, 2, block_0.clone(), network);
 
         let mut address_utxo_set = AddressUtxoSet::new(address_1, &utxo_set, &unstable_blocks);
 
@@ -184,7 +184,7 @@ mod test {
             .with_transaction(tx.clone())
             .build();
 
-        let mut unstable_blocks = UnstableBlocks::new(&utxo_set, 2, block_0.clone(), Some(network));
+        let mut unstable_blocks = UnstableBlocks::new(&utxo_set, 2, block_0.clone(), network);
         unstable_blocks::push(&mut unstable_blocks, &utxo_set, block_1.clone()).unwrap();
 
         let mut address_utxo_set = AddressUtxoSet::new(address_1, &utxo_set, &unstable_blocks);
@@ -241,7 +241,7 @@ mod test {
 
         // Process the blocks.
         let utxo_set = UtxoSet::new(Network::Mainnet);
-        let mut unstable_blocks = UnstableBlocks::new(&utxo_set, 2, block_0.clone(), Some(network));
+        let mut unstable_blocks = UnstableBlocks::new(&utxo_set, 2, block_0.clone(), network);
         unstable_blocks::push(&mut unstable_blocks, &utxo_set, block_1.clone()).unwrap();
 
         let mut address_1_utxo_set = AddressUtxoSet::new(address_1, &utxo_set, &unstable_blocks);

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -144,12 +144,7 @@ pub fn post_upgrade() {
     memory.read(4, &mut state_bytes);
 
     // Deserialize and set the state.
-    let mut state: State =
-        ciborium::de::from_reader(&*state_bytes).expect("failed to decode state");
-
-    // TODO(EXC-1310): to be removed after upgrade
-    let network = state.network();
-    state.unstable_blocks = state.unstable_blocks.with_network(network);
+    let state: State = ciborium::de::from_reader(&*state_bytes).expect("failed to decode state");
 
     set_state(state);
 }

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -60,7 +60,7 @@ impl State {
     pub fn new(stability_threshold: u32, network: Network, genesis_block: Block) -> Self {
         let utxos = UtxoSet::new(network);
         let unstable_blocks =
-            UnstableBlocks::new(&utxos, stability_threshold, genesis_block, Some(network));
+            UnstableBlocks::new(&utxos, stability_threshold, genesis_block, network);
 
         Self {
             utxos,

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -18,16 +18,11 @@ pub struct UnstableBlocks {
     stability_threshold: u32,
     tree: BlockTree,
     outpoints_cache: OutPointsCache,
-    network: Option<Network>, // EXC-1310
+    network: Network,
 }
 
 impl UnstableBlocks {
-    pub fn new(
-        utxos: &UtxoSet,
-        stability_threshold: u32,
-        anchor: Block,
-        network: Option<Network>, // TODO(EXC-1310): Optional just for the upgrade, will be refactored after.
-    ) -> Self {
+    pub fn new(utxos: &UtxoSet, stability_threshold: u32, anchor: Block, network: Network) -> Self {
         // Create a cache of the transaction outputs, starting with the given anchor block.
         let mut outpoints_cache = OutPointsCache::new();
         outpoints_cache
@@ -67,14 +62,8 @@ impl UnstableBlocks {
         self.stability_threshold = stability_threshold;
     }
 
-    fn get_network(&self) -> Option<Network> {
+    fn get_network(&self) -> Network {
         self.network
-    }
-
-    // TODO(EXC-1310): temporary method will be removed after an upgrade.
-    pub fn with_network(mut self, network: Network) -> UnstableBlocks {
-        self.network = Some(network);
-        self
     }
 }
 
@@ -188,7 +177,7 @@ pub fn get_chain_with_tip<'a, 'b>(
 // Returns the index of the `anchor`'s stable child if it exists.
 fn get_stable_child(blocks: &UnstableBlocks) -> Option<usize> {
     // Compute the difficulty based depth of all the children.
-    let network = blocks.get_network().expect("Network should be defined."); // TODO(EXC-1310)
+    let network = blocks.get_network();
 
     let mut depths: Vec<_> = blocks
         .tree
@@ -243,7 +232,7 @@ mod test {
         let anchor = BlockBuilder::genesis().build();
         let network = Network::Mainnet;
         let utxos = UtxoSet::new(network);
-        let mut forest = UnstableBlocks::new(&utxos, 1, anchor, Some(network));
+        let mut forest = UnstableBlocks::new(&utxos, 1, anchor, network);
         assert_eq!(peek(&forest), None);
         assert_eq!(pop(&mut forest), None);
     }
@@ -255,7 +244,7 @@ mod test {
         let block_2 = BlockBuilder::with_prev_header(block_1.header()).build();
         let network = Network::Regtest;
         let utxos = UtxoSet::new(network);
-        let mut forest = UnstableBlocks::new(&utxos, 2, block_0.clone(), Some(network));
+        let mut forest = UnstableBlocks::new(&utxos, 2, block_0.clone(), network);
 
         push(&mut forest, &utxos, block_1).unwrap();
         assert_eq!(peek(&forest), None);
@@ -286,7 +275,7 @@ mod test {
 
         let network = Network::Mainnet;
         let utxos = UtxoSet::new(network);
-        let mut forest = UnstableBlocks::new(&utxos, 7, block_0.clone(), Some(network));
+        let mut forest = UnstableBlocks::new(&utxos, 7, block_0.clone(), network);
 
         push(&mut forest, &utxos, block_1.clone()).unwrap();
         push(&mut forest, &utxos, block_2).unwrap();
@@ -325,7 +314,7 @@ mod test {
 
         let network = Network::Regtest;
         let utxos = UtxoSet::new(network);
-        let mut forest = UnstableBlocks::new(&utxos, 2, genesis_block.clone(), Some(network));
+        let mut forest = UnstableBlocks::new(&utxos, 2, genesis_block.clone(), network);
 
         push(&mut forest, &utxos, block).unwrap();
         push(&mut forest, &utxos, forked_block.clone()).unwrap();
@@ -372,7 +361,7 @@ mod test {
 
         let network = Network::Mainnet;
         let utxos = UtxoSet::new(network);
-        let mut forest = UnstableBlocks::new(&utxos, 3, genesis_block.clone(), Some(network));
+        let mut forest = UnstableBlocks::new(&utxos, 3, genesis_block.clone(), network);
 
         push(&mut forest, &utxos, fork1_block.clone()).unwrap();
         push(&mut forest, &utxos, fork2_block.clone()).unwrap();
@@ -468,7 +457,7 @@ mod test {
 
         let network = Network::Mainnet;
         let utxos = UtxoSet::new(network);
-        let mut forest = UnstableBlocks::new(&utxos, 0, block_0.clone(), Some(network));
+        let mut forest = UnstableBlocks::new(&utxos, 0, block_0.clone(), network);
         push(&mut forest, &utxos, block_1.clone()).unwrap();
         push(&mut forest, &utxos, block_2).unwrap();
 
@@ -493,7 +482,7 @@ mod test {
 
         let network = Network::Mainnet;
         let utxos = UtxoSet::new(network);
-        let mut forest = UnstableBlocks::new(&utxos, 1, block_0.clone(), Some(network));
+        let mut forest = UnstableBlocks::new(&utxos, 1, block_0.clone(), network);
 
         push(&mut forest, &utxos, block_1.clone()).unwrap();
         push(&mut forest, &utxos, block_2.clone()).unwrap();
@@ -517,7 +506,7 @@ mod test {
 
         let network = Network::Mainnet;
         let utxos = UtxoSet::new(network);
-        let mut forest = UnstableBlocks::new(&utxos, 1, block_0.clone(), Some(network));
+        let mut forest = UnstableBlocks::new(&utxos, 1, block_0.clone(), network);
 
         push(&mut forest, &utxos, block_1).unwrap();
         push(&mut forest, &utxos, block_2).unwrap();
@@ -539,7 +528,7 @@ mod test {
 
         let network = Network::Mainnet;
         let utxos = UtxoSet::new(network);
-        let mut forest = UnstableBlocks::new(&utxos, 1, block_0.clone(), Some(network));
+        let mut forest = UnstableBlocks::new(&utxos, 1, block_0.clone(), network);
 
         push(&mut forest, &utxos, block_1).unwrap();
         push(&mut forest, &utxos, block_2.clone()).unwrap();
@@ -568,7 +557,7 @@ mod test {
 
         let network = Network::Mainnet;
         let utxos = UtxoSet::new(network);
-        let mut forest = UnstableBlocks::new(&utxos, 1, block_0.clone(), Some(network));
+        let mut forest = UnstableBlocks::new(&utxos, 1, block_0.clone(), network);
 
         push(&mut forest, &utxos, block_1.clone()).unwrap();
         push(&mut forest, &utxos, block_2).unwrap();
@@ -606,7 +595,7 @@ mod test {
 
         let network = Network::Mainnet;
         let utxos = UtxoSet::new(network);
-        let mut forest = UnstableBlocks::new(&utxos, 1, block_0.clone(), Some(network));
+        let mut forest = UnstableBlocks::new(&utxos, 1, block_0.clone(), network);
 
         push(&mut forest, &utxos, block_x).unwrap();
         push(&mut forest, &utxos, block_y).unwrap();
@@ -644,7 +633,7 @@ mod test {
 
         let network = Network::Mainnet;
         let utxos = UtxoSet::new(network);
-        let mut forest = UnstableBlocks::new(&utxos, 1, block_0.clone(), Some(network));
+        let mut forest = UnstableBlocks::new(&utxos, 1, block_0.clone(), network);
 
         push(&mut forest, &utxos, block_1).unwrap();
         push(&mut forest, &utxos, block_2).unwrap();
@@ -662,7 +651,7 @@ mod test {
         let block_0 = BlockBuilder::genesis().build();
         let network = Network::Mainnet;
         let utxos = UtxoSet::new(network);
-        let forest = UnstableBlocks::new(&utxos, 1, block_0.clone(), Some(network));
+        let forest = UnstableBlocks::new(&utxos, 1, block_0.clone(), network);
 
         assert_eq!(get_main_chain(&forest), BlockChain::new(&block_0));
     }

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -638,8 +638,7 @@ mod test {
             .build();
         ingest_tx(&mut utxo, &coinbase_tx);
 
-        let unstable_blocks =
-            UnstableBlocks::new(&utxo, 2, crate::genesis_block(network), Some(network));
+        let unstable_blocks = UnstableBlocks::new(&utxo, 2, crate::genesis_block(network), network);
 
         let expected = vec![Utxo {
             outpoint: OutPoint {


### PR DESCRIPTION
After the latest release, the `network` field in `UnstableBlocks` no longer needs to be optional.

Closes [EXC-1310](https://dfinity.atlassian.net/browse/EXC-1310).