### PR TITLE
feat: use the guard pattern when fetching blocks.

### DIFF
--- a/canister/src/guard.rs
+++ b/canister/src/guard.rs
@@ -1,0 +1,27 @@
+use crate::with_state_mut;
+
+/// Ensures that there is only one instance of the heartbeat state machine.
+// Note: the struct has one private field to ensure that nobody can construct it
+// directly outside of this module.
+#[must_use]
+pub struct FetchBlocksGuard(());
+
+impl FetchBlocksGuard {
+    pub fn new() -> Option<Self> {
+        with_state_mut(|s| {
+            if s.syncing_state.is_fetching_blocks {
+                return None;
+            }
+            s.syncing_state.is_fetching_blocks = true;
+            Some(FetchBlocksGuard(()))
+        })
+    }
+}
+
+impl Drop for FetchBlocksGuard {
+    fn drop(&mut self) {
+        with_state_mut(|s| {
+            s.syncing_state.is_fetching_blocks = false;
+        });
+    }
+}

--- a/canister/src/guard.rs
+++ b/canister/src/guard.rs
@@ -1,6 +1,6 @@
 use crate::with_state_mut;
 
-/// Ensures that there is only one instance of the heartbeat state machine.
+/// Ensures that there is only one request to fetch blocks at any given time.
 // Note: the struct has one private field to ensure that nobody can construct it
 // directly outside of this module.
 #[must_use]

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -2,6 +2,7 @@ mod address_utxoset;
 mod api;
 mod block_header_store;
 mod blocktree;
+mod guard;
 mod heartbeat;
 pub mod memory;
 mod metrics;

--- a/e2e-tests/profiling/scenario-1.txt
+++ b/e2e-tests/profiling/scenario-1.txt
@@ -1,11 +1,11 @@
 Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 33354, ins_remove_inputs: 1371, ins_insert_outputs: 29530, ins_txids: 788, ins_insert_utxos: 27635 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6381101532, ins_remove_inputs: 2742, ins_insert_outputs: 6381094242, ins_txids: 7943927, ins_insert_utxos: 6364299653 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16645660049, ins_remove_inputs: 10827692410, ins_insert_outputs: 5810377536, ins_txids: 10174260, ins_insert_utxos: 5789131544 }
-Ingest Block 3: BlockIngestionStats { num_rounds: 1, ins_total: 582574, ins_remove_inputs: 1371, ins_insert_outputs: 578750, ins_txids: 788, ins_insert_utxos: 576855 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 539047, ins_apply_unstable_blocks: 92381 }
-GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 443744, ins_apply_unstable_blocks: 47074 }
-GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 152421662, ins_apply_unstable_blocks: 34592333, ins_build_utxos_vec: 117183544 }
-GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 75980339, ins_apply_unstable_blocks: 71059797, ins_build_utxos_vec: 4288476 }
-GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 26541866, ins_apply_unstable_blocks: 26147121 }
-get_current_fee_percentiles: 38887455
-get_current_fee_percentiles: 292879
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6375428345, ins_remove_inputs: 2742, ins_insert_outputs: 6375421055, ins_txids: 7940090, ins_insert_utxos: 6358630303 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 16645660049, ins_remove_inputs: 10827692572, ins_insert_outputs: 5810377374, ins_txids: 10174260, ins_insert_utxos: 5789131382 }
+Ingest Block 3: BlockIngestionStats { num_rounds: 1, ins_total: 576470, ins_remove_inputs: 1371, ins_insert_outputs: 572646, ins_txids: 788, ins_insert_utxos: 570751 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 555104, ins_apply_unstable_blocks: 92327 }
+GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 443997, ins_apply_unstable_blocks: 47042 }
+GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 151289688, ins_apply_unstable_blocks: 34436026, ins_build_utxos_vec: 116228810 }
+GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 76393341, ins_apply_unstable_blocks: 71275705, ins_build_utxos_vec: 4487697 }
+GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 26541622, ins_apply_unstable_blocks: 26147004 }
+get_current_fee_percentiles: 39731788
+get_current_fee_percentiles: 293028

--- a/e2e-tests/profiling/scenario-2.txt
+++ b/e2e-tests/profiling/scenario-2.txt
@@ -1,6 +1,6 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 35547, ins_remove_inputs: 1371, ins_insert_outputs: 31723, ins_txids: 788, ins_insert_utxos: 29828 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5159888410, ins_remove_inputs: 13711371, ins_insert_outputs: 5138593242, ins_txids: 8170886, ins_insert_utxos: 5119351923 }
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 33774, ins_remove_inputs: 1371, ins_insert_outputs: 29950, ins_txids: 788, ins_insert_utxos: 28055 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 5159888365, ins_remove_inputs: 13711371, ins_insert_outputs: 5138593197, ins_txids: 8170886, ins_insert_utxos: 5119351878 }
 Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5721465221, ins_remove_inputs: 13711371, ins_insert_outputs: 5700170053, ins_txids: 8170886, ins_insert_utxos: 5680928734 }
 Ingest Block 3: BlockIngestionStats { num_rounds: 2, ins_total: 5975187759, ins_remove_inputs: 13711371, ins_insert_outputs: 5953892591, ins_txids: 8170886, ins_insert_utxos: 5934651272 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 26386111, ins_apply_unstable_blocks: 25930989 }
-GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 75380519, ins_apply_unstable_blocks: 69998254, ins_build_utxos_vec: 4739342 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 26383508, ins_apply_unstable_blocks: 25930956 }
+GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 75407054, ins_apply_unstable_blocks: 70056578, ins_build_utxos_vec: 4697931 }


### PR DESCRIPTION
# Problem
If for any reason the logic in fetching blocks panics, we'll forever stop fetching new blocks.

# Solution
Use the guard pattern, which guarantees that we always set the `is_fetching_blocks` flag to `false` and continue fetching new blocks whenever we receive a response, even if it traps.