### PR TITLE
refactor: clean up interface types.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
  "bitcoin",
  "hex",
  "ic-btc-canister",
+ "ic-btc-interface",
  "ic-cdk 0.6.10",
  "ic-cdk-macros 0.6.10",
 ]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -13,3 +13,4 @@ hex = "0.4.3"
 ic-cdk = "0.6.1"
 ic-cdk-macros = "0.6.1"
 ic-btc-canister = { path = "../canister" }
+ic-btc-interface = { path = "../interface" }

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1,10 +1,7 @@
 use bitcoin::consensus::Decodable;
 use bitcoin::Block as BitcoinBlock;
-use ic_btc_canister::{
-    types::Config,
-    types::{Block, Network},
-    with_state_mut,
-};
+use ic_btc_canister::{types::Block, with_state_mut};
+use ic_btc_interface::{Config, Network};
 use ic_cdk_macros::{init, query};
 use std::cell::RefCell;
 

--- a/bootstrap/main-state-builder/src/main.rs
+++ b/bootstrap/main-state-builder/src/main.rs
@@ -11,11 +11,11 @@ use bitcoin::{consensus::Decodable, Block as BitcoinBlock};
 use clap::Parser;
 use ic_btc_canister::{
     pre_upgrade,
-    types::{Block, BlockHash, BlockHeaderBlob, Config, Flag, Network, OutPoint, TxOut},
+    types::{Block, BlockHash, BlockHeaderBlob, OutPoint, TxOut},
     unstable_blocks::{self, UnstableBlocks},
     with_state, with_state_mut,
 };
