### PR TITLE
[DO NOT REVIEW] add watchdog canister

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,25 +951,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "futures-channel"
-version = "0.3.27"
+name = "futures"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-lite"
@@ -988,33 +1015,34 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.11",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1343,6 +1371,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-cdk"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9beb0bf1dcd0639c313630e34aa547a2b19450ddf1969c176e13225ef3b29048"
+dependencies = [
+ "candid 0.8.4",
+ "ic-cdk-macros 0.6.10",
+ "ic0",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "ic-cdk-macros"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +1410,20 @@ dependencies = [
  "serde",
  "serde_tokenstream",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ic-cdk-timers"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c739e7c592cb66df4f15c6b6c4859b1195782f63923e2fb1b29553d9c0819bd4"
+dependencies = [
+ "futures",
+ "ic-cdk 0.7.4",
+ "ic0",
+ "serde",
+ "serde_bytes",
+ "slotmap",
 ]
 
 [[package]]
@@ -2594,6 +2649,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slotmap"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3105,6 +3169,22 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "watchdog"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "candid 0.8.4",
+ "futures",
+ "hex",
+ "ic-cdk 0.6.10",
+ "ic-cdk-macros 0.6.10",
+ "ic-cdk-timers",
+ "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "canister",
     "interface",
     "validation",
+    "watchdog",
 
     # Crates for bootstrapping the state
     "bootstrap/state-builder",

--- a/watchdog/Cargo.toml
+++ b/watchdog/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "watchdog"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[[bin]]
+name = "watchdog"
+path = "src/main.rs"
+
+[dependencies]
+candid = "0.8.2"
+ic-cdk = "0.6.0"
+ic-cdk-macros = "0.6.0"
+ic-cdk-timers = "0.1"
+serde = { version = "1.0.158", features = [ "derive" ] }
+serde_json = "1.0.94"
+hex = "0.4.3"
+async-trait = "0.1.67"
+regex = "1.7.0"
+futures = "0.3.27"

--- a/watchdog/README.md
+++ b/watchdog/README.md
@@ -1,0 +1,65 @@
+# bitcoin-canister-watchdog
+
+Watchdog service for a bitcoin_canister that compares its latest block height against some bitcoin explorer APIs and decides if bitcoin_canister is healthy or not.
+
+Watchdog collects data via HTTP out calls with `timer_interval_secs` interval, it expects to get the data from at least `min_explorers` explorers. The status is `ok` if bitcoin_canister latest block height is within `blocks_behind_threshold` and `blocks_ahead_threshold` difference from a calculated pivot block height (currently a median from all the available explorers).
+
+## Commands
+
+```sh
+$ dfx stop
+
+$ dfx start --background  --clean
+
+$ dfx deploy watchdog
+
+...
+URLs:
+  Backend canister via Candid interface:
+    watchdog: http://127.0.0.1:4943/?canisterId=ryjl3-tyaaa-aaaaa-aaaba-cai&id=rrkah-fqaaa-aaaaa-aaaaq-cai
+```
+
+## API
+
+Actual health report:
+
+```json
+{
+    "config": {
+        "timer_interval_secs": 60,
+        "min_explorers": 2,
+        "blocks_ahead_threshold": 2,
+        "blocks_behind_threshold": -2,
+        "storage_ttl_millis": 300000
+    },
+    "status": {
+        "code": "ok",
+        "message": "Bitcoin canister block height is within the limits",
+        "height_diff": 0
+    },
+    "bitcoin_canister": 783338,
+    "pivot": [
+        "blockchain.info",
+        783338
+    ],
+    "explorers_n": 4,
+    "explorers": [
+        [
+            "api.blockcypher.com",
+            783338
+        ],
+        [
+            "blockchain.info",
+            783338
+        ],
+        [
+            "blockstream.info",
+            783338
+        ],
+        [
+            "chain.api.btc.com",
+            783338
+        ]
+    ]
+}
+```

--- a/watchdog/candid.did
+++ b/watchdog/candid.did
@@ -1,0 +1,42 @@
+type config = record {
+  timer_interval_secs: nat32;
+  min_explorers: nat32;
+  blocks_ahead_threshold: int32;
+  blocks_behind_threshold: int32;
+  storage_ttl_millis: nat64;
+};
+
+type status_code = variant {
+  ok;
+  behind;
+  ahead;
+  no_bitcoin_canister_data;
+  not_enough_explorers;
+  no_pivot_data;
+};
+
+type status = record {
+  code: status_code;
+  message: text;
+  height_diff: opt int32;
+};
+
+type block_height = nat64;
+type tuple_name_height = record {
+  text;
+  block_height;
+};
+
+type info = record {
+  config: config;
+  status: status;
+  bitcoin_canister: opt block_height;
+  pivot: opt tuple_name_height;
+  explorers_n: nat32;
+  explorers: vec tuple_name_height;
+};
+
+service : {
+  get_info: () -> (info) query;
+  get_info_json: () -> (text) query;
+}

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -1,0 +1,30 @@
+/// The configuration of the watchdog canister.
+use candid::CandidType;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, CandidType)]
+pub struct Config {
+    pub timer_interval_secs: u32,
+    pub min_explorers: u32,
+    pub blocks_ahead_threshold: i32,
+    pub blocks_behind_threshold: i32,
+    pub storage_ttl_millis: u64,
+    pub bitcoin_canister_host: String,
+}
+
+const ONE_SECOND: u64 = 1_000; // 10^3 milli-seconds in one second.
+const ONE_MINUTE: u64 = 60 * ONE_SECOND;
+
+impl Default for Config {
+    /// The default configuration.
+    fn default() -> Self {
+        Self {
+            timer_interval_secs: 60,
+            min_explorers: 2,
+            blocks_ahead_threshold: 2,
+            blocks_behind_threshold: -2,
+            storage_ttl_millis: 5 * ONE_MINUTE,
+            bitcoin_canister_host: "ghsi2-tqaaa-aaaan-aaaca-cai.raw.ic0.app".to_string(),
+        }
+    }
+}

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -24,6 +24,7 @@ impl Default for Config {
             blocks_ahead_threshold: 2,
             blocks_behind_threshold: -2,
             storage_ttl_millis: 5 * ONE_MINUTE,
+            // TODO: replace `raw.ic0.app` with a more secure alternative.
             bitcoin_canister_host: "ghsi2-tqaaa-aaaan-aaaca-cai.raw.ic0.app".to_string(),
         }
     }

--- a/watchdog/src/info.rs
+++ b/watchdog/src/info.rs
@@ -1,3 +1,4 @@
+use crate::config::Config;
 use crate::types::BlockHeight;
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
@@ -57,32 +58,6 @@ impl Status {
     }
 }
 
