### PR TITLE
feat: add metric to track if the canister is synced

### DIFF
--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -112,6 +112,12 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             &state.metrics.block_ingestion_stats.get_labels_and_values(),
         )?;
 
+        w.encode_gauge(
+            "is_synced",
+            if crate::is_synced() { 1.0 } else { 0.0 },
+            "Is the canister synced with the network?",
+        )?;
+
         Ok(())
     })
 }

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -219,7 +219,7 @@ fn verify_api_access() {
     });
 }
 
-// Verifies that if the difference between the maximum height
+// Verifies if the difference between the maximum height
 // of all block headers and the maximum height of all unstable
 // blocks is at most the SYNCED_THRESHOLD.
 fn verify_synced() {

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -219,16 +219,26 @@ fn verify_api_access() {
     });
 }
 
-/// Verifies that if the difference between the maximum height
-/// of all block headers and the maximum height of all unstable
-/// blocks is at most the SYNCED_THRESHOLD.
+// Verifies that if the difference between the maximum height
+// of all block headers and the maximum height of all unstable
+// blocks is at most the SYNCED_THRESHOLD.
 fn verify_synced() {
     with_state(|state| {
         if state.disable_api_if_not_fully_synced == Flag::Disabled {
             return;
         }
+
+        if !is_synced() {
+            panic!("Canister state is not fully synced.");
+        }
+    });
+}
+
+/// Returns true if the canister is synced with the network, false otherwise.
+pub(crate) fn is_synced() -> bool {
+    with_state(|state| {
         let main_chain_height = main_chain_height(state);
-        if main_chain_height + SYNCED_THRESHOLD
+        main_chain_height + SYNCED_THRESHOLD
             < max(
                 state
                     .unstable_blocks
@@ -236,10 +246,7 @@ fn verify_synced() {
                     .unwrap_or(0),
                 main_chain_height,
             )
-        {
-            panic!("Canister state is not fully synced.");
-        }
-    });
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem
There is now logic in the canister to disable its API automatically if it's not synced with the network, but we have no way of tracking whether or not our definition of "synced" is too sensitive, and whether or not we're frequently flapping between the synced and not synced states.

## Solution
Add a `is_synced` metric to the canister that we can use to monitor changes in the synced state.