### PR TITLE
fix: broken upgradability test

### DIFF
--- a/canister/src/metrics.rs
+++ b/canister/src/metrics.rs
@@ -22,10 +22,22 @@ pub struct Metrics {
     pub send_transaction_count: u64,
 
     /// The stats of the most recent block ingested into the stable UTXO set.
+    // TODO(EXC-1379): Remove this code once it's deployed to production.
+    #[serde(default)]
     pub block_ingestion_stats: BlockIngestionStats,
 
     /// Instructions needed to insert a block into the pool of unstable blocks.
+    // TODO(EXC-1379): Remove this code once it's deployed to production.
+    #[serde(default = "init_block_insertion_histogram")]
     pub block_insertion: InstructionHistogram,
+}
+
+// TODO(EXC-1379): Remove this code once it's deployed to production.
+fn init_block_insertion_histogram() -> InstructionHistogram {
+    InstructionHistogram::new(
+        "ins_block_insertion",
+        "Instructions needed to insert a block into the pool of unstable blocks.",
+    )
 }
 
 impl Default for Metrics {

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -48,11 +48,12 @@ pub struct State {
     pub metrics: Metrics,
 
     /// Flag to control access to the apis provided by the canister.
-    #[serde(default)]
     pub api_access: Flag,
 
     /// Flag to determine if the API should be automatically disabled
     /// if the canister isn't fully synced.
+    // TODO(EXC-1379): Remove this code once it's deployed to production.
+    #[serde(default)]
     pub disable_api_if_not_fully_synced: Flag,
 }
 

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -23,6 +23,8 @@ pub struct UnstableBlocks {
     outpoints_cache: OutPointsCache,
     network: Network,
     /// The hashes of the blocks that are expected to be received.
+    // TODO(EXC-1379): remove this directive once it's deployed to production.
+    #[serde(default)]
     next_block_hashes: NextBlockHashes,
 }
 

--- a/dfx.json
+++ b/dfx.json
@@ -14,7 +14,7 @@
       "build": "./scripts/build-canister.sh benchmarks",
       "wasm": "./target/wasm32-unknown-unknown/release/benchmarks.wasm.gz"
     },
-    "upgradablity-test": {
+    "upgradability-test": {
       "type": "custom",
       "candid": "./canister/candid.did",
       "wasm": "upgradability-test.wasm.gz"

--- a/e2e-tests/upgradability.sh
+++ b/e2e-tests/upgradability.sh
@@ -37,13 +37,19 @@ wget -O upgradability-test.wasm.gz "${LATEST_RELEASE}"
 dfx start --background --clean
 
 # Deploy the latest release
-dfx deploy --no-wallet upgradablity-test --argument "${ARGUMENT}"
+dfx deploy --no-wallet upgradability-test --argument "${ARGUMENT}"
 
-dfx canister stop upgradablity-test
+dfx canister stop upgradability-test
 
-# replace from upgradablity-test with bitcoin in .dfx/local/canister_ids.json
+# replace from upgradability-test with bitcoin in .dfx/local/canister_ids.json
 # so that the canister is upgraded to the bitcoin canister of the current branch.
 sed -i'' -e 's/upgradability-test/bitcoin/' .dfx/local/canister_ids.json
+
+# Verify that the bitcoin canister now exists and is already stopped.
+if ! [[ $(dfx canister status bitcoin 2>&1) == *"Status: Stopped"* ]]; then
+  echo "Bitcoin canister must be already created and stopped."
+  exit 1
+fi
 
 # Deploy upgraded canister
 dfx deploy --no-wallet bitcoin --argument "${ARGUMENT}"


### PR DESCRIPTION
## Problem
There is an "upgradability" test that checks if the canister can be upgraded from the latest release to the current commit successfully. This test is broken due to a typo in the canister's name, resulting in a failed upgrade this week.

## Solution
Fix the typo in the test, and add a check to ensure that, if a typo were to reintroduced, that the test would fail.