-/// The configuration of the watchdog canister.
-#[derive(Clone, Debug, Serialize, Deserialize, CandidType)]
-pub struct Config {
-    pub timer_interval_secs: u32,
-    pub min_explorers: u32,
-    pub blocks_ahead_threshold: i32,
-    pub blocks_behind_threshold: i32,
-    pub storage_ttl_millis: u64,
-}
-
-const ONE_SECOND: u64 = 1_000; // 10^3 milli-seconds in one second.
-const ONE_MINUTE: u64 = 60 * ONE_SECOND;
-
-impl Default for Config {
-    /// The default configuration.
-    fn default() -> Self {
-        Self {
-            timer_interval_secs: 60,
-            min_explorers: 2,
-            blocks_ahead_threshold: 2,
-            blocks_behind_threshold: -2,
-            storage_ttl_millis: 5 * ONE_MINUTE,
-        }
-    }
-}
-
 /// The information of the watchdog canister.
 #[derive(Debug, Serialize, Deserialize, CandidType, Clone)]
 pub struct Info {
@@ -120,7 +95,7 @@ impl Info {
             None => Status::new(StatusCode::NoBitcoinCanisterData, None),
             Some(bitcoin_canister_height) => {
                 if info.explorers_n < info.config.min_explorers {
-                    // No enough explorers.
+                    // Not enough explorers.
                     Status::new(StatusCode::NotEnoughExplorers, None)
                 } else {
                     match &info.pivot {

--- a/watchdog/src/info.rs
+++ b/watchdog/src/info.rs
@@ -1,0 +1,301 @@
+use crate::types::BlockHeight;
+use candid::CandidType;
+use serde::{Deserialize, Serialize};
+
+/// The status of the bitcoin_canister.
+#[derive(Debug, PartialEq, Serialize, Deserialize, CandidType, Clone)]
+enum StatusCode {
+    #[serde(rename = "undefined")]
+    Undefined = 0,
+    #[serde(rename = "ok")]
+    Ok = 1,
+    #[serde(rename = "behind")]
+    Behind = 2,
+    #[serde(rename = "ahead")]
+    Ahead = 3,
+    #[serde(rename = "no_bitcoin_canister_data")]
+    NoBitcoinCanisterData = 4,
+    #[serde(rename = "not_enough_explorers")]
+    NotEnoughExplorers = 5,
+    #[serde(rename = "no_pivot_data")]
+    NoPivotData = 6,
+}
+
+impl StatusCode {
+    /// The message of the status code.
+    fn message(&self) -> &'static str {
+        match self {
+            StatusCode::Undefined => "Undefined",
+            StatusCode::Ok => "Bitcoin canister block height is within the limits",
+            StatusCode::Behind => "Bitcoin canister block height is behind the pivot",
+            StatusCode::Ahead => "Bitcoin canister block height is ahead of the pivot",
+            StatusCode::NoBitcoinCanisterData => "No bitcoin_canister data",
+            StatusCode::NotEnoughExplorers => "Not enough explorers",
+            StatusCode::NoPivotData => "No pivot data",
+        }
+    }
+}
+
+/// The status of the bitcoin_canister.
+#[derive(Debug, Serialize, Deserialize, CandidType, Clone)]
+struct Status {
+    code: StatusCode,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    height_diff: Option<i32>,
+}
+
+impl Status {
+    pub fn new(code: StatusCode, height_diff: Option<i32>) -> Self {
+        let message = code.message().to_string();
+        Self {
+            code,
+            message,
+            height_diff,
+        }
+    }
+}
+
+/// The configuration of the watchdog canister.
+#[derive(Clone, Debug, Serialize, Deserialize, CandidType)]
+pub struct Config {
+    pub timer_interval_secs: u32,
+    pub min_explorers: u32,
+    pub blocks_ahead_threshold: i32,
+    pub blocks_behind_threshold: i32,
+    pub storage_ttl_millis: u64,
+}
+
+const ONE_SECOND: u64 = 1_000; // 10^3 milli-seconds in one second.
+const ONE_MINUTE: u64 = 60 * ONE_SECOND;
+
+impl Default for Config {
+    /// The default configuration.
+    fn default() -> Self {
+        Self {
+            timer_interval_secs: 60,
+            min_explorers: 2,
+            blocks_ahead_threshold: 2,
+            blocks_behind_threshold: -2,
+            storage_ttl_millis: 5 * ONE_MINUTE,
+        }
+    }
+}
+
+/// The information of the watchdog canister.
+#[derive(Debug, Serialize, Deserialize, CandidType, Clone)]
+pub struct Info {
+    config: Config,
+    status: Status,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    bitcoin_canister: Option<BlockHeight>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pivot: Option<(String, BlockHeight)>,
+    explorers_n: u32,
+    explorers: Vec<(String, BlockHeight)>,
+}
+
+impl Info {
+    pub fn new(
+        config: Config,
+        bitcoin_canister: Option<BlockHeight>,
+        explorers: Vec<(String, BlockHeight)>,
+    ) -> Self {
+        let explorers_n = explorers.len() as u32;
+        let info = Self {
+            config,
+            status: Status::new(StatusCode::Undefined, None),
+            bitcoin_canister,
+            pivot: median(explorers.clone()),
+            explorers_n,
+            explorers,
+        };
+
+        // Compute the status based on the given data (bitcoin_canister, explorers, pivot).
+        let status = match bitcoin_canister {
+            // No bitcoin_canister data.
+            None => Status::new(StatusCode::NoBitcoinCanisterData, None),
+            Some(bitcoin_canister_height) => {
+                if info.explorers_n < info.config.min_explorers {
+                    // No enough explorers.
+                    Status::new(StatusCode::NotEnoughExplorers, None)
+                } else {
+                    match &info.pivot {
+                        // No pivot data.
+                        None => Status::new(StatusCode::NoPivotData, None),
+                        Some((_name, pivot)) => {
+                            // All data is available.
+                            // Compute the difference between the bitcoin_canister height and the pivot.
+                            let diff = bitcoin_canister_height.get() as i32 - pivot.get() as i32;
+                            if diff < info.config.blocks_behind_threshold {
+                                Status::new(StatusCode::Behind, Some(diff))
+                            } else if diff > info.config.blocks_ahead_threshold {
+                                Status::new(StatusCode::Ahead, Some(diff))
+                            } else {
+                                Status::new(StatusCode::Ok, Some(diff))
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        Self { status, ..info }
+    }
+
+    pub fn as_json_str(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap()
+    }
+}
+
+/// The median of the given values.
+fn median<T: std::cmp::Ord + Clone>(mut values: Vec<T>) -> Option<T> {
+    let n = values.len();
+    if n == 0 {
+        None
+    } else {
+        values.sort();
+        let mid = if n % 2 == 0 { (n - 1) / 2 } else { n / 2 };
+        Some(values[mid].clone())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_median() {
+        assert_eq!(median::<u64>(vec![]), None);
+        assert_eq!(median(vec![1]), Some(1));
+        assert_eq!(median(vec![2, 1]), Some(1));
+        assert_eq!(median(vec![3, 2, 1]), Some(2));
+        assert_eq!(median(vec![4, 3, 2, 1]), Some(2));
+        assert_eq!(median(vec![5, 4, 3, 2, 1]), Some(3));
+
+        assert_eq!(
+            median(vec![
+                BlockHeight::new(3),
+                BlockHeight::new(2),
+                BlockHeight::new(1)
+            ]),
+            Some(BlockHeight::new(2))
+        );
+
+        assert_eq!(
+            median(vec![
+                ("ccc", BlockHeight::new(3)),
+                ("bbb", BlockHeight::new(2)),
+                ("aaa", BlockHeight::new(1)),
+            ]),
+            Some(("bbb", BlockHeight::new(2)))
+        );
+
+        assert_eq!(
+            median(vec![
+                ("ccc", BlockHeight::new(2)),
+                ("bbb", BlockHeight::new(2)),
+                ("aaa", BlockHeight::new(2)),
+            ]),
+            Some(("bbb", BlockHeight::new(2)))
+        );
+
+        assert_eq!(
+            median(vec![
+                ("ccc".to_string(), BlockHeight::new(2)),
+                ("bbb".to_string(), BlockHeight::new(2)),
+                ("aaa".to_string(), BlockHeight::new(2)),
+            ]),
+            Some(("bbb".to_string(), BlockHeight::new(2)))
+        );
+    }
+
+    #[test]
+    fn test_info_status_ok() {
+        let config = Config::default();
+        let bitcoin_canister_height = BlockHeight::new(9);
+        let explorers = vec![
+            ("ccc".to_string(), BlockHeight::new(12)),
+            ("bbb".to_string(), BlockHeight::new(11)),
+            ("aaa".to_string(), BlockHeight::new(10)),
+        ];
+
+        let info = Info::new(config, Some(bitcoin_canister_height), explorers);
+
+        assert_eq!(info.status.code, StatusCode::Ok);
+    }
+
+    #[test]
+    fn test_info_status_no_bitcoin_canister_data() {
+        let config = Config::default();
+        let explorers = vec![
+            ("ccc".to_string(), BlockHeight::new(12)),
+            ("bbb".to_string(), BlockHeight::new(11)),
+            ("aaa".to_string(), BlockHeight::new(10)),
+        ];
+
+        let info = Info::new(config, None, explorers);
+
+        assert_eq!(info.status.code, StatusCode::NoBitcoinCanisterData);
+    }
+
+    #[test]
+    fn test_info_status_not_enough_explorers() {
+        let config = Config::default();
+        let bitcoin_canister_height = BlockHeight::new(11);
+        let explorers = vec![("aaa".to_string(), BlockHeight::new(10))];
+
+        let info = Info::new(config, Some(bitcoin_canister_height), explorers);
+
+        assert_eq!(info.status.code, StatusCode::NotEnoughExplorers);
+    }
+
+    #[test]
+    fn test_info_status_ahead() {
+        let config = Config::default();
+        let bitcoin_canister_height = BlockHeight::new(15);
+        let explorers = vec![
+            ("ccc".to_string(), BlockHeight::new(12)),
+            ("bbb".to_string(), BlockHeight::new(11)),
+            ("aaa".to_string(), BlockHeight::new(10)),
+        ];
+
+        let info = Info::new(config, Some(bitcoin_canister_height), explorers);
+
+        assert_eq!(info.status.code, StatusCode::Ahead);
+        assert_eq!(info.status.height_diff, Some(4));
+    }
+
+    #[test]
+    fn test_info_status_behind() {
+        let config = Config::default();
+        let bitcoin_canister_height = BlockHeight::new(5);
+        let explorers = vec![
+            ("ccc".to_string(), BlockHeight::new(12)),
+            ("bbb".to_string(), BlockHeight::new(11)),
+            ("aaa".to_string(), BlockHeight::new(10)),
+        ];
+
+        let info = Info::new(config, Some(bitcoin_canister_height), explorers);
+
+        assert_eq!(info.status.code, StatusCode::Behind);
+        assert_eq!(info.status.height_diff, Some(-6));
+    }
+
+    #[test]
+    fn test_info_status_no_pivot_data() {
+        let config = Config {
+            min_explorers: 0,
+            ..Config::default()
+        };
+        let bitcoin_canister_height = BlockHeight::new(5);
+        let explorers = vec![];
+
+        let info = Info::new(config, Some(bitcoin_canister_height), explorers);
+
+        assert_eq!(info.status.code, StatusCode::NoPivotData);
+    }
+}

--- a/watchdog/src/lib.rs
+++ b/watchdog/src/lib.rs
@@ -1,12 +1,11 @@
+mod config;
 mod info;
 mod remote_api;
 mod time;
 mod types;
 
-// #[cfg(not(target_arch = "wasm32"))]
-// mod ic_http_mock;
-
-pub use crate::info::{Config, Info};
+pub use crate::config::Config;
+pub use crate::info::Info;
 
 use futures::future::{join_all, BoxFuture};
 use remote_api::{

--- a/watchdog/src/lib.rs
+++ b/watchdog/src/lib.rs
@@ -1,0 +1,65 @@
+mod info;
+mod remote_api;
+mod time;
+mod types;
+
+// #[cfg(not(target_arch = "wasm32"))]
+// mod ic_http_mock;
+
+pub use crate::info::{Config, Info};
+
+use futures::future::{join_all, BoxFuture};
+use remote_api::{
+    ApiBlockcypherCom, BitcoinCanister, BlockchainInfo, BlockstreamInfo, ChainApiBtcCom,
+};
+
+#[cfg(target_arch = "wasm32")]
+pub fn print(msg: &str) {
+    ic_cdk::api::print(msg);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn print(msg: &str) {
+    println!("{}", msg);
+}
+
+/// Fetches the latest block height from the remote APIs.
+pub async fn tick_async() {
+    print("tick_async...");
+
+    let futures: Vec<BoxFuture<_>> = vec![
+        //Box::pin(ApiBitapsCom::fetch()),  // TODO: investigate why it lags behind.
+        Box::pin(ApiBlockcypherCom::fetch()),
+        Box::pin(BitcoinCanister::fetch()),
+        Box::pin(BlockchainInfo::fetch()),
+        Box::pin(BlockstreamInfo::fetch()),
+        Box::pin(ChainApiBtcCom::fetch()),
+    ];
+    join_all(futures).await;
+}
+
+/// Returns the health info report based on the latest block heights.
+pub fn get_info() -> Info {
+    let mut heights = vec![];
+    // if let Some(height) = ApiBitapsCom::get_height() {
+    //    heights.push((ApiBitapsCom::host(), height));
+    // }
+    if let Some(height) = ApiBlockcypherCom::get_height() {
+        heights.push((ApiBlockcypherCom::host(), height));
+    }
+    if let Some(height) = BlockchainInfo::get_height() {
+        heights.push((BlockchainInfo::host(), height));
+    }
+    if let Some(height) = BlockstreamInfo::get_height() {
+        heights.push((BlockstreamInfo::host(), height));
+    }
+    if let Some(height) = ChainApiBtcCom::get_height() {
+        heights.push((ChainApiBtcCom::host(), height));
+    }
+    let heights = heights
+        .into_iter()
+        .map(|(n, h)| (n.to_string(), h))
+        .collect();
+
+    Info::new(Config::default(), BitcoinCanister::get_height(), heights)
+}

--- a/watchdog/src/lib.rs
+++ b/watchdog/src/lib.rs
@@ -10,7 +10,8 @@ pub use crate::info::{Config, Info};
 
 use futures::future::{join_all, BoxFuture};
 use remote_api::{
-    ApiBlockcypherCom, BitcoinCanister, BlockchainInfo, BlockstreamInfo, ChainApiBtcCom,
+    ApiBlockchairCom, ApiBlockcypherCom, BitcoinCanister, BlockchainInfo, BlockstreamInfo,
+    ChainApiBtcCom,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -29,6 +30,7 @@ pub async fn tick_async() {
 
     let futures: Vec<BoxFuture<_>> = vec![
         //Box::pin(ApiBitapsCom::fetch()),  // TODO: investigate why it lags behind.
+        Box::pin(ApiBlockchairCom::fetch()),
         Box::pin(ApiBlockcypherCom::fetch()),
         Box::pin(BitcoinCanister::fetch()),
         Box::pin(BlockchainInfo::fetch()),
@@ -44,6 +46,9 @@ pub fn get_info() -> Info {
     // if let Some(height) = ApiBitapsCom::get_height() {
     //    heights.push((ApiBitapsCom::host(), height));
     // }
+    if let Some(height) = ApiBlockchairCom::get_height() {
+        heights.push((ApiBlockchairCom::host(), height));
+    }
     if let Some(height) = ApiBlockcypherCom::get_height() {
         heights.push((ApiBlockcypherCom::host(), height));
     }

--- a/watchdog/src/main.rs
+++ b/watchdog/src/main.rs
@@ -1,0 +1,30 @@
+use watchdog::tick_async;
+use watchdog::{Config, Info};
+
+#[ic_cdk_macros::init]
+fn init() {
+    // Initialize the timer with the interval specified in the config.
+    let config = Config::default();
+    let interval = std::time::Duration::from_secs(config.timer_interval_secs as u64);
+    watchdog::print(&format!(
+        "Starting a periodic task with interval {interval:?}"
+    ));
+    ic_cdk_timers::set_timer_interval(interval, || ic_cdk::spawn(tick_async()));
+}
+
+#[ic_cdk_macros::post_upgrade]
+fn post_upgrade() {
+    init()
+}
+
+#[ic_cdk_macros::query]
+pub fn get_info() -> Info {
+    watchdog::get_info()
+}
+
+#[ic_cdk_macros::query]
+pub fn get_info_json() -> String {
+    watchdog::get_info().as_json_str()
+}
+
+fn main() {}

--- a/watchdog/src/remote_api/api_bitaps_com.rs
+++ b/watchdog/src/remote_api/api_bitaps_com.rs
@@ -18,8 +18,8 @@ pub struct ApiBitapsCom {}
 
 impl ApiBitapsCom {
     /// The host name of the remote API.
-    pub fn host() -> &'static str {
-        "api.bitaps.com"
+    pub fn host() -> String {
+        "api.bitaps.com".to_string()
     }
 
     /// The URL of the remote API.
@@ -30,12 +30,12 @@ impl ApiBitapsCom {
 
     /// Reads the block height from the local storage.
     pub fn get_height() -> Option<BlockHeight> {
-        storage::get(Self::host())
+        storage::get(&Self::host())
     }
 
     /// Stores the block height in the local storage.
     fn set_height(height: BlockHeight) {
-        storage::insert(Self::host(), height)
+        storage::insert(&Self::host(), height)
     }
 
     /// The transform function for the JSON body.

--- a/watchdog/src/remote_api/api_bitaps_com.rs
+++ b/watchdog/src/remote_api/api_bitaps_com.rs
@@ -1,0 +1,98 @@
+use crate::remote_api::http::{
+    apply_to_body_json, build_transform_context, create_request, fetch_body,
+};
+use crate::remote_api::storage;
+use crate::types::BlockHeight;
+use ic_cdk::api::management_canister::http_request::{
+    CanisterHttpRequestArgument, HttpResponse, TransformArgs,
+};
+use serde_json::json;
+
+/// The transform function for the remote API.
+#[ic_cdk_macros::query]
+fn transform_api_bitaps_com(raw: TransformArgs) -> HttpResponse {
+    apply_to_body_json(raw, ApiBitapsCom::transform)
+}
+
+pub struct ApiBitapsCom {}
+
+impl ApiBitapsCom {
+    /// The host name of the remote API.
+    pub fn host() -> &'static str {
+        "api.bitaps.com"
+    }
+
+    /// The URL of the remote API.
+    pub fn url() -> String {
+        let host = Self::host();
+        format!("https://{host}/btc/v1/blockchain/block/last")
+    }
+
+    /// Reads the block height from the local storage.
+    pub fn get_height() -> Option<BlockHeight> {
+        storage::get(Self::host())
+    }
+
+    /// Stores the block height in the local storage.
+    fn set_height(height: BlockHeight) {
+        storage::insert(Self::host(), height)
+    }
+
+    /// The transform function for the JSON body.
+    fn transform(json: serde_json::Value) -> serde_json::Value {
+        let empty = json!({});
+        match json
+            .get("data")
+            .unwrap_or(&empty)
+            .get("height")
+            .and_then(BlockHeight::from_json)
+        {
+            Some(x) => x.as_json(),
+            None => empty,
+        }
+    }
+
+    /// Creates the HTTP request.
+    fn create_request() -> CanisterHttpRequestArgument {
+        create_request(
+            Self::host(),
+            Self::url(),
+            None,
+            Some(build_transform_context(transform_api_bitaps_com, vec![])),
+        )
+    }
+
+    /// Fetches the block height from the remote API and stores it in the local storage.
+    pub async fn fetch() {
+        let request = Self::create_request();
+        let body = fetch_body(request).await;
+
+        match body {
+            Err(_) => (),
+            Ok(body) => match BlockHeight::from_string(body) {
+                None => (),
+                Some(height) => {
+                    Self::set_height(height);
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_request_url() {
+        assert_eq!(
+            ApiBitapsCom::create_request().url,
+            "https://api.bitaps.com/btc/v1/blockchain/block/last"
+        );
+    }
+
+    #[test]
+    fn test_has_transform() {
+        assert!(ApiBitapsCom::create_request().transform.is_some());
+    }
+}

--- a/watchdog/src/remote_api/api_blockchair_com.rs
+++ b/watchdog/src/remote_api/api_blockchair_com.rs
@@ -1,0 +1,101 @@
+use crate::remote_api::http::{
+    apply_to_body_json, build_transform_context, create_request, fetch_body,
+};
+use crate::remote_api::storage;
+use crate::types::BlockHeight;
+use ic_cdk::api::management_canister::http_request::{
+    CanisterHttpRequestArgument, HttpResponse, TransformArgs,
+};
+use serde_json::json;
+
+/// The transform function for the remote API.
+#[ic_cdk_macros::query]
+fn transform_api_blockchair_com(raw: TransformArgs) -> HttpResponse {
+    apply_to_body_json(raw, ApiBlockchairCom::transform)
+}
+
+pub struct ApiBlockchairCom {}
+
+impl ApiBlockchairCom {
+    /// The host name of the remote API.
+    pub fn host() -> &'static str {
+        "api.blockchair.com"
+    }
+
+    /// The URL of the remote API.
+    pub fn url() -> String {
+        let host = Self::host();
+        format!("https://{host}/bitcoin/stats")
+    }
+
+    /// Reads the block height from the local storage.
+    pub fn get_height() -> Option<BlockHeight> {
+        storage::get(Self::host())
+    }
+
+    /// Stores the block height in the local storage.
+    fn set_height(height: BlockHeight) {
+        storage::insert(Self::host(), height)
+    }
+
+    /// The transform function for the JSON body.
+    fn transform(json: serde_json::Value) -> serde_json::Value {
+        let empty = json!({});
+        match json
+            .get("data")
+            .unwrap_or(&empty)
+            .get("best_block_height")
+            .and_then(BlockHeight::from_json)
+        {
+            Some(x) => x.as_json(),
+            None => empty,
+        }
+    }
+
+    /// Creates the HTTP request.
+    fn create_request() -> CanisterHttpRequestArgument {
+        create_request(
+            Self::host(),
+            Self::url(),
+            None,
+            Some(build_transform_context(
+                transform_api_blockchair_com,
+                vec![],
+            )),
+        )
+    }
+
+    /// Fetches the block height from the remote API and stores it in the local storage.
+    pub async fn fetch() {
+        let request = Self::create_request();
+        let body = fetch_body(request).await;
+
+        match body {
+            Err(_) => (),
+            Ok(body) => match BlockHeight::from_string(body) {
+                None => (),
+                Some(height) => {
+                    Self::set_height(height);
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_request_url() {
+        assert_eq!(
+            ApiBlockchairCom::create_request().url,
+            "https://api.blockchair.com/bitcoin/stats"
+        );
+    }
+
+    #[test]
+    fn test_has_transform() {
+        assert!(ApiBlockchairCom::create_request().transform.is_some());
+    }
+}

--- a/watchdog/src/remote_api/api_blockchair_com.rs
+++ b/watchdog/src/remote_api/api_blockchair_com.rs
@@ -18,8 +18,8 @@ pub struct ApiBlockchairCom {}
 
 impl ApiBlockchairCom {
     /// The host name of the remote API.
-    pub fn host() -> &'static str {
-        "api.blockchair.com"
+    pub fn host() -> String {
+        "api.blockchair.com".to_string()
     }
 
     /// The URL of the remote API.
@@ -30,12 +30,12 @@ impl ApiBlockchairCom {
 
     /// Reads the block height from the local storage.
     pub fn get_height() -> Option<BlockHeight> {
-        storage::get(Self::host())
+        storage::get(&Self::host())
     }
 
     /// Stores the block height in the local storage.
     fn set_height(height: BlockHeight) {
-        storage::insert(Self::host(), height)
+        storage::insert(&Self::host(), height)
     }
 
     /// The transform function for the JSON body.

--- a/watchdog/src/remote_api/api_blockcypher_com.rs
+++ b/watchdog/src/remote_api/api_blockcypher_com.rs
@@ -1,0 +1,95 @@
+use crate::remote_api::http::{
+    apply_to_body_json, build_transform_context, create_request, fetch_body,
+};
+use crate::remote_api::storage;
+use crate::types::BlockHeight;
+use ic_cdk::api::management_canister::http_request::{
+    CanisterHttpRequestArgument, HttpResponse, TransformArgs,
+};
+use serde_json::json;
+
+/// The transform function for the remote API.
+#[ic_cdk_macros::query]
+fn transform_api_block_cypher_com(raw: TransformArgs) -> HttpResponse {
+    apply_to_body_json(raw, ApiBlockcypherCom::transform)
+}
+pub struct ApiBlockcypherCom {}
+
+impl ApiBlockcypherCom {
+    /// The host name of the remote API.
+    pub fn host() -> &'static str {
+        "api.blockcypher.com"
+    }
+
+    /// The URL of the remote API.
+    pub fn url() -> String {
+        let host = Self::host();
+        format!("https://{host}/v1/btc/main")
+    }
+
+    /// Reads the block height from the local storage.
+    pub fn get_height() -> Option<BlockHeight> {
+        storage::get(Self::host())
+    }
+
+    /// Stores the block height in the local storage.
+    fn set_height(height: BlockHeight) {
+        storage::insert(Self::host(), height)
+    }
+
+    /// The transform function for the JSON body.
+    fn transform(json: serde_json::Value) -> serde_json::Value {
+        let empty = json!({});
+        match json.get("height").and_then(BlockHeight::from_json) {
+            Some(x) => x.as_json(),
+            None => empty,
+        }
+    }
+
+    /// Creates the HTTP request.
+    fn create_request() -> CanisterHttpRequestArgument {
+        create_request(
+            Self::host(),
+            Self::url(),
+            None,
+            Some(build_transform_context(
+                transform_api_block_cypher_com,
+                vec![],
+            )),
+        )
+    }
+
+    /// Fetches the block height from the remote API and stores it in the local storage.
+    pub async fn fetch() {
+        let request = Self::create_request();
+        let body = fetch_body(request).await;
+
+        match body {
+            Err(_) => (),
+            Ok(body) => match BlockHeight::from_string(body) {
+                None => (),
+                Some(height) => {
+                    Self::set_height(height);
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_request_url() {
+        assert_eq!(
+            ApiBlockcypherCom::create_request().url,
+            "https://api.blockcypher.com/v1/btc/main"
+        );
+    }
+
+    #[test]
+    fn test_has_transform() {
+        assert!(ApiBlockcypherCom::create_request().transform.is_some());
+    }
+}

--- a/watchdog/src/remote_api/api_blockcypher_com.rs
+++ b/watchdog/src/remote_api/api_blockcypher_com.rs
@@ -17,8 +17,8 @@ pub struct ApiBlockcypherCom {}
 
 impl ApiBlockcypherCom {
     /// The host name of the remote API.
-    pub fn host() -> &'static str {
-        "api.blockcypher.com"
+    pub fn host() -> String {
+        "api.blockcypher.com".to_string()
     }
 
     /// The URL of the remote API.
@@ -29,12 +29,12 @@ impl ApiBlockcypherCom {
 
     /// Reads the block height from the local storage.
     pub fn get_height() -> Option<BlockHeight> {
-        storage::get(Self::host())
+        storage::get(&Self::host())
     }
 
     /// Stores the block height in the local storage.
     fn set_height(height: BlockHeight) {
-        storage::insert(Self::host(), height)
+        storage::insert(&Self::host(), height)
     }
 
     /// The transform function for the JSON body.

--- a/watchdog/src/remote_api/bitcoin_canister.rs
+++ b/watchdog/src/remote_api/bitcoin_canister.rs
@@ -1,0 +1,123 @@
+use crate::remote_api::http::{build_transform_context, create_request, fetch_body};
+use crate::remote_api::storage;
+use crate::types::BlockHeight;
+use ic_cdk::api::management_canister::http_request::{
+    CanisterHttpRequestArgument, HttpResponse, TransformArgs,
+};
+use regex::Regex;
+use std::cell::RefCell;
+
+const RE_PATTERN: &str = r"\n\s*main_chain_height (\d+) \d+\n";
+
+// This is a thread-local storage for calculating the regex only once.
+thread_local! {
+    static REGEX: RefCell<Result<Regex, regex::Error>> = RefCell::new(Regex::new(RE_PATTERN));
+}
+
+/// Apply regex rule to a given text.
+fn apply(re: &Regex, text: &str) -> Result<String, String> {
+    match re.captures(text) {
+        None => Err("Regex: no match found.".to_string()),
+        Some(cap) => match cap.len() {
+            2 => Ok(String::from(&cap[1])),
+            x => Err(format!("Regex: expected 1 group exactly, provided {}.", x)),
+        },
+    }
+}
+
+/// The transform function for the remote API.
+#[ic_cdk_macros::query]
+fn transform_bitcoin_canister(raw: TransformArgs) -> HttpResponse {
+    let mut response = HttpResponse {
+        status: raw.response.status.clone(),
+        ..Default::default()
+    };
+    if response.status == 200 {
+        let body =
+            String::from_utf8(raw.response.body).expect("Raw response is not UTF-8 encoded.");
+        response.body = BitcoinCanister::transform(body).as_bytes().to_vec();
+    } else {
+        crate::print(&format!("Received an error: err = {:?}", raw));
+    }
+    response
+}
+
+pub struct BitcoinCanister {}
+
+impl BitcoinCanister {
+    /// The host of the remote API.
+    pub fn host() -> &'static str {
+        "ghsi2-tqaaa-aaaan-aaaca-cai.raw.ic0.app"
+    }
+
+    /// The URL of the remote API.
+    pub fn url() -> String {
+        let host = Self::host();
+        format!("https://{host}/metrics")
+    }
+
+    /// Reads the block height from the local storage.
+    pub fn get_height() -> Option<BlockHeight> {
+        storage::get(Self::host())
+    }
+
+    /// Stores the block height in the local storage.
+    fn set_height(height: BlockHeight) {
+        storage::insert(Self::host(), height)
+    }
+
+    /// The transform function for the text body.
+    fn transform(text: String) -> String {
+        match REGEX.with(|x| x.borrow().clone()) {
+            Err(_) => String::new(),
+            Ok(re) => match apply(&re, &text) {
+                Err(_) => String::new(),
+                Ok(height) => height,
+            },
+        }
+    }
+
+    /// Creates a request to the remote API.
+    fn create_request() -> CanisterHttpRequestArgument {
+        create_request(
+            Self::host(),
+            Self::url(),
+            None,
+            Some(build_transform_context(transform_bitcoin_canister, vec![])),
+        )
+    }
+
+    /// Fetches the block height from the remote API and stores it in the local storage.
+    pub async fn fetch() {
+        let request = Self::create_request();
+        let body = fetch_body(request).await;
+
+        match body {
+            Err(_) => (),
+            Ok(body) => match BlockHeight::from_string(body) {
+                None => (),
+                Some(height) => {
+                    Self::set_height(height);
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_request_url() {
+        assert_eq!(
+            BitcoinCanister::create_request().url,
+            "https://ghsi2-tqaaa-aaaan-aaaca-cai.raw.ic0.app/metrics"
+        );
+    }
+
+    #[test]
+    fn test_has_transform() {
+        assert!(BitcoinCanister::create_request().transform.is_some());
+    }
+}

--- a/watchdog/src/remote_api/bitcoin_canister.rs
+++ b/watchdog/src/remote_api/bitcoin_canister.rs
@@ -1,3 +1,4 @@
+use crate::config::Config;
 use crate::remote_api::http::{build_transform_context, create_request, fetch_body};
 use crate::remote_api::storage;
 use crate::types::BlockHeight;
@@ -46,8 +47,8 @@ pub struct BitcoinCanister {}
 
 impl BitcoinCanister {
     /// The host of the remote API.
-    pub fn host() -> &'static str {
-        "ghsi2-tqaaa-aaaan-aaaca-cai.raw.ic0.app"
+    pub fn host() -> String {
+        Config::default().bitcoin_canister_host
     }
 
     /// The URL of the remote API.
@@ -58,12 +59,12 @@ impl BitcoinCanister {
 
     /// Reads the block height from the local storage.
     pub fn get_height() -> Option<BlockHeight> {
-        storage::get(Self::host())
+        storage::get(&Self::host())
     }
 
     /// Stores the block height in the local storage.
     fn set_height(height: BlockHeight) {
-        storage::insert(Self::host(), height)
+        storage::insert(&Self::host(), height)
     }
 
     /// The transform function for the text body.

--- a/watchdog/src/remote_api/blockchain_info.rs
+++ b/watchdog/src/remote_api/blockchain_info.rs
@@ -1,0 +1,68 @@
+use crate::remote_api::http::{create_request, fetch_body};
+use crate::remote_api::storage;
+use crate::types::BlockHeight;
+use ic_cdk::api::management_canister::http_request::CanisterHttpRequestArgument;
+
+pub struct BlockchainInfo {}
+
+impl BlockchainInfo {
+    /// The host name of the remote API.
+    pub fn host() -> &'static str {
+        "blockchain.info"
+    }
+
+    /// The URL of the remote API.
+    pub fn url() -> String {
+        let host = Self::host();
+        format!("https://{host}/q/getblockcount")
+    }
+
+    /// Reads the block height from the local storage.
+    pub fn get_height() -> Option<BlockHeight> {
+        storage::get(Self::host())
+    }
+
+    /// Stores the block height in the local storage.
+    fn set_height(height: BlockHeight) {
+        storage::insert(Self::host(), height)
+    }
+
+    /// Creates the HTTP request.
+    fn create_request() -> CanisterHttpRequestArgument {
+        create_request(Self::host(), Self::url(), None, None)
+    }
+
+    /// Fetches the block height from the remote API and stores it in the local storage.
+    pub async fn fetch() {
+        let request = Self::create_request();
+        let body = fetch_body(request).await;
+
+        match body {
+            Err(_) => (),
+            Ok(body) => match BlockHeight::from_string(body) {
+                None => (),
+                Some(height) => {
+                    Self::set_height(height);
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_request_url() {
+        assert_eq!(
+            BlockchainInfo::create_request().url,
+            "https://blockchain.info/q/getblockcount"
+        );
+    }
+
+    #[test]
+    fn test_has_no_transform() {
+        assert!(BlockchainInfo::create_request().transform.is_none());
+    }
+}

--- a/watchdog/src/remote_api/blockchain_info.rs
+++ b/watchdog/src/remote_api/blockchain_info.rs
@@ -7,8 +7,8 @@ pub struct BlockchainInfo {}
 
 impl BlockchainInfo {
     /// The host name of the remote API.
-    pub fn host() -> &'static str {
-        "blockchain.info"
+    pub fn host() -> String {
+        "blockchain.info".to_string()
     }
 
     /// The URL of the remote API.
@@ -19,12 +19,12 @@ impl BlockchainInfo {
 
     /// Reads the block height from the local storage.
     pub fn get_height() -> Option<BlockHeight> {
-        storage::get(Self::host())
+        storage::get(&Self::host())
     }
 
     /// Stores the block height in the local storage.
     fn set_height(height: BlockHeight) {
-        storage::insert(Self::host(), height)
+        storage::insert(&Self::host(), height)
     }
 
     /// Creates the HTTP request.

--- a/watchdog/src/remote_api/blockstream_info.rs
+++ b/watchdog/src/remote_api/blockstream_info.rs
@@ -7,8 +7,8 @@ pub struct BlockstreamInfo {}
 
 impl BlockstreamInfo {
     /// The host name of the remote API.
-    pub fn host() -> &'static str {
-        "blockstream.info"
+    pub fn host() -> String {
+        "blockstream.info".to_string()
     }
 
     /// The URL of the remote API.
@@ -19,12 +19,12 @@ impl BlockstreamInfo {
 
     /// Reads the block height from the local storage.
     pub fn get_height() -> Option<BlockHeight> {
-        storage::get(Self::host())
+        storage::get(&Self::host())
     }
 
     /// Stores the block height in the local storage.
     fn set_height(height: BlockHeight) {
-        storage::insert(Self::host(), height)
+        storage::insert(&Self::host(), height)
     }
 
     /// Creates the HTTP request.

--- a/watchdog/src/remote_api/blockstream_info.rs
+++ b/watchdog/src/remote_api/blockstream_info.rs
@@ -1,0 +1,68 @@
+use crate::remote_api::http::{create_request, fetch_body};
+use crate::remote_api::storage;
+use crate::types::BlockHeight;
+use ic_cdk::api::management_canister::http_request::CanisterHttpRequestArgument;
+
+pub struct BlockstreamInfo {}
+
+impl BlockstreamInfo {
+    /// The host name of the remote API.
+    pub fn host() -> &'static str {
+        "blockstream.info"
+    }
+
+    /// The URL of the remote API.
+    pub fn url() -> String {
+        let host = Self::host();
+        format!("https://{host}/api/blocks/tip/height")
+    }
+
+    /// Reads the block height from the local storage.
+    pub fn get_height() -> Option<BlockHeight> {
+        storage::get(Self::host())
+    }
+
+    /// Stores the block height in the local storage.
+    fn set_height(height: BlockHeight) {
+        storage::insert(Self::host(), height)
+    }
+
+    /// Creates the HTTP request.
+    fn create_request() -> CanisterHttpRequestArgument {
+        create_request(Self::host(), Self::url(), None, None)
+    }
+
+    /// Fetches the block height from the remote API and stores it in the local storage.
+    pub async fn fetch() {
+        let request = Self::create_request();
+        let body = fetch_body(request).await;
+
+        match body {
+            Err(_) => (),
+            Ok(body) => match BlockHeight::from_string(body) {
+                None => (),
+                Some(height) => {
+                    Self::set_height(height);
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_request_url() {
+        assert_eq!(
+            BlockstreamInfo::create_request().url,
+            "https://blockstream.info/api/blocks/tip/height"
+        );
+    }
+
+    #[test]
+    fn test_has_no_transform() {
+        assert!(BlockstreamInfo::create_request().transform.is_none());
+    }
+}

--- a/watchdog/src/remote_api/chain_api_btc_com.rs
+++ b/watchdog/src/remote_api/chain_api_btc_com.rs
@@ -18,8 +18,8 @@ fn transform_chain_api_btc_com(raw: TransformArgs) -> HttpResponse {
 
 impl ChainApiBtcCom {
     /// The host name of the remote API.
-    pub fn host() -> &'static str {
-        "chain.api.btc.com"
+    pub fn host() -> String {
+        "chain.api.btc.com".to_string()
     }
 
     /// The URL of the remote API.
@@ -30,12 +30,12 @@ impl ChainApiBtcCom {
 
     /// Reads the block height from the local storage.
     pub fn get_height() -> Option<BlockHeight> {
-        storage::get(Self::host())
+        storage::get(&Self::host())
     }
 
     /// Stores the block height in the local storage.
     fn set_height(height: BlockHeight) {
-        storage::insert(Self::host(), height)
+        storage::insert(&Self::host(), height)
     }
 
     /// The transform function for the JSON body.

--- a/watchdog/src/remote_api/chain_api_btc_com.rs
+++ b/watchdog/src/remote_api/chain_api_btc_com.rs
@@ -1,0 +1,98 @@
+use crate::remote_api::http::{
+    apply_to_body_json, build_transform_context, create_request, fetch_body,
+};
+use crate::remote_api::storage;
+use crate::types::BlockHeight;
+use ic_cdk::api::management_canister::http_request::{
+    CanisterHttpRequestArgument, HttpResponse, TransformArgs,
+};
+use serde_json::json;
+
+pub struct ChainApiBtcCom {}
+
+/// The transform function for the remote API.
+#[ic_cdk_macros::query]
+fn transform_chain_api_btc_com(raw: TransformArgs) -> HttpResponse {
+    apply_to_body_json(raw, ChainApiBtcCom::transform)
+}
+
+impl ChainApiBtcCom {
+    /// The host name of the remote API.
+    pub fn host() -> &'static str {
+        "chain.api.btc.com"
+    }
+
+    /// The URL of the remote API.
+    pub fn url() -> String {
+        let host = Self::host();
+        format!("https://{host}/v3/block/latest")
+    }
+
+    /// Reads the block height from the local storage.
+    pub fn get_height() -> Option<BlockHeight> {
+        storage::get(Self::host())
+    }
+
+    /// Stores the block height in the local storage.
+    fn set_height(height: BlockHeight) {
+        storage::insert(Self::host(), height)
+    }
+
+    /// The transform function for the JSON body.
+    fn transform(json: serde_json::Value) -> serde_json::Value {
+        let empty = json!({});
+        match json
+            .get("data")
+            .unwrap_or(&empty)
+            .get("height")
+            .and_then(BlockHeight::from_json)
+        {
+            Some(x) => x.as_json(),
+            None => empty,
+        }
+    }
+
+    /// Creates the HTTP request.
+    fn create_request() -> CanisterHttpRequestArgument {
+        create_request(
+            Self::host(),
+            Self::url(),
+            None,
+            Some(build_transform_context(transform_chain_api_btc_com, vec![])),
+        )
+    }
+
+    /// Fetches the block height from the remote API and stores it in the local storage.
+    pub async fn fetch() {
+        let request = Self::create_request();
+        let body = fetch_body(request).await;
+
+        match body {
+            Err(_) => (),
+            Ok(body) => match BlockHeight::from_string(body) {
+                None => (),
+                Some(height) => {
+                    Self::set_height(height);
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_request_url() {
+        assert_eq!(
+            ChainApiBtcCom::create_request().url,
+            "https://chain.api.btc.com/v3/block/latest"
+        );
+    }
+
+    #[test]
+    fn test_has_transform() {
+        assert!(ChainApiBtcCom::create_request().transform.is_some());
+    }
+}

--- a/watchdog/src/remote_api/http.rs
+++ b/watchdog/src/remote_api/http.rs
@@ -78,7 +78,7 @@ pub async fn fetch_body(request: CanisterHttpRequestArgument) -> Result<String, 
 
 /// Creates a CanisterHttpRequestArgument.
 pub fn create_request(
-    host: &str,
+    host: String,
     url: String,
     max_response_bytes: Option<u64>,
     transform: Option<TransformContext>,

--- a/watchdog/src/remote_api/http.rs
+++ b/watchdog/src/remote_api/http.rs
@@ -1,0 +1,125 @@
+use crate::print;
+use candid::Principal;
+use ic_cdk::api::call::RejectionCode;
+use ic_cdk::api::management_canister::http_request::{
+    CanisterHttpRequestArgument, HttpHeader, HttpMethod, HttpResponse, TransformArgs,
+    TransformContext, TransformFunc,
+};
+
+/// The result of a Call.
+///
+/// Errors on the IC have two components; a Code and a message associated with it.
+pub type CallResult<R> = Result<R, (RejectionCode, String)>;
+
+/// Calls the http_request function.
+pub async fn http_request(arg: CanisterHttpRequestArgument) -> CallResult<(HttpResponse,)> {
+    ic_cdk::api::management_canister::http_request::http_request(arg).await
+}
+
+// TODO: remove after switching to ic-http-mock.
+pub type TransformFn = fn(TransformArgs) -> HttpResponse;
+
+// TODO: update the content after switching to ic-http-mock.
+/// A mock for the TransformContext.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn build_transform_context(func: TransformFn, context: Vec<u8>) -> TransformContext {
+    fn get_function_name<F>(_: F) -> &'static str {
+        let full_name = std::any::type_name::<F>();
+        match full_name.rfind(':') {
+            Some(index) => &full_name[index + 1..],
+            None => full_name,
+        }
+    }
+
+    let function_name = get_function_name(func).to_string();
+    TransformContext {
+        function: TransformFunc(candid::Func {
+            principal: Principal::anonymous(),
+            method: function_name,
+        }),
+        context,
+    }
+}
+
+/// Creates a TransformContext.
+#[cfg(target_arch = "wasm32")]
+pub fn build_transform_context<T>(func: T, context: Vec<u8>) -> TransformContext
+where
+    T: Fn(TransformArgs) -> HttpResponse,
+{
+    TransformContext::new(func, context)
+}
+
+/// Performs a http_request and returns the body of the response.
+pub async fn fetch_body(request: CanisterHttpRequestArgument) -> Result<String, String> {
+    match http_request(request).await {
+        Ok((response,)) => {
+            if response.status == 200 {
+                let body = String::from_utf8(response.body)
+                    .expect("Transformed response is not UTF-8 encoded.");
+                Ok(body)
+            } else {
+                let message = format!(
+                    "The http_request resulted into error with status: {:?}",
+                    response.status
+                );
+                print(&message);
+                Err(message)
+            }
+        }
+        Err((r, m)) => {
+            let message =
+                format!("The http_request resulted into error. RejectionCode: {r:?}, Error: {m}");
+            print(&message);
+            Err(message)
+        }
+    }
+}
+
+/// Creates a CanisterHttpRequestArgument.
+pub fn create_request(
+    host: &str,
+    url: String,
+    max_response_bytes: Option<u64>,
+    transform: Option<TransformContext>,
+) -> CanisterHttpRequestArgument {
+    CanisterHttpRequestArgument {
+        url,
+        method: HttpMethod::GET,
+        body: None,
+        max_response_bytes,
+        transform,
+        headers: vec![
+            HttpHeader {
+                name: "Host".to_string(),
+                value: format!("{host}:443"),
+            },
+            HttpHeader {
+                name: "User-Agent".to_string(),
+                value: "bitcoin_watchdog_canister".to_string(),
+            },
+        ],
+    }
+}
+
+/// Applies a function to the body of the response assuming it contains JSON.
+pub fn apply_to_body_json(
+    raw: TransformArgs,
+    function: fn(serde_json::Value) -> serde_json::Value,
+) -> HttpResponse {
+    let mut response = HttpResponse {
+        status: raw.response.status.clone(),
+        ..Default::default()
+    };
+    if response.status == 200 {
+        let body =
+            String::from_utf8(raw.response.body).expect("Raw response is not UTF-8 encoded.");
+        let original = serde_json::from_str(body.as_str())
+            .unwrap_or_else(|_| panic!("Can't parse JSON from a raw response, body={}", body));
+        let modified = function(original);
+        response.body = modified.to_string().as_bytes().to_vec();
+    } else {
+        print(&format!("Received an error: err = {:?}", raw));
+    }
+    response
+}

--- a/watchdog/src/remote_api/mod.rs
+++ b/watchdog/src/remote_api/mod.rs
@@ -36,7 +36,7 @@ pub enum RemoteAPI {
 
 impl RemoteAPI {
     /// The host name of the remote API.
-    fn host(&self) -> &'static str {
+    fn host(&self) -> String {
         match self {
             RemoteAPI::ApiBitapsCom => ApiBitapsCom::host(),
             RemoteAPI::ApiBlockchairCom => ApiBlockchairCom::host(),
@@ -67,7 +67,7 @@ mod test {
             (ChainApiBtcCom, "chain.api.btc.com"),
         ];
         for (variant, host) in test_cases {
-            assert_eq!(variant.host(), host);
+            assert_eq!(variant.host(), host.to_string());
         }
     }
 }

--- a/watchdog/src/remote_api/mod.rs
+++ b/watchdog/src/remote_api/mod.rs
@@ -4,6 +4,9 @@ mod storage;
 mod api_bitaps_com;
 pub use api_bitaps_com::ApiBitapsCom;
 
+mod api_blockchair_com;
+pub use api_blockchair_com::ApiBlockchairCom;
+
 mod api_blockcypher_com;
 pub use api_blockcypher_com::ApiBlockcypherCom;
 
@@ -23,6 +26,7 @@ pub use chain_api_btc_com::ChainApiBtcCom;
 #[derive(Eq, PartialEq, Debug)]
 pub enum RemoteAPI {
     ApiBitapsCom,
+    ApiBlockchairCom,
     ApiBlockcypherCom,
     BitcoinCanister,
     BlockchainInfo,
@@ -35,6 +39,7 @@ impl RemoteAPI {
     fn host(&self) -> &'static str {
         match self {
             RemoteAPI::ApiBitapsCom => ApiBitapsCom::host(),
+            RemoteAPI::ApiBlockchairCom => ApiBlockchairCom::host(),
             RemoteAPI::ApiBlockcypherCom => ApiBlockcypherCom::host(),
             RemoteAPI::BitcoinCanister => BitcoinCanister::host(),
             RemoteAPI::BlockchainInfo => BlockchainInfo::host(),
@@ -54,6 +59,7 @@ mod test {
 
         let test_cases = [
             (ApiBitapsCom, "api.bitaps.com"),
+            (ApiBlockchairCom, "api.blockchair.com"),
             (ApiBlockcypherCom, "api.blockcypher.com"),
             (BitcoinCanister, "ghsi2-tqaaa-aaaan-aaaca-cai.raw.ic0.app"),
             (BlockchainInfo, "blockchain.info"),

--- a/watchdog/src/remote_api/mod.rs
+++ b/watchdog/src/remote_api/mod.rs
@@ -1,0 +1,67 @@
+mod http;
+mod storage;
+
+mod api_bitaps_com;
+pub use api_bitaps_com::ApiBitapsCom;
+
+mod api_blockcypher_com;
+pub use api_blockcypher_com::ApiBlockcypherCom;
+
+mod bitcoin_canister;
+pub use bitcoin_canister::BitcoinCanister;
+
+mod blockchain_info;
+pub use blockchain_info::BlockchainInfo;
+
+mod blockstream_info;
+pub use blockstream_info::BlockstreamInfo;
+
+mod chain_api_btc_com;
+pub use chain_api_btc_com::ChainApiBtcCom;
+
+/// The remote APIs.
+#[derive(Eq, PartialEq, Debug)]
+pub enum RemoteAPI {
+    ApiBitapsCom,
+    ApiBlockcypherCom,
+    BitcoinCanister,
+    BlockchainInfo,
+    BlockstreamInfo,
+    ChainApiBtcCom,
+}
+
+impl RemoteAPI {
+    /// The host name of the remote API.
+    fn host(&self) -> &'static str {
+        match self {
+            RemoteAPI::ApiBitapsCom => ApiBitapsCom::host(),
+            RemoteAPI::ApiBlockcypherCom => ApiBlockcypherCom::host(),
+            RemoteAPI::BitcoinCanister => BitcoinCanister::host(),
+            RemoteAPI::BlockchainInfo => BlockchainInfo::host(),
+            RemoteAPI::BlockstreamInfo => BlockstreamInfo::host(),
+            RemoteAPI::ChainApiBtcCom => ChainApiBtcCom::host(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_to_string() {
+        use RemoteAPI::*;
+
+        let test_cases = [
+            (ApiBitapsCom, "api.bitaps.com"),
+            (ApiBlockcypherCom, "api.blockcypher.com"),
+            (BitcoinCanister, "ghsi2-tqaaa-aaaan-aaaca-cai.raw.ic0.app"),
+            (BlockchainInfo, "blockchain.info"),
+            (BlockstreamInfo, "blockstream.info"),
+            (ChainApiBtcCom, "chain.api.btc.com"),
+        ];
+        for (variant, host) in test_cases {
+            assert_eq!(variant.host(), host);
+        }
+    }
+}

--- a/watchdog/src/remote_api/storage.rs
+++ b/watchdog/src/remote_api/storage.rs
@@ -1,0 +1,43 @@
+use crate::info::Config;
+use crate::time;
+use crate::types::BlockHeight;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::time::Duration;
+
+#[derive(Copy, Clone)]
+struct Entry {
+    insertion_time: time::CanisterUptime,
+
+    height: BlockHeight,
+}
+
+// This is a thread-local storage for the remote API data.
+thread_local! {
+    static STORAGE: RefCell<HashMap<String, Entry>> = RefCell::default();
+}
+
+/// Inserts a new entry into the storage.
+pub(crate) fn insert(key: &str, height: BlockHeight) {
+    let entry = Entry {
+        insertion_time: time::now(),
+        height,
+    };
+    STORAGE.with(|cell| cell.borrow_mut().insert(key.to_string(), entry));
+}
+
+/// Returns the entry from the storage.
+pub(crate) fn get(key: &str) -> Option<BlockHeight> {
+    let entry = STORAGE.with(|cell| cell.borrow().get(&key.to_string()).copied());
+    match entry {
+        None => None, // No data found.
+        Some(e) => {
+            let elapsed = time::now() - e.insertion_time;
+            if elapsed > Duration::from_millis(Config::default().storage_ttl_millis) {
+                None // Drop stale data.
+            } else {
+                Some(e.height)
+            }
+        }
+    }
+}

--- a/watchdog/src/remote_api/storage.rs
+++ b/watchdog/src/remote_api/storage.rs
@@ -1,4 +1,4 @@
-use crate::info::Config;
+use crate::config::Config;
 use crate::time;
 use crate::types::BlockHeight;
 use std::cell::RefCell;

--- a/watchdog/src/time.rs
+++ b/watchdog/src/time.rs
@@ -1,0 +1,49 @@
+use std::time::Duration;
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::cell::RefCell;
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
+
+#[cfg(not(target_arch = "wasm32"))]
+thread_local! {
+    /// Canister inner uptime since start in nanoseconds.
+    static START: RefCell<Instant> = RefCell::new(Instant::now());
+}
+
+/// Canister inner uptime since start in nanoseconds.
+#[derive(Copy, Clone)]
+pub struct CanisterUptime(u128);
+
+impl CanisterUptime {
+    fn from_nanos(nanos: u128) -> Self {
+        CanisterUptime(nanos)
+    }
+}
+
+impl std::ops::Sub<CanisterUptime> for CanisterUptime {
+    type Output = Duration;
+
+    fn sub(self, other: CanisterUptime) -> Duration {
+        let lhs = self.0;
+        let rhs = other.0;
+        let sub = lhs - rhs;
+        Duration::from_nanos(sub as u64)
+    }
+}
+
+/// Canister inner uptime since start in nanoseconds.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn now() -> CanisterUptime {
+    let nanos = START.with(|cell| cell.borrow().elapsed().as_nanos());
+    CanisterUptime::from_nanos(nanos)
+}
+
+/// Canister inner uptime since start in nanoseconds.
+#[cfg(target_arch = "wasm32")]
+pub fn now() -> CanisterUptime {
+    // Current timestamp, in nanoseconds since the epoch (1970-01-01).
+    let nanos = ic_cdk::api::time();
+    CanisterUptime::from_nanos(nanos.into())
+}

--- a/watchdog/src/types.rs
+++ b/watchdog/src/types.rs
@@ -1,0 +1,30 @@
+use candid::CandidType;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(
+    Debug, PartialEq, PartialOrd, Ord, Eq, Clone, Copy, Serialize, Deserialize, CandidType,
+)]
+pub struct BlockHeight(u64);
+
+impl BlockHeight {
+    pub fn new(height: u64) -> Self {
+        Self(height)
+    }
+
+    pub fn get(&self) -> u64 {
+        self.0
+    }
+
+    pub fn from_json(json: &serde_json::Value) -> Option<Self> {
+        json.as_u64().map(Self::new)
+    }
+
+    pub fn as_json(&self) -> serde_json::Value {
+        json!(self.0)
+    }
+
+    pub fn from_string(str: String) -> Option<Self> {
+        str.parse::<u64>().map(Self::new).ok()
+    }
+}


### PR DESCRIPTION
DO NOT REVIEW: going to split this PR to separate fetching #177 & serving data.

This PR adds a watchdog_canister for checking bitcoin_canister height health.

Current implementation does not use `ic-http` for testing HTTP outcalls, should be added later.