-use ic_btc_interface::Height;
+use ic_btc_interface::{Config, Flag, Height, Network};
 use ic_stable_structures::FileMemory;
 use std::{
     collections::BTreeMap,

--- a/bootstrap/state-builder/src/build_address_utxos.rs
+++ b/bootstrap/state-builder/src/build_address_utxos.rs
@@ -8,7 +8,7 @@
 //!   --utxos-dump-path utxos-dump.csv
 use bitcoin::{Address as BitcoinAddress, Script, Txid as BitcoinTxid};
 use clap::Parser;
-use ic_btc_canister::types::{Address, AddressUtxo, OutPoint, Txid, into_bitcoin_network};
+use ic_btc_canister::types::{into_bitcoin_network, Address, AddressUtxo, OutPoint, Txid};
 use ic_btc_interface::Network;
 use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
 use std::{

--- a/bootstrap/state-builder/src/build_address_utxos.rs
+++ b/bootstrap/state-builder/src/build_address_utxos.rs
@@ -8,7 +8,8 @@
 //!   --utxos-dump-path utxos-dump.csv
 use bitcoin::{Address as BitcoinAddress, Script, Txid as BitcoinTxid};
 use clap::Parser;
-use ic_btc_canister::types::{Address, AddressUtxo, Network, OutPoint, Txid};
+use ic_btc_canister::types::{Address, AddressUtxo, OutPoint, Txid, into_bitcoin_network};
+use ic_btc_interface::Network;
 use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
 use std::{
     fs::File,
@@ -64,7 +65,7 @@ fn main() {
         } else {
             BitcoinAddress::from_script(
                 &Script::from(hex::decode(script).expect("script must be valid hex")),
-                args.network.into(),
+                into_bitcoin_network(args.network),
             )
         };
 

--- a/bootstrap/state-builder/src/build_balances.rs
+++ b/bootstrap/state-builder/src/build_balances.rs
@@ -8,7 +8,8 @@
 //!   --utxos-dump-path utxos-dump.csv
 use bitcoin::{Address as BitcoinAddress, Script};
 use clap::Parser;
-use ic_btc_canister::types::{Address, Network};
+use ic_btc_canister::types::{into_bitcoin_network, Address};
+use ic_btc_interface::Network;
 use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
@@ -63,7 +64,7 @@ fn main() {
         } else {
             BitcoinAddress::from_script(
                 &Script::from(hex::decode(script).expect("script must be valid hex")),
-                args.network.into(),
+                into_bitcoin_network(args.network),
             )
         };
 

--- a/bootstrap/state-builder/src/build_utxos.rs
+++ b/bootstrap/state-builder/src/build_utxos.rs
@@ -9,9 +9,10 @@
 use bitcoin::{Address, Txid as BitcoinTxid};
 use clap::Parser;
 use ic_btc_canister::{
-    types::{Config, Flag, Network, OutPoint, TxOut, Txid},
+    types::{OutPoint, TxOut, Txid},
     with_state, with_state_mut,
 };
+use ic_btc_interface::{Config, Flag, Network};
 use ic_stable_structures::{
     memory_manager::{MemoryId, MemoryManager},
     Memory,

--- a/bootstrap/state-builder/src/main.rs
+++ b/bootstrap/state-builder/src/main.rs
@@ -13,9 +13,10 @@ use clap::Parser;
 use ic_btc_canister::{
     heartbeat, pre_upgrade, runtime,
     state::main_chain_height,
-    types::{Config, Flag, GetSuccessorsCompleteResponse, GetSuccessorsResponse, Network},
+    types::{GetSuccessorsCompleteResponse, GetSuccessorsResponse},
     with_state,
 };
+use ic_btc_interface::{Config, Flag, Network};
 use rusty_leveldb::{Options, DB};
 use std::{
     collections::BTreeMap,

--- a/canister/src/address_utxoset.rs
+++ b/canister/src/address_utxoset.rs
@@ -116,10 +116,7 @@ impl<'a> AddressUtxoSet<'a> {
 mod test {
     use super::*;
     use crate::test_utils::{random_p2pkh_address, BlockBuilder, TransactionBuilder};
-    use crate::{
-        types::{OutPoint},
-        unstable_blocks,
-    };
+    use crate::{types::OutPoint, unstable_blocks};
     use ic_btc_interface::Network;
 
     #[test]

--- a/canister/src/address_utxoset.rs
+++ b/canister/src/address_utxoset.rs
@@ -117,9 +117,10 @@ mod test {
     use super::*;
     use crate::test_utils::{random_p2pkh_address, BlockBuilder, TransactionBuilder};
     use crate::{
-        types::{Network, OutPoint},
+        types::{OutPoint},
         unstable_blocks,
     };
+    use ic_btc_interface::Network;
 
     #[test]
     fn add_tx_to_empty_utxo() {

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -150,10 +150,10 @@ mod test {
     use crate::{
         genesis_block, state,
         test_utils::{random_p2pkh_address, BlockBuilder, TransactionBuilder},
-        types::{OutPoint},
+        types::OutPoint,
         with_state,
     };
-    use ic_btc_interface::{Config, Fees, Satoshi, Network};
+    use ic_btc_interface::{Config, Fees, Network, Satoshi};
     use std::iter::FromIterator;
 
     /// Covers an inclusive range of `[0, 100]` percentiles.

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -150,10 +150,10 @@ mod test {
     use crate::{
         genesis_block, state,
         test_utils::{random_p2pkh_address, BlockBuilder, TransactionBuilder},
-        types::{Config, Fees, Network, OutPoint},
+        types::{OutPoint},
         with_state,
     };
-    use ic_btc_interface::Satoshi;
+    use ic_btc_interface::{Config, Fees, Satoshi, Network};
     use std::iter::FromIterator;
 
     /// Covers an inclusive range of `[0, 100]` percentiles.

--- a/canister/src/api/get_balance.rs
+++ b/canister/src/api/get_balance.rs
@@ -103,9 +103,10 @@ mod test {
     use crate::{
         genesis_block, state,
         test_utils::{random_p2pkh_address, BlockBuilder, TransactionBuilder},
-        types::{Config, Fees, Network, OutPoint},
+        types::OutPoint,
         with_state_mut,
     };
+    use ic_btc_interface::{Config, Fees, Network};
 
     #[test]
     fn error_on_malformed_address() {

--- a/canister/src/api/get_utxos.rs
+++ b/canister/src/api/get_utxos.rs
@@ -275,9 +275,10 @@ mod test {
             random_p2pkh_address, random_p2tr_address, random_p2wpkh_address, random_p2wsh_address,
             BlockBuilder, TransactionBuilder,
         },
-        types::{Block, Config, Fees, Network},
+        types::Block,
         with_state_mut,
     };
+    use ic_btc_interface::{Config, Fees, Network};
     use ic_btc_interface::{OutPoint, Utxo};
     use proptest::prelude::*;
 

--- a/canister/src/api/send_transaction.rs
+++ b/canister/src/api/send_transaction.rs
@@ -41,8 +41,7 @@ pub async fn send_transaction(request: SendTransactionRequest) -> Result<(), Sen
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::types::{Config, Fees, Flag, Network};
-    use ic_btc_interface::NetworkInRequest;
+    use ic_btc_interface::{Config, Fees, Flag, Network, NetworkInRequest};
 
     fn empty_transaction() -> Vec<u8> {
         let mut buf = vec![];

--- a/canister/src/api/set_config.rs
+++ b/canister/src/api/set_config.rs
@@ -1,4 +1,4 @@
-use crate::SetConfigRequest;
+use ic_btc_interface::SetConfigRequest;
 use std::convert::TryInto;
 
 pub async fn set_config(request: SetConfigRequest) {
@@ -58,11 +58,8 @@ async fn verify_caller() {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{
-        init,
-        types::{Config, Fees, Flag},
-        with_state,
-    };
+    use crate::{init, with_state};
+    use ic_btc_interface::{Config, Fees, Flag};
     use proptest::prelude::*;
 
     #[test]

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -1,4 +1,5 @@
-use crate::types::{Block, BlockHash, Network};
+use crate::types::{Block, BlockHash};
+use ic_btc_interface::Network;
 use std::fmt;
 mod serde;
 

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -2,13 +2,14 @@ use crate::{
     runtime::{call_get_successors, print},
     state::{self, ResponseToProcess, State},
     types::{
-        Block, BlockHash, BlockHeaderBlob, Flag, GetSuccessorsCompleteResponse,
-        GetSuccessorsRequest, GetSuccessorsRequestInitial, GetSuccessorsResponse,
+        Block, BlockHash, BlockHeaderBlob, GetSuccessorsCompleteResponse, GetSuccessorsRequest,
+        GetSuccessorsRequestInitial, GetSuccessorsResponse,
     },
 };
 use crate::{with_state, with_state_mut};
 use bitcoin::Block as BitcoinBlock;
 use bitcoin::{consensus::Decodable, BlockHeader};
+use ic_btc_interface::Flag;
 
 /// The heartbeat of the Bitcoin canister.
 ///
@@ -249,13 +250,11 @@ mod test {
         genesis_block, init,
         runtime::{self, GetSuccessorsReply},
         test_utils::{random_p2pkh_address, BlockBuilder, TransactionBuilder},
-        types::{
-            Address, BlockBlob, Config, GetSuccessorsCompleteResponse,
-            GetSuccessorsPartialResponse, Network,
-        },
+        types::{Address, BlockBlob, GetSuccessorsCompleteResponse, GetSuccessorsPartialResponse},
         utxo_set::IngestingBlock,
     };
     use bitcoin::BlockHeader;
+    use ic_btc_interface::{Config, Network};
 
     fn build_block(prev_header: &BlockHeader, address: Address, num_transactions: u128) -> Block {
         let mut block = BlockBuilder::with_prev_header(prev_header);

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -21,14 +21,14 @@ mod validation;
 use crate::{
     runtime::{msg_cycles_accept, msg_cycles_available},
     state::State,
-    types::{Block, Config, Flag, HttpRequest, HttpResponse, Network, SetConfigRequest},
+    types::{into_bitcoin_network, Block, HttpRequest, HttpResponse},
 };
 pub use api::send_transaction;
 pub use api::set_config;
 pub use heartbeat::heartbeat;
 use ic_btc_interface::{
-    GetBalanceError, GetBalanceRequest, GetCurrentFeePercentilesRequest, GetUtxosError,
-    GetUtxosRequest, GetUtxosResponse, MillisatoshiPerByte, Satoshi,
+    Config, Flag, GetBalanceError, GetBalanceRequest, GetCurrentFeePercentilesRequest,
+    GetUtxosError, GetUtxosRequest, GetUtxosResponse, MillisatoshiPerByte, Network, Satoshi,
 };
 use ic_stable_structures::Memory;
 pub use memory::get_memory;
@@ -174,7 +174,9 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
 
 /// Returns the genesis block of the given network.
 pub(crate) fn genesis_block(network: Network) -> Block {
-    Block::new(bitcoin::blockdata::constants::genesis_block(network.into()))
+    Block::new(bitcoin::blockdata::constants::genesis_block(
+        into_bitcoin_network(network),
+    ))
 }
 
 pub(crate) fn charge_cycles(amount: u128) {
@@ -252,8 +254,8 @@ pub(crate) fn is_synced() -> bool {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{test_utils::build_regtest_chain, types::Network};
-    use ic_btc_interface::NetworkInRequest;
+    use crate::{test_utils::build_regtest_chain};
+    use ic_btc_interface::{NetworkInRequest, Network};
     use proptest::prelude::*;
 
     proptest! {

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -254,8 +254,8 @@ pub(crate) fn is_synced() -> bool {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{test_utils::build_regtest_chain};
-    use ic_btc_interface::{NetworkInRequest, Network};
+    use crate::test_utils::build_regtest_chain;
+    use ic_btc_interface::{Network, NetworkInRequest};
     use proptest::prelude::*;
 
     proptest! {

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -1,7 +1,7 @@
-use ic_btc_canister::types::{Config, HttpRequest, HttpResponse, SetConfigRequest};
+use ic_btc_canister::types::{HttpRequest, HttpResponse};
 use ic_btc_interface::{
-    GetBalanceRequest, GetCurrentFeePercentilesRequest, GetUtxosRequest, MillisatoshiPerByte,
-    SendTransactionRequest,
+    Config, GetBalanceRequest, GetCurrentFeePercentilesRequest, GetUtxosRequest,
+    MillisatoshiPerByte, SendTransactionRequest, SetConfigRequest,
 };
 use ic_cdk::api::call::{reject, reply};
 use ic_cdk_macros::{heartbeat, init, post_upgrade, pre_upgrade, query, update};

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -4,14 +4,14 @@ use crate::{
     metrics::Metrics,
     runtime::{performance_counter, time},
     types::{
-        Address, Block, BlockHash, Fees, Flag, GetSuccessorsCompleteResponse,
-        GetSuccessorsPartialResponse, Network, Slicing,
+        Address, Block, BlockHash, GetSuccessorsCompleteResponse,
+        GetSuccessorsPartialResponse, Slicing, into_bitcoin_network
     },
     unstable_blocks::{self, UnstableBlocks},
     validation::ValidationContext,
     UtxoSet,
 };
-use ic_btc_interface::{Height, MillisatoshiPerByte};
+use ic_btc_interface::{Height, MillisatoshiPerByte, Fees, Flag, Network};
 use ic_btc_validation::{validate_header, ValidateHeaderError as InsertBlockError};
 use ic_cdk::export::Principal;
 use serde::{Deserialize, Serialize};
@@ -102,7 +102,7 @@ impl State {
 pub fn insert_block(state: &mut State, block: Block) -> Result<(), InsertBlockError> {
     let start = performance_counter();
     validate_header(
-        &state.network().into(),
+        &into_bitcoin_network(state.network()),
         &ValidationContext::new(state, block.header())
             .map_err(|_| InsertBlockError::PrevHeaderNotFound)?,
         block.header(),

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -4,14 +4,14 @@ use crate::{
     metrics::Metrics,
     runtime::{performance_counter, time},
     types::{
-        Address, Block, BlockHash, GetSuccessorsCompleteResponse,
-        GetSuccessorsPartialResponse, Slicing, into_bitcoin_network
+        into_bitcoin_network, Address, Block, BlockHash, GetSuccessorsCompleteResponse,
+        GetSuccessorsPartialResponse, Slicing,
     },
     unstable_blocks::{self, UnstableBlocks},
     validation::ValidationContext,
     UtxoSet,
 };
-use ic_btc_interface::{Height, MillisatoshiPerByte, Fees, Flag, Network};
+use ic_btc_interface::{Fees, Flag, Height, MillisatoshiPerByte, Network};
 use ic_btc_validation::{validate_header, ValidateHeaderError as InsertBlockError};
 use ic_cdk::export::Principal;
 use serde::{Deserialize, Serialize};

--- a/canister/src/test_utils.rs
+++ b/canister/src/test_utils.rs
@@ -1,11 +1,12 @@
 use crate::{
     genesis_block,
-    types::{Address, Block, Network, OutPoint, Transaction},
+    types::{into_bitcoin_network, Address, Block, OutPoint, Transaction},
 };
 use bitcoin::{
     hashes::Hash, secp256k1::rand::rngs::OsRng, secp256k1::Secp256k1, Address as BitcoinAddress,
     BlockHeader, PublicKey, Script, WScriptHash,
 };
+use ic_btc_interface::Network;
 use ic_btc_test_utils::{
     BlockBuilder as ExternalBlockBuilder, TransactionBuilder as ExternalTransactionBuilder,
 };
@@ -20,13 +21,13 @@ pub fn random_p2pkh_address(network: Network) -> Address {
 
     BitcoinAddress::p2pkh(
         &PublicKey::new(secp.generate_keypair(&mut rng).1),
-        network.into(),
+        into_bitcoin_network(network),
     )
     .into()
 }
 
 pub fn random_p2tr_address(network: Network) -> Address {
-    ic_btc_test_utils::random_p2tr_address(network.into()).into()
+    ic_btc_test_utils::random_p2tr_address(into_bitcoin_network(network)).into()
 }
 
 pub fn random_p2wpkh_address(network: Network) -> Address {
@@ -34,7 +35,7 @@ pub fn random_p2wpkh_address(network: Network) -> Address {
     let mut rng = OsRng::new().unwrap();
     BitcoinAddress::p2wpkh(
         &PublicKey::new(secp.generate_keypair(&mut rng).1),
-        network.into(),
+        into_bitcoin_network(network),
     )
     .expect("failed to create p2wpkh address")
     .into()
@@ -46,7 +47,7 @@ pub fn random_p2wsh_address(network: Network) -> Address {
     rng.fill_bytes(&mut hash);
     BitcoinAddress::p2wsh(
         &Script::new_v0_p2wsh(&WScriptHash::from_hash(Hash::from_slice(&hash).unwrap())),
-        network.into(),
+        into_bitcoin_network(network),
     )
     .into()
 }

--- a/canister/src/tests.rs
+++ b/canister/src/tests.rs
@@ -6,7 +6,7 @@ use crate::{
     test_utils::{BlockBuilder, BlockChainBuilder, TransactionBuilder},
     types::{
         Block, BlockBlob, BlockHash, BlockHeaderBlob, GetBalanceRequest,
-        GetSuccessorsCompleteResponse, GetSuccessorsResponse, GetUtxosRequest, Network,
+        GetSuccessorsCompleteResponse, GetSuccessorsResponse, GetUtxosRequest,
     },
     utxo_set::{IngestingBlock, DUPLICATE_TX_IDS},
     verify_synced, with_state, SYNCED_THRESHOLD,
@@ -18,7 +18,7 @@ use bitcoin::{
 };
 use bitcoin::{Block as BitcoinBlock, BlockHeader};
 use byteorder::{LittleEndian, ReadBytesExt};
-use ic_btc_interface::{GetUtxosResponse, UtxosFilter};
+use ic_btc_interface::{GetUtxosResponse, Network, UtxosFilter};
 use ic_btc_interface::{OutPoint, Utxo};
 use ic_cdk::api::call::RejectionCode;
 use std::str::FromStr;

--- a/canister/src/tests/confirmation_counts.rs
+++ b/canister/src/tests/confirmation_counts.rs
@@ -4,11 +4,11 @@ use crate::{
     runtime::{set_successors_responses, GetSuccessorsReply},
     test_utils::BlockChainBuilder,
     types::{
-        Block, GetSuccessorsCompleteResponse, GetSuccessorsResponse, GetUtxosRequest, Network,
+        Block, GetSuccessorsCompleteResponse, GetSuccessorsResponse, GetUtxosRequest,
     },
 };
 use async_std::task::block_on;
-use ic_btc_interface::UtxosFilter;
+use ic_btc_interface::{UtxosFilter, Network};
 use proptest::prelude::*;
 
 const ADDRESS: &str = "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8";

--- a/canister/src/tests/confirmation_counts.rs
+++ b/canister/src/tests/confirmation_counts.rs
@@ -3,12 +3,10 @@ use crate::{
     heartbeat,
     runtime::{set_successors_responses, GetSuccessorsReply},
     test_utils::BlockChainBuilder,
-    types::{
-        Block, GetSuccessorsCompleteResponse, GetSuccessorsResponse, GetUtxosRequest,
-    },
+    types::{Block, GetSuccessorsCompleteResponse, GetSuccessorsResponse, GetUtxosRequest},
 };
 use async_std::task::block_on;
-use ic_btc_interface::{UtxosFilter, Network};
+use ic_btc_interface::{Network, UtxosFilter};
 use proptest::prelude::*;
 
 const ADDRESS: &str = "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8";

--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -5,10 +5,10 @@ use bitcoin::{
 };
 use ic_btc_interface::{
     Address as AddressStr, GetBalanceRequest as PublicGetBalanceRequest,
-    GetUtxosRequest as PublicGetUtxosRequest, Height, Network, Satoshi,
-    UtxosFilter, UtxosFilterInRequest,
+    GetUtxosRequest as PublicGetUtxosRequest, Height, Network, Satoshi, UtxosFilter,
+    UtxosFilterInRequest,
 };
-use ic_cdk::export::{candid::CandidType};
+use ic_cdk::export::candid::CandidType;
 use ic_stable_structures::{BoundedStorable, Storable as StableStructuresStorable};
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -1,10 +1,10 @@
 mod outpoints_cache;
 use crate::{
     blocktree::{self, BlockChain, BlockDoesNotExtendTree, BlockTree},
-    types::{Address, Block, BlockHash, Network, OutPoint, TxOut},
+    types::{Address, Block, BlockHash, OutPoint, TxOut},
     UtxoSet,
 };
-use ic_btc_interface::Height;
+use ic_btc_interface::{Height, Network};
 use outpoints_cache::OutPointsCache;
 use serde::{Deserialize, Serialize};
 
@@ -277,7 +277,8 @@ fn get_stable_child(blocks: &UnstableBlocks) -> Option<usize> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{test_utils::BlockBuilder, types::Network};
+    use crate::{test_utils::BlockBuilder};
+    use ic_btc_interface::Network;
 
     #[test]
     fn empty() {

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -277,7 +277,7 @@ fn get_stable_child(blocks: &UnstableBlocks) -> Option<usize> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{test_utils::BlockBuilder};
+    use crate::test_utils::BlockBuilder;
     use ic_btc_interface::Network;
 
     #[test]

--- a/canister/src/unstable_blocks/outpoints_cache.rs
+++ b/canister/src/unstable_blocks/outpoints_cache.rs
@@ -235,8 +235,8 @@ mod test {
     use super::*;
     use crate::{
         test_utils::{random_p2pkh_address, BlockBuilder, TransactionBuilder},
-        types::Network,
     };
+    use ic_btc_interface::Network;
 
     #[test]
     fn empty_when_initialized() {

--- a/canister/src/unstable_blocks/outpoints_cache.rs
+++ b/canister/src/unstable_blocks/outpoints_cache.rs
@@ -233,9 +233,7 @@ struct TxOutInfo {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{
-        test_utils::{random_p2pkh_address, BlockBuilder, TransactionBuilder},
-    };
+    use crate::test_utils::{random_p2pkh_address, BlockBuilder, TransactionBuilder};
     use ic_btc_interface::Network;
 
     #[test]

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -3,12 +3,12 @@ use crate::{
     multi_iter::MultiIter,
     runtime::{inc_performance_counter, performance_counter, print},
     types::{
-        Address, AddressUtxo, Block, BlockHash, OutPoint, Slicing, Storable, Transaction,
-        TxOut, Txid, Utxo,
+        Address, AddressUtxo, Block, BlockHash, OutPoint, Slicing, Storable, Transaction, TxOut,
+        Txid, Utxo,
     },
 };
 use bitcoin::{Script, TxOut as BitcoinTxOut};
-use ic_btc_interface::{Height, Satoshi, Network};
+use ic_btc_interface::{Height, Network, Satoshi};
 use ic_stable_structures::{StableBTreeMap, Storable as _};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, iter::Iterator, str::FromStr};
@@ -570,8 +570,8 @@ mod test {
         types::{OutPoint, Txid},
         unstable_blocks::UnstableBlocks,
     };
-    use ic_btc_interface::Network;
     use bitcoin::blockdata::{opcodes::all::OP_RETURN, script::Builder};
+    use ic_btc_interface::Network;
     use proptest::prelude::*;
     use std::collections::BTreeSet;
 

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -3,12 +3,12 @@ use crate::{
     multi_iter::MultiIter,
     runtime::{inc_performance_counter, performance_counter, print},
     types::{
-        Address, AddressUtxo, Block, BlockHash, Network, OutPoint, Slicing, Storable, Transaction,
+        Address, AddressUtxo, Block, BlockHash, OutPoint, Slicing, Storable, Transaction,
         TxOut, Txid, Utxo,
     },
 };
 use bitcoin::{Script, TxOut as BitcoinTxOut};
-use ic_btc_interface::{Height, Satoshi};
+use ic_btc_interface::{Height, Satoshi, Network};
 use ic_stable_structures::{StableBTreeMap, Storable as _};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, iter::Iterator, str::FromStr};
@@ -567,9 +567,10 @@ mod test {
     use crate::test_utils::{random_p2pkh_address, BlockBuilder, TransactionBuilder};
     use crate::{
         address_utxoset::AddressUtxoSet,
-        types::{Network, OutPoint, Txid},
+        types::{OutPoint, Txid},
         unstable_blocks::UnstableBlocks,
     };
+    use ic_btc_interface::Network;
     use bitcoin::blockdata::{opcodes::all::OP_RETURN, script::Builder};
     use proptest::prelude::*;
     use std::collections::BTreeSet;

--- a/canister/src/validation.rs
+++ b/canister/src/validation.rs
@@ -66,9 +66,9 @@ mod test {
         state::{ingest_stable_blocks_into_utxoset, insert_block},
         test_utils::build_chain,
     };
+    use ic_btc_interface::Network;
     use proptest::prelude::*;
     use std::str::FromStr;
-    use ic_btc_interface::Network;
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(10))]

--- a/canister/src/validation.rs
+++ b/canister/src/validation.rs
@@ -65,10 +65,10 @@ mod test {
     use crate::{
         state::{ingest_stable_blocks_into_utxoset, insert_block},
         test_utils::build_chain,
-        types::Network,
     };
     use proptest::prelude::*;
     use std::str::FromStr;
+    use ic_btc_interface::Network;
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(10))]


### PR DESCRIPTION
* Removes types in `canister/src/types.rs` that are already present in `ic_btc_interface`.
* Merges the `Network` and `NetworkSnakeCase` enums, as keeping both of them is redundant.