### PR TITLE
feat: Add metric to track block ingestion instruction counts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,6 +1216,7 @@ dependencies = [
  "ic-btc-validation",
  "ic-cdk 0.6.7",
  "ic-cdk-macros 0.6.7",
+ "ic-metrics-encoder",
  "ic-stable-structures",
  "lazy_static",
  "maplit",
@@ -1304,6 +1305,12 @@ dependencies = [
  "serde_tokenstream",
  "syn",
 ]
+
+[[package]]
+name = "ic-metrics-encoder"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aef00d455eba8b8244a415f073a43042e57da6d09c294485a2b2ebc858c9da2"
 
 [[package]]
 name = "ic-stable-structures"

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -16,6 +16,7 @@ ic-btc-types = { git = "https://github.com/dfinity/ic", rev = "c905ede6e62f16799
 ic-btc-validation = { path = "../validation" }
 ic-cdk = "0.6.1"
 ic-cdk-macros = "0.6.1"
+ic-metrics-encoder = "1.0.0"
 ic-stable-structures = "0.3.0"
 lazy_static = "1.4.0"
 serde = "1.0.132"

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -98,6 +98,12 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         )?;
 
         w.encode_gauge(
+            "total_block_ingestion_instruction_count",
+            state.metrics.total_block_ingestion_instruction_count as f64,
+            "The total number of instructions spent ingesting new Bitcoin blocks",
+        )?;
+
+        w.encode_gauge(
             "cycles_balance",
             ic_cdk::api::canister_balance() as f64,
             "The cycles balance of the canister.",

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -102,7 +102,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             "The total number of (valid) requests to the send_transaction endpoint.",
         )?;
 
-        w.encode_labeled_counter(&state.metrics.ingest_block_instruction_count)?;
+        w.encode_labeled_counter(&state.metrics.ingest_block_instructions_count)?;
 
         w.encode_gauge(
             "cycles_balance",
@@ -217,6 +217,7 @@ impl<W: io::Write> MetricsEncoder<W> {
         self.encode_histogram(&h.name, h.buckets(), h.sum, &h.help)
     }
 
+    /// Encodes a `LabeledCounter`.
     pub fn encode_labeled_counter(&mut self, c: &LabeledCounter) -> io::Result<()> {
         for (k, v) in &c.values_by_labels {
             self.encode_value_with_labels(c.name.as_str(), &[("type", k)], *v)?;

--- a/canister/src/metrics.rs
+++ b/canister/src/metrics.rs
@@ -24,7 +24,7 @@ pub struct Metrics {
     pub send_transaction_count: u64,
 
     // The number of instructions spent ingesting new Bitcoin blocks by type.
-    pub ingest_block_instruction_count: LabeledCounter,
+    pub ingest_block_instructions_count: LabeledCounter,
 }
 
 impl Default for Metrics {
@@ -59,8 +59,8 @@ impl Default for Metrics {
 
             send_transaction_count: 0,
 
-            ingest_block_instruction_count: LabeledCounter::new(
-                "ingest_block_instruction_count",
+            ingest_block_instructions_count: LabeledCounter::new(
+                "ingest_block_instructions_count",
                 "The number of instructions spent ingesting new Bitcoin blocks by type.",
                 BlockIngestionStats::get_all_labels(),
             ),

--- a/canister/src/metrics.rs
+++ b/canister/src/metrics.rs
@@ -1,4 +1,8 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
+
+use crate::utxo_set::BlockIngestionStats;
 
 const M: u64 = 1_000_000;
 const BUCKET_SIZE: u64 = 500 * M;
@@ -19,8 +23,8 @@ pub struct Metrics {
     /// The total number of (valid) requests sent to `send_transaction`.
     pub send_transaction_count: u64,
 
-    // The total number of instructions spent ingesting new Bitcoin blocks.
-    pub total_block_ingestion_instruction_count: u64,
+    // The number of instructions spent ingesting new Bitcoin blocks by type.
+    pub ingest_block_instruction_count: LabeledCounter,
 }
 
 impl Default for Metrics {
@@ -55,7 +59,45 @@ impl Default for Metrics {
 
             send_transaction_count: 0,
 
-            total_block_ingestion_instruction_count: 0,
+            ingest_block_instruction_count: LabeledCounter::new(
+                "ingest_block_instruction_count",
+                "The number of instructions spent ingesting new Bitcoin blocks by type.",
+                BlockIngestionStats::get_all_labels(),
+            ),
+        }
+    }
+}
+
+/// A counter with labels for observing instruction counts.
+#[derive(Serialize, Deserialize, PartialEq)]
+pub struct LabeledCounter {
+    pub name: String,
+    pub values_by_labels: HashMap<String, u64>,
+    pub help: String,
+}
+
+impl LabeledCounter {
+    pub fn new<S: Into<String>>(name: S, help: S, all_labels: Vec<String>) -> Self {
+        Self {
+            name: name.into(),
+            help: help.into(),
+            values_by_labels: {
+                let mut map = HashMap::new();
+                for ty in all_labels {
+                    map.insert(ty, 0u64);
+                }
+                map
+            },
+        }
+    }
+
+    pub fn get_value_with_label(&self, label: String) -> &u64 {
+        self.values_by_labels.get(&label).unwrap()
+    }
+
+    pub fn observe(&mut self, values_with_labels: &[(String, u64)]) {
+        for (label, val) in values_with_labels.iter() {
+            *self.values_by_labels.get_mut(label).unwrap() += *val;
         }
     }
 }

--- a/canister/src/metrics.rs
+++ b/canister/src/metrics.rs
@@ -91,8 +91,8 @@ impl LabeledCounter {
         }
     }
 
-    pub fn get_value_with_label(&self, label: String) -> &u64 {
-        self.values_by_labels.get(&label).unwrap()
+    pub fn get_value_with_label(&self, label: &str) -> &u64 {
+        self.values_by_labels.get(label).unwrap()
     }
 
     pub fn observe(&mut self, values_with_labels: &[(String, u64)]) {

--- a/canister/src/metrics.rs
+++ b/canister/src/metrics.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
 use crate::utxo_set::BlockIngestionStats;
@@ -23,8 +21,8 @@ pub struct Metrics {
     /// The total number of (valid) requests sent to `send_transaction`.
     pub send_transaction_count: u64,
 
-    // The number of instructions spent ingesting new Bitcoin blocks by type.
-    pub ingest_block_instructions_count: LabeledCounter,
+    /// The stats of the most recent block ingestion.
+    pub block_ingestion_stats: BlockIngestionStats,
 }
 
 impl Default for Metrics {
@@ -59,45 +57,7 @@ impl Default for Metrics {
 
             send_transaction_count: 0,
 
-            ingest_block_instructions_count: LabeledCounter::new(
-                "ingest_block_instructions_count",
-                "The number of instructions spent ingesting new Bitcoin blocks by type.",
-                BlockIngestionStats::get_all_labels(),
-            ),
-        }
-    }
-}
-
-/// A counter with labels for observing instruction counts.
-#[derive(Serialize, Deserialize, PartialEq)]
-pub struct LabeledCounter {
-    pub name: String,
-    pub values_by_labels: HashMap<String, u64>,
-    pub help: String,
-}
-
-impl LabeledCounter {
-    pub fn new<S: Into<String>>(name: S, help: S, all_labels: Vec<String>) -> Self {
-        Self {
-            name: name.into(),
-            help: help.into(),
-            values_by_labels: {
-                let mut map = HashMap::new();
-                for ty in all_labels {
-                    map.insert(ty, 0u64);
-                }
-                map
-            },
-        }
-    }
-
-    pub fn get_value_with_label(&self, label: &str) -> &u64 {
-        self.values_by_labels.get(label).unwrap()
-    }
-
-    pub fn observe(&mut self, values_with_labels: &[(String, u64)]) {
-        for (label, val) in values_with_labels.iter() {
-            *self.values_by_labels.get_mut(label).unwrap() += *val;
+            block_ingestion_stats: BlockIngestionStats::default(),
         }
     }
 }

--- a/canister/src/metrics.rs
+++ b/canister/src/metrics.rs
@@ -18,6 +18,9 @@ pub struct Metrics {
 
     /// The total number of (valid) requests sent to `send_transaction`.
     pub send_transaction_count: u64,
+
+    // The total number of instructions spent ingesting new Bitcoin blocks.
+    pub total_block_ingestion_instruction_count: u64,
 }
 
 impl Default for Metrics {
@@ -51,6 +54,8 @@ impl Default for Metrics {
             ),
 
             send_transaction_count: 0,
+
+            total_block_ingestion_instruction_count: 0,
         }
     }
 }

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -280,16 +280,16 @@ mod test {
 
             set_performance_counter_step(1000);
 
-            let ins_total_before = *state.metrics.ingest_block_instructions_count.get_value_with_label(String::from("ins_total"));
-            let ins_insert_outputs_before = *state.metrics.ingest_block_instructions_count.get_value_with_label(String::from("ins_insert_outputs"));
+            let ins_total_before = *state.metrics.ingest_block_instructions_count.get_value_with_label("ins_total");
+            let ins_insert_outputs_before = *state.metrics.ingest_block_instructions_count.get_value_with_label("ins_insert_outputs");
 
             for block in blocks[1..].iter() {
                 insert_block(&mut state, block.clone()).unwrap();
                 ingest_stable_blocks_into_utxoset(&mut state);
             }
 
-            let ins_total_after = *state.metrics.ingest_block_instructions_count.get_value_with_label(String::from("ins_total"));
-            let ins_insert_outputs_after = *state.metrics.ingest_block_instructions_count.get_value_with_label(String::from("ins_insert_outputs"));
+            let ins_total_after = *state.metrics.ingest_block_instructions_count.get_value_with_label("ins_total");
+            let ins_insert_outputs_after = *state.metrics.ingest_block_instructions_count.get_value_with_label("ins_insert_outputs");
 
             assert_eq!(ins_total_after - ins_total_before, if num_blocks > stability_threshold{
                 // total number of instructions should be
@@ -303,9 +303,9 @@ mod test {
             // We have only output transactions, hence 'ins_insert_outputs' should be equal to 'ins_total'.
             assert_eq!(ins_total_after - ins_total_before, ins_insert_outputs_after - ins_insert_outputs_before);
             // While all others should be 0.
-            assert_eq!(*state.metrics.ingest_block_instructions_count.get_value_with_label(String::from("ins_remove_inputs")), 0);
-            assert_eq!(*state.metrics.ingest_block_instructions_count.get_value_with_label(String::from("ins_txids")), 0);
-            assert_eq!(*state.metrics.ingest_block_instructions_count.get_value_with_label(String::from("ins_insert_utxos")), 0);
+            assert_eq!(*state.metrics.ingest_block_instructions_count.get_value_with_label("ins_remove_inputs"), 0);
+            assert_eq!(*state.metrics.ingest_block_instructions_count.get_value_with_label("ins_txids"), 0);
+            assert_eq!(*state.metrics.ingest_block_instructions_count.get_value_with_label("ins_insert_utxos"), 0);
 
             let mut bytes = vec![];
             ciborium::ser::into_writer(&state, &mut bytes).unwrap();

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -135,7 +135,7 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
         Some(Slicing::Done((ingested_block_hash, stats))) => {
             state
                 .metrics
-                .ingest_block_instruction_count
+                .ingest_block_instructions_count
                 .observe(&stats.get_labels_and_values());
             pop_block(state, ingested_block_hash)
         }
@@ -153,7 +153,7 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
             Slicing::Done((ingested_block_hash, stats)) => {
                 state
                     .metrics
-                    .ingest_block_instruction_count
+                    .ingest_block_instructions_count
                     .observe(&stats.get_labels_and_values());
 
                 pop_block(state, ingested_block_hash)
@@ -278,12 +278,12 @@ mod test {
 
             let mut state = State::new(stability_threshold, network, blocks[0].clone());
             set_performance_counter_step(1000);
-            let ins_before = *state.metrics.ingest_block_instruction_count.get_value_with_label(String::from("ins_total"));
+            let ins_before = *state.metrics.ingest_block_instructions_count.get_value_with_label(String::from("ins_total"));
             for block in blocks[1..].iter() {
                 insert_block(&mut state, block.clone()).unwrap();
                 ingest_stable_blocks_into_utxoset(&mut state);
             }
-            let ins_after = *state.metrics.ingest_block_instruction_count.get_value_with_label(String::from("ins_total"));
+            let ins_after = *state.metrics.ingest_block_instructions_count.get_value_with_label(String::from("ins_total"));
 
             assert_eq!(ins_after - ins_before, if num_blocks > stability_threshold{
                 // total number of instructions should be

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -132,7 +132,10 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
     match state.utxos.ingest_block_continue() {
         None => {}
         Some(Slicing::Paused(())) => return has_state_changed(state),
-        Some(Slicing::Done(ingested_block_hash)) => pop_block(state, ingested_block_hash),
+        Some(Slicing::Done((ingested_block_hash, instructions))) => {
+            state.metrics.total_block_ingestion_instruction_count += instructions.instructions_used;
+            pop_block(state, ingested_block_hash)
+        }
     }
 
     // Check if there are any stable blocks and ingest those into the UTXO set.
@@ -144,7 +147,11 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
 
         match state.utxos.ingest_block(new_stable_block.clone()) {
             Slicing::Paused(()) => return has_state_changed(state),
-            Slicing::Done(ingested_block_hash) => pop_block(state, ingested_block_hash),
+            Slicing::Done((ingested_block_hash, instructions)) => {
+                state.metrics.total_block_ingestion_instruction_count +=
+                    instructions.instructions_used;
+                pop_block(state, ingested_block_hash)
+            }
         }
     }
 

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -286,4 +286,49 @@ mod test {
             assert!(state == new_state);
         }
     }
+
+    #[test]
+    fn block_ingestion_stats_are_updated() {
+        let stability_threshold = 0;
+        let num_blocks = 3;
+        let num_transactions_per_block = 10;
+        let network = Network::Regtest;
+        let blocks = build_chain(network, num_blocks, num_transactions_per_block);
+
+        let mut state = State::new(stability_threshold, network, blocks[0].clone());
+
+        assert_eq!(state.stable_height(), 0);
+        insert_block(&mut state, blocks[1].clone()).unwrap();
+
+        // The genesis block is now stable. Ingest it.
+        let metrics_before = state.metrics.block_ingestion_stats.clone();
+        ingest_stable_blocks_into_utxoset(&mut state);
+        assert_eq!(state.stable_height(), 1);
+        
+        // Verify that the stats have been updated.
+        assert_ne!(metrics_before, state.metrics.block_ingestion_stats);
+
+        // Ingest the next block. This time, the performance counter is set so that
+        // the ingestion is time-sliced.
+        crate::runtime::set_performance_counter_step(1_000_000_000);
+
+        insert_block(&mut state, blocks[2].clone()).unwrap();
+        let metrics_before = state.metrics.block_ingestion_stats.clone();
+        let mut num_rounds = 0;
+        while state.stable_height() == 1 {
+            assert_eq!(metrics_before, state.metrics.block_ingestion_stats);
+            ingest_stable_blocks_into_utxoset(&mut state);
+            crate::runtime::performance_counter_reset();
+            num_rounds += 1;
+        }
+
+        // Assert that the block has been ingested.
+        assert_eq!(state.stable_height(), 2);
+
+        // Assert that the block ingestion has been time-sliced.
+        assert!(num_rounds > 1);
+
+        // Assert the stats have been updated.
+        assert_ne!(metrics_before, state.metrics.block_ingestion_stats);
+    }
 }

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -304,7 +304,7 @@ mod test {
         let metrics_before = state.metrics.block_ingestion_stats.clone();
         ingest_stable_blocks_into_utxoset(&mut state);
         assert_eq!(state.stable_height(), 1);
-        
+
         // Verify that the stats have been updated.
         assert_ne!(metrics_before, state.metrics.block_ingestion_stats);
 

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -257,7 +257,7 @@ pub struct FeePercentilesCache {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{runtime::set_performance_counter_step, test_utils::build_chain};
+    use crate::test_utils::build_chain;
     use proptest::prelude::*;
 
     proptest! {

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -519,8 +519,14 @@ impl BlockIngestionStats {
     pub fn get_labels_and_values(&self) -> Vec<((&str, &str), u64)> {
         vec![
             (("instruction_count", "total"), self.ins_total),
-            (("instruction_count", "remove_inputs"), self.ins_remove_inputs),
-            (("instruction_count", "insert_outputs"), self.ins_insert_outputs),
+            (
+                ("instruction_count", "remove_inputs"),
+                self.ins_remove_inputs,
+            ),
+            (
+                ("instruction_count", "insert_outputs"),
+                self.ins_insert_outputs,
+            ),
             (("instruction_count", "txids"), self.ins_txids),
             (("instruction_count", "insert_utxos"), self.ins_insert_utxos),
         ]

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -640,6 +640,10 @@ mod test {
                     assert_eq!(hash, block.block_hash());
                     // Cost of inserting one output (1000)
                     assert_eq!(stats.ins_total, 1000);
+                    assert_eq!(stats.ins_insert_outputs, 1000);
+                    assert_eq!(stats.ins_insert_utxos, 0);
+                    assert_eq!(stats.ins_remove_inputs, 0);
+                    assert_eq!(stats.ins_txids, 0);
                 }
                 _ => panic!("Unexpected result."),
             }
@@ -878,6 +882,10 @@ mod test {
                 assert_eq!(hash, block.block_hash());
                 // 2 * cost of removing input (1000) + 3 * cost of inserting output (1000) = 5000
                 assert_eq!(stats.ins_total, 5000);
+                assert_eq!(stats.ins_remove_inputs, 2000);
+                assert_eq!(stats.ins_insert_outputs, 3000);
+                assert_eq!(stats.ins_insert_utxos, 0);
+                assert_eq!(stats.ins_txids, 0);
             }
             _ => panic!("Unexpected result."),
         }
@@ -964,6 +972,10 @@ mod test {
                     assert_eq!(hash, block_0.block_hash());
                     // tx_cardinality * cost of inserting output (1000)
                     assert_eq!(stats.ins_total, 1000 * tx_cardinality);
+                    assert_eq!(stats.ins_remove_inputs, 0);
+                    assert_eq!(stats.ins_insert_outputs, 1000 * tx_cardinality);
+                    assert_eq!(stats.ins_insert_utxos, 0);
+                    assert_eq!(stats.ins_txids, 0);
                 }
                 _ => panic!("Unexpected result.")
             }

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -58,12 +58,6 @@ pub struct UtxoSet {
     pub ingesting_block: Option<IngestingBlock>,
 }
 
-#[derive(PartialEq)]
-pub struct IngestionInstructionsCount {
-    // The number of instructions used to ingest block.
-    pub instructions_used: u64,
-}
-
 impl UtxoSet {
     pub fn new(network: Network) -> Self {
         Self {

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -97,9 +97,9 @@ impl UtxoSet {
     /// Continue ingesting a block.
     /// Returns:
     ///   * `None` if there was no block to continue ingesting.
-    ///   * `Slicing::Done(block_hash, ingestion_instructions_count)` if the partially ingested
+    ///   * `Slicing::Done(block_hash, ingestion_stats)` if the partially ingested
     ///      block is now fully ingested, where `block_hash` is the hash of the ingested block,
-    ///      and ingestion_instructions_count is the number of instructions used to ingest block.
+    ///      while 'ingestion_stats' is the number of instructions used to ingest block by type.
     ///   * `Slicing::Paused(())` if the block continued to be ingested, but is time-sliced.
     pub fn ingest_block_continue(
         &mut self,

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -516,23 +516,13 @@ pub struct BlockIngestionStats {
 }
 
 impl BlockIngestionStats {
-    pub fn get_all_labels() -> Vec<String> {
+    pub fn get_labels_and_values(&self) -> Vec<((&str, &str), u64)> {
         vec![
-            String::from("ins_total"),
-            String::from("ins_remove_inputs"),
-            String::from("ins_insert_outputs"),
-            String::from("ins_txids"),
-            String::from("ins_insert_utxos"),
-        ]
-    }
-
-    pub fn get_labels_and_values(&self) -> Vec<(String, u64)> {
-        vec![
-            (String::from("ins_total"), self.ins_total),
-            (String::from("ins_remove_inputs"), self.ins_remove_inputs),
-            (String::from("ins_insert_outputs"), self.ins_insert_outputs),
-            (String::from("ins_txids"), self.ins_txids),
-            (String::from("ins_insert_utxos"), self.ins_insert_utxos),
+            (("instruction_count", "total"), self.ins_total),
+            (("instruction_count", "remove_inputs"), self.ins_remove_inputs),
+            (("instruction_count", "insert_outputs"), self.ins_insert_outputs),
+            (("instruction_count", "txids"), self.ins_txids),
+            (("instruction_count", "insert_utxos"), self.ins_insert_utxos),
         ]
     }
 }

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -157,7 +157,6 @@ impl UtxoSet {
         }
 
         stats.ins_total += performance_counter() - ins_start;
-
         print(&format!(
             "[INSTRUCTION COUNT] Ingest Block {}: {:?}",
             self.next_height, stats

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -912,7 +912,7 @@ mod test {
             .build();
 
         runtime::set_performance_counter_step(1000);
-        match utxo_set.ingest_block(block.clone()) {
+        match utxo_set.ingest_block(block) {
             Slicing::Done((_, stats)) => {
                 // 2 * cost of removing input (1000) + 3 * cost of inserting output (1000) = 5000
                 assert_eq!(stats.ins_total, 5000);

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -99,7 +99,7 @@ impl UtxoSet {
     ///   * `None` if there was no block to continue ingesting.
     ///   * `Slicing::Done(block_hash, ingestion_instructions_count)` if the partially ingested
     ///      block is now fully ingested, where `block_hash` is the hash of the ingested block,
-    ///      and ingestion_instructions_count is the total number of instructions used to ingest block.
+    ///      and ingestion_instructions_count is the number of instructions used to ingest block.
     ///   * `Slicing::Paused(())` if the block continued to be ingested, but is time-sliced.
     pub fn ingest_block_continue(
         &mut self,

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -862,7 +862,7 @@ mod test {
         match utxo_set.ingest_block(block.clone()) {
             Slicing::Done((hash, instructions)) => {
                 assert_eq!(hash, block.block_hash());
-                // 2 * remove inputs (1000) + 3 * insert outputs (1000) = 5000
+                // 2 * cost of removing input (1000) + 3 * cost of inserting output (1000) = 5000
                 assert_eq!(instructions.instructions_used, 5000);
             }
             _ => panic!("Unexpected result."),

--- a/e2e-tests/profiling/scenario-1.txt
+++ b/e2e-tests/profiling/scenario-1.txt
@@ -1,11 +1,11 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 33087, ins_remove_inputs: 1368, ins_insert_outputs: 29530, ins_txids: 788, ins_insert_utxos: 27635 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6372507580, ins_remove_inputs: 2736, ins_insert_outputs: 6372500692, ins_txids: 7938564, ins_insert_utxos: 6355711466 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16644309377, ins_remove_inputs: 10827662452, ins_insert_outputs: 5810377482, ins_txids: 10174260, ins_insert_utxos: 5789131490 }
-Ingest Block 3: BlockIngestionStats { num_rounds: 1, ins_total: 575907, ins_remove_inputs: 1368, ins_insert_outputs: 572350, ins_txids: 788, ins_insert_utxos: 570455 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 554868, ins_apply_unstable_blocks: 92385 }
-GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 443781, ins_apply_unstable_blocks: 47076 }
-GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 152026926, ins_apply_unstable_blocks: 34569176, ins_build_utxos_vec: 116829847 }
-GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 76529781, ins_apply_unstable_blocks: 71378430, ins_build_utxos_vec: 4518839 }
-GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 26541104, ins_apply_unstable_blocks: 26147135 }
-get_current_fee_percentiles: 38862221
-get_current_fee_percentiles: 290595
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 33354, ins_remove_inputs: 1371, ins_insert_outputs: 29530, ins_txids: 788, ins_insert_utxos: 27635 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6381101532, ins_remove_inputs: 2742, ins_insert_outputs: 6381094242, ins_txids: 7943927, ins_insert_utxos: 6364299653 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16645660049, ins_remove_inputs: 10827692410, ins_insert_outputs: 5810377536, ins_txids: 10174260, ins_insert_utxos: 5789131544 }
+Ingest Block 3: BlockIngestionStats { num_rounds: 1, ins_total: 582574, ins_remove_inputs: 1371, ins_insert_outputs: 578750, ins_txids: 788, ins_insert_utxos: 576855 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 539047, ins_apply_unstable_blocks: 92381 }
+GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 443744, ins_apply_unstable_blocks: 47074 }
+GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 152421662, ins_apply_unstable_blocks: 34592333, ins_build_utxos_vec: 117183544 }
+GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 75980339, ins_apply_unstable_blocks: 71059797, ins_build_utxos_vec: 4288476 }
+GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 26541718, ins_apply_unstable_blocks: 26147121 }
+get_current_fee_percentiles: 38887455
+get_current_fee_percentiles: 292879

--- a/e2e-tests/profiling/scenario-1.txt
+++ b/e2e-tests/profiling/scenario-1.txt
@@ -6,6 +6,6 @@ GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min
 GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 443744, ins_apply_unstable_blocks: 47074 }
 GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 152421662, ins_apply_unstable_blocks: 34592333, ins_build_utxos_vec: 117183544 }
 GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 75980339, ins_apply_unstable_blocks: 71059797, ins_build_utxos_vec: 4288476 }
-GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 26541718, ins_apply_unstable_blocks: 26147121 }
+GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 26541866, ins_apply_unstable_blocks: 26147121 }
 get_current_fee_percentiles: 38887455
 get_current_fee_percentiles: 292879

--- a/e2e-tests/profiling/scenario-1.txt
+++ b/e2e-tests/profiling/scenario-1.txt
@@ -1,11 +1,11 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 34417, ins_remove_inputs: 1368, ins_insert_outputs: 30860, ins_txids: 788, ins_insert_utxos: 28965 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6455552582, ins_remove_inputs: 2736, ins_insert_outputs: 6455545694, ins_txids: 7940724, ins_insert_utxos: 6438754308 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16902342433, ins_remove_inputs: 10994860513, ins_insert_outputs: 5901212477, ins_txids: 10152524, ins_insert_utxos: 5879988221 }
-Ingest Block 3: BlockIngestionStats { num_rounds: 1, ins_total: 590131, ins_remove_inputs: 1368, ins_insert_outputs: 586574, ins_txids: 788, ins_insert_utxos: 584679 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 544190, ins_apply_unstable_blocks: 92385 }
-GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 449116, ins_apply_unstable_blocks: 47076 }
-GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 153175683, ins_apply_unstable_blocks: 34491775, ins_build_utxos_vec: 118046803 }
-GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 76376907, ins_apply_unstable_blocks: 71258285, ins_build_utxos_vec: 4488971 }
-GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 26544367, ins_apply_unstable_blocks: 26147135 }
-get_current_fee_percentiles: 38888974
-get_current_fee_percentiles: 292137
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 33352, ins_remove_inputs: 1371, ins_insert_outputs: 29528, ins_txids: 788, ins_insert_utxos: 27633 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6381081532, ins_remove_inputs: 2742, ins_insert_outputs: 6381074242, ins_txids: 7943927, ins_insert_utxos: 6364279653 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16645640049, ins_remove_inputs: 10827692653, ins_insert_outputs: 5810357293, ins_txids: 10174260, ins_insert_utxos: 5789111301 }
+Ingest Block 3: BlockIngestionStats { num_rounds: 1, ins_total: 567078, ins_remove_inputs: 1371, ins_insert_outputs: 563254, ins_txids: 781, ins_insert_utxos: 561366 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 540595, ins_apply_unstable_blocks: 92371 }
+GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 445900, ins_apply_unstable_blocks: 47086 }
+GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 147428775, ins_apply_unstable_blocks: 34583087, ins_build_utxos_vec: 112212403 }
+GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 75950048, ins_apply_unstable_blocks: 71040502, ins_build_utxos_vec: 4275352 }
+GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 26541845, ins_apply_unstable_blocks: 26147100 }
+get_current_fee_percentiles: 38872776
+get_current_fee_percentiles: 291419

--- a/e2e-tests/profiling/scenario-2.txt
+++ b/e2e-tests/profiling/scenario-2.txt
@@ -3,4 +3,4 @@ Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5159888410, ins_
 Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5721465221, ins_remove_inputs: 13711371, ins_insert_outputs: 5700170053, ins_txids: 8170886, ins_insert_utxos: 5680928734 }
 Ingest Block 3: BlockIngestionStats { num_rounds: 2, ins_total: 5975187759, ins_remove_inputs: 13711371, ins_insert_outputs: 5953892591, ins_txids: 8170886, ins_insert_utxos: 5934651272 }
 GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 26386111, ins_apply_unstable_blocks: 25930989 }
-GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 75354705, ins_apply_unstable_blocks: 69983301, ins_build_utxos_vec: 4729757 }
+GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 75380519, ins_apply_unstable_blocks: 69998254, ins_build_utxos_vec: 4739342 }

--- a/e2e-tests/profiling/scenario-2.txt
+++ b/e2e-tests/profiling/scenario-2.txt
@@ -1,6 +1,6 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 36610, ins_remove_inputs: 1368, ins_insert_outputs: 33053, ins_txids: 788, ins_insert_utxos: 31158 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5237618420, ins_remove_inputs: 13681368, ins_insert_outputs: 5217673519, ins_txids: 8170886, ins_insert_utxos: 5198432200 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5809157217, ins_remove_inputs: 13681368, ins_insert_outputs: 5789212316, ins_txids: 8170886, ins_insert_utxos: 5769970997 }
-Ingest Block 3: BlockIngestionStats { num_rounds: 2, ins_total: 6067593952, ins_remove_inputs: 13681368, ins_insert_outputs: 6047649051, ins_txids: 8170886, ins_insert_utxos: 6028407732 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 26382966, ins_apply_unstable_blocks: 25931001 }
-GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 75383103, ins_apply_unstable_blocks: 69998485, ins_build_utxos_vec: 4736809 }
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 35545, ins_remove_inputs: 1371, ins_insert_outputs: 31721, ins_txids: 788, ins_insert_utxos: 29826 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5159869537, ins_remove_inputs: 13711371, ins_insert_outputs: 5138574369, ins_txids: 8170886, ins_insert_utxos: 5119333050 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5721445221, ins_remove_inputs: 13711371, ins_insert_outputs: 5700150053, ins_txids: 8170886, ins_insert_utxos: 5680908734 }
+Ingest Block 3: BlockIngestionStats { num_rounds: 2, ins_total: 5975167714, ins_remove_inputs: 13711371, ins_insert_outputs: 5953872546, ins_txids: 8170886, ins_insert_utxos: 5934631227 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 26382892, ins_apply_unstable_blocks: 25930986 }
+GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 75379526, ins_apply_unstable_blocks: 69999879, ins_build_utxos_vec: 4733355 }

--- a/e2e-tests/profiling/scenario-2.txt
+++ b/e2e-tests/profiling/scenario-2.txt
@@ -1,6 +1,6 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 35280, ins_remove_inputs: 1368, ins_insert_outputs: 31723, ins_txids: 788, ins_insert_utxos: 29828 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5158538098, ins_remove_inputs: 13681368, ins_insert_outputs: 5138593197, ins_txids: 8170886, ins_insert_utxos: 5119351878 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5720114954, ins_remove_inputs: 13681368, ins_insert_outputs: 5700170053, ins_txids: 8170886, ins_insert_utxos: 5680928734 }
-Ingest Block 3: BlockIngestionStats { num_rounds: 2, ins_total: 5973837492, ins_remove_inputs: 13681368, ins_insert_outputs: 5953892591, ins_txids: 8170886, ins_insert_utxos: 5934651272 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 26385484, ins_apply_unstable_blocks: 25931001 }
-GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 75357969, ins_apply_unstable_blocks: 69999534, ins_build_utxos_vec: 4709063 }
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 35547, ins_remove_inputs: 1371, ins_insert_outputs: 31723, ins_txids: 788, ins_insert_utxos: 29828 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5159888410, ins_remove_inputs: 13711371, ins_insert_outputs: 5138593242, ins_txids: 8170886, ins_insert_utxos: 5119351923 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5721465221, ins_remove_inputs: 13711371, ins_insert_outputs: 5700170053, ins_txids: 8170886, ins_insert_utxos: 5680928734 }
+Ingest Block 3: BlockIngestionStats { num_rounds: 2, ins_total: 5975187759, ins_remove_inputs: 13711371, ins_insert_outputs: 5953892591, ins_txids: 8170886, ins_insert_utxos: 5934651272 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 26386111, ins_apply_unstable_blocks: 25930989 }
+GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 75354705, ins_apply_unstable_blocks: 69983301, ins_build_utxos_vec: 4729757 }


### PR DESCRIPTION
Problem:
We currently do not have a way of tracking how many instructions it takes to ingest new Bitcoin blocks.

Solution:
Keep track of the latest stats in a variable and expose them as a metric so that we can track these on our dashboards.