### PR TITLE
feat: [EXC-1374] add script for running benchmarks.

### DIFF
--- a/benchmarks/drun.txt
+++ b/benchmarks/drun.txt
@@ -1,0 +1,3 @@
+create
+install rwlgt-iiaaa-aaaaa-aaaaa-cai ../target/wasm32-unknown-unknown/release/benchmarks.wasm.gz ""
+query rwlgt-iiaaa-aaaaa-aaaaa-cai insert_300_blocks "DIDL\x00\x00"

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+pushd "$SCRIPT_DIR"
+
+# Build the benchmarks canister
+bash ../scripts/build-canister.sh benchmarks
+
+# Run the benchmarks, decode the output.
+drun ./drun.txt --instruction-limit 99999999999999 \
+    | awk '{ print $3 }' \
+    | grep "44.*" -o \
+    | xargs didc decode


### PR DESCRIPTION
In a previous commit, a benchmarks canister was introduced to help benchmark specific parts of the code.

This commit includes a script to run these benchmarks. The script relies on `drun`, which is configured to run benchmarks with practically no instruction limit. For now, it is assumed to be available in the caller's path.

Running `./benchmarks/run.sh`, returns the following:

```
(113_061_801_763 : nat64)
```

In other words, the one benchmark we currently have takes 113B instructions to run (!!)