### PR TITLE
feat: track instruction counts of block insertions

### DIFF
--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -91,6 +91,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         encode_instruction_histogram(w, &state.metrics.get_balance_total)?;
         encode_instruction_histogram(w, &state.metrics.get_balance_apply_unstable_blocks)?;
         encode_instruction_histogram(w, &state.metrics.get_current_fee_percentiles_total)?;
+        encode_instruction_histogram(w, &state.metrics.block_insertion)?;
 
         w.encode_gauge(
             "send_transaction_count",
@@ -107,7 +108,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         encode_labeled_gauge(
             w,
             "block_ingestion_stats",
-            "The stats of the most recent block ingestion.",
+            "The stats of the most recent block ingested into the stable UTXO set.",
             &state.metrics.block_ingestion_stats.get_labels_and_values(),
         )?;
 

--- a/canister/src/metrics.rs
+++ b/canister/src/metrics.rs
@@ -21,8 +21,11 @@ pub struct Metrics {
     /// The total number of (valid) requests sent to `send_transaction`.
     pub send_transaction_count: u64,
 
-    /// The stats of the most recent block ingestion.
+    /// The stats of the most recent block ingested into the stable UTXO set.
     pub block_ingestion_stats: BlockIngestionStats,
+
+    /// Instructions needed to insert a block into the pool of unstable blocks.
+    pub block_insertion: InstructionHistogram,
 }
 
 impl Default for Metrics {
@@ -58,6 +61,11 @@ impl Default for Metrics {
             send_transaction_count: 0,
 
             block_ingestion_stats: BlockIngestionStats::default(),
+
+            block_insertion: InstructionHistogram::new(
+                "ins_block_insertion",
+                "Instructions needed to insert a block into the pool of unstable blocks.",
+            ),
         }
     }
 }

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -2,7 +2,7 @@ use crate::{
     address_utxoset::AddressUtxoSet,
     block_header_store::BlockHeaderStore,
     metrics::Metrics,
-    runtime::time,
+    runtime::{time, performance_counter},
     types::{
         Address, Block, BlockHash, Fees, Flag, GetSuccessorsCompleteResponse,
         GetSuccessorsPartialResponse, Network, Slicing,
@@ -94,6 +94,7 @@ impl State {
 /// Inserts a block into the state.
 /// Returns an error if the block doesn't extend any known block in the state.
 pub fn insert_block(state: &mut State, block: Block) -> Result<(), InsertBlockError> {
+    let start = performance_counter();
     validate_header(
         &state.network().into(),
         &ValidationContext::new(state, block.header())
@@ -104,6 +105,9 @@ pub fn insert_block(state: &mut State, block: Block) -> Result<(), InsertBlockEr
 
     unstable_blocks::push(&mut state.unstable_blocks, &state.utxos, block)
         .expect("Inserting a block with a validated header must succeed.");
+
+    let instructions_count = performance_counter() - start;
+    state.metrics.block_insertion.observe(instructions_count);
     Ok(())
 }
 

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -2,7 +2,7 @@ use crate::{
     address_utxoset::AddressUtxoSet,
     block_header_store::BlockHeaderStore,
     metrics::Metrics,
-    runtime::{time, performance_counter},
+    runtime::{performance_counter, time},
     types::{
         Address, Block, BlockHash, Fees, Flag, GetSuccessorsCompleteResponse,
         GetSuccessorsPartialResponse, Network, Slicing,


### PR DESCRIPTION
Inserting new blocks into the pool of `UnstableBlocks` can be relatively
expensive, and it would be useful to track exactly how expensive it is.