### PR TITLE
chore: [EXC-1386] migrate block header store to new stable structures version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,7 +1284,8 @@ dependencies = [
  "ic-cdk 0.6.10",
  "ic-cdk-macros 0.6.10",
  "ic-metrics-encoder",
- "ic-stable-structures",
+ "ic-stable-structures 0.3.0",
+ "ic-stable-structures 0.5.2",
  "lazy_static",
  "maplit",
  "proptest",
@@ -1382,6 +1383,12 @@ name = "ic-stable-structures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cf57a7a43948acb3bc11572533f57e52f60cbbf33d7c699678ac9d1a9307537"
+
+[[package]]
+name = "ic-stable-structures"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d43ba7c5067d1360860e2234d93411d2126c8eac788467966ed1383161f91fc"
 
 [[package]]
 name = "ic-types"
@@ -2643,7 +2650,7 @@ dependencies = [
  "hex",
  "ic-btc-canister",
  "ic-btc-interface",
- "ic-stable-structures",
+ "ic-stable-structures 0.3.0",
  "integer-encoding",
  "rand 0.8.5",
  "rand_chacha 0.3.1",

--- a/bootstrap/main-state-builder/Cargo.lock
+++ b/bootstrap/main-state-builder/Cargo.lock
@@ -503,7 +503,8 @@ dependencies = [
  "ic-cdk",
  "ic-cdk-macros",
  "ic-metrics-encoder",
- "ic-stable-structures",
+ "ic-stable-structures 0.3.0",
+ "ic-stable-structures 0.5.2",
  "lazy_static",
  "serde",
  "serde_bytes",
@@ -564,6 +565,12 @@ name = "ic-stable-structures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cf57a7a43948acb3bc11572533f57e52f60cbbf33d7c699678ac9d1a9307537"
+
+[[package]]
+name = "ic-stable-structures"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d43ba7c5067d1360860e2234d93411d2126c8eac788467966ed1383161f91fc"
 
 [[package]]
 name = "ic0"
@@ -721,7 +728,7 @@ dependencies = [
  "hex",
  "ic-btc-canister",
  "ic-btc-interface",
- "ic-stable-structures",
+ "ic-stable-structures 0.3.0",
 ]
 
 [[package]]

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -18,6 +18,7 @@ ic-cdk = "0.6.1"
 ic-cdk-macros = "0.6.1"
 ic-metrics-encoder = "1.0.0"
 ic-stable-structures = "0.3.0"
+ic-stable-structures_new = { package = "ic-stable-structures", version = "0.5.2" }
 lazy_static = "1.4.0"
 serde = "1.0.132"
 serde_bytes = "0.11"

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -5,6 +5,7 @@ mod blocktree;
 mod guard;
 mod heartbeat;
 pub mod memory;
+mod memory_new;
 mod metrics;
 mod multi_iter;
 pub mod runtime;

--- a/canister/src/memory_new.rs
+++ b/canister/src/memory_new.rs
@@ -1,4 +1,4 @@
-//! A copy of memory.rs that is compatibly with the new version of stable-structures.
+//! A copy of memory.rs that is compatible with the new version of stable-structures.
 //! Once the migration to the new stable-structures version is complete, this file will
 //! fully replace memory.rs
 

--- a/canister/src/memory_new.rs
+++ b/canister/src/memory_new.rs
@@ -1,0 +1,53 @@
+//! A copy of memory.rs that is compatibly with the new version of stable-structures.
+//! Once the migration to the new stable-structures version is complete, this file will
+//! fully replace memory.rs
+
+use ic_stable_structures_new::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+#[cfg(not(feature = "file_memory"))]
+use ic_stable_structures_new::DefaultMemoryImpl;
+#[cfg(feature = "file_memory")]
+use ic_stable_structures_new::FileMemory;
+use std::cell::RefCell;
+
+const BLOCK_HEADERS: MemoryId = MemoryId::new(5);
+const BLOCK_HEIGHTS: MemoryId = MemoryId::new(6);
+
+#[cfg(feature = "file_memory")]
+type InnerMemory = FileMemory;
+
+#[cfg(not(feature = "file_memory"))]
+type InnerMemory = DefaultMemoryImpl;
+
+pub type Memory = VirtualMemory<InnerMemory>;
+
+#[cfg(feature = "file_memory")]
+thread_local! {
+    static MEMORY: RefCell<Option<InnerMemory>> = RefCell::new(None);
+
+    static MEMORY_MANAGER: RefCell<Option<MemoryManager<InnerMemory>>> = RefCell::new(None);
+}
+
+#[cfg(not(feature = "file_memory"))]
+thread_local! {
+    static MEMORY: RefCell<Option<InnerMemory>> = RefCell::new(Some(InnerMemory::default()));
+
+    static MEMORY_MANAGER: RefCell<Option<MemoryManager<InnerMemory>>> =
+        RefCell::new(Some(MemoryManager::init(MEMORY.with(|m| m.borrow().clone().unwrap()))));
+}
+
+fn with_memory_manager<R>(f: impl FnOnce(&MemoryManager<InnerMemory>) -> R) -> R {
+    MEMORY_MANAGER.with(|cell| {
+        f(cell
+            .borrow()
+            .as_ref()
+            .expect("memory manager not initialized"))
+    })
+}
+
+pub fn get_block_headers_memory() -> Memory {
+    with_memory_manager(|m| m.get(BLOCK_HEADERS))
+}
+
+pub fn get_block_heights_memory() -> Memory {
+    with_memory_manager(|m| m.get(BLOCK_HEIGHTS))
+}

--- a/canister/src/test_utils.rs
+++ b/canister/src/test_utils.rs
@@ -135,7 +135,7 @@ pub fn is_stable_btreemap_equal<M: Memory + Clone, K: Storable + Eq, V: Storable
 }
 
 // A version of `is_stable_btreemap_equal` for the new stable-structures version.
-// TODO: delete the old version once the migration to the new stable-structures is complete.
+// TODO(EXC-1382): delete the old version once the migration to the new stable-structures is complete.
 pub fn is_stable_btreemap_equal_new<
     M: ic_stable_structures_new::Memory,
     K: ic_stable_structures_new::BoundedStorable + Ord + Eq + Clone,

--- a/canister/src/test_utils.rs
+++ b/canister/src/test_utils.rs
@@ -134,6 +134,29 @@ pub fn is_stable_btreemap_equal<M: Memory + Clone, K: Storable + Eq, V: Storable
     true
 }
 
+// A version of `is_stable_btreemap_equal` for the new stable-structures version.
+// TODO: delete the old version once the migration to the new stable-structures is complete.
+pub fn is_stable_btreemap_equal_new<
+    M: ic_stable_structures_new::Memory,
+    K: ic_stable_structures_new::BoundedStorable + Ord + Eq + Clone,
+    V: ic_stable_structures_new::BoundedStorable + Eq,
+>(
+    a: &ic_stable_structures_new::StableBTreeMap<K, V, M>,
+    b: &ic_stable_structures_new::StableBTreeMap<K, V, M>,
+) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+
+    for (x, y) in a.iter().zip(b.iter()) {
+        if x != y {
+            return false;
+        }
+    }
+
+    true
+}
+
 /// A wrapper around `ic_btc_test_utils::BlockBuilder` that returns `crate::types::Block`
 /// as opposed to `bitcoin::Block`.
 pub struct BlockBuilder {

--- a/canister/src/unstable_blocks/next_block_hashes.rs
+++ b/canister/src/unstable_blocks/next_block_hashes.rs
@@ -56,15 +56,14 @@ impl NextBlockHashes {
 #[cfg(test)]
 mod test {
     use crate::{types::BlockHash, unstable_blocks::next_block_hashes::NextBlockHashes};
-    use ic_stable_structures::Storable;
 
     #[test]
     fn test_get_max_height() {
         let mut block_hashes: NextBlockHashes = Default::default();
 
         assert_eq!(block_hashes.get_max_height(), None);
-        let hash1 = BlockHash::from_bytes(vec![1; 32]);
-        let hash2 = BlockHash::from_bytes(vec![2; 32]);
+        let hash1 = BlockHash::from(vec![1; 32]);
+        let hash2 = BlockHash::from(vec![2; 32]);
         block_hashes.insert(&hash1, 5);
 
         assert_eq!(block_hashes.get_max_height(), Some(5));
@@ -87,7 +86,7 @@ mod test {
         let mut block_hashes: NextBlockHashes = Default::default();
 
         assert_eq!(block_hashes.get_max_height(), None);
-        let hash1 = BlockHash::from_bytes(vec![1; 32]);
+        let hash1 = BlockHash::from(vec![1; 32]);
 
         block_hashes.insert(&hash1, 5);
 
@@ -109,7 +108,7 @@ mod test {
             vec![hash1.clone()]
         );
 
-        let hash2 = BlockHash::from_bytes(vec![2; 32]);
+        let hash2 = BlockHash::from(vec![2; 32]);
 
         block_hashes.insert(&hash2, 5);
 
@@ -126,9 +125,9 @@ mod test {
         let mut block_hashes: NextBlockHashes = Default::default();
 
         assert_eq!(block_hashes.get_max_height(), None);
-        let hash1 = BlockHash::from_bytes(vec![1; 32]);
-        let hash2 = BlockHash::from_bytes(vec![2; 32]);
-        let hash3 = BlockHash::from_bytes(vec![5; 32]);
+        let hash1 = BlockHash::from(vec![1; 32]);
+        let hash2 = BlockHash::from(vec![2; 32]);
+        let hash3 = BlockHash::from(vec![5; 32]);
 
         block_hashes.insert(&hash1, 5);
         block_hashes.insert(&hash2, 5);
@@ -184,10 +183,10 @@ mod test {
         let mut block_hashes: NextBlockHashes = Default::default();
 
         assert_eq!(block_hashes.get_max_height(), None);
-        let hash1 = BlockHash::from_bytes(vec![1; 32]);
-        let hash2 = BlockHash::from_bytes(vec![2; 32]);
-        let hash3 = BlockHash::from_bytes(vec![5; 32]);
-        let hash4 = BlockHash::from_bytes(vec![7; 32]);
+        let hash1 = BlockHash::from(vec![1; 32]);
+        let hash2 = BlockHash::from(vec![2; 32]);
+        let hash3 = BlockHash::from(vec![5; 32]);
+        let hash4 = BlockHash::from(vec![7; 32]);
 
         block_hashes.insert(&hash1, 5);
         block_hashes.insert(&hash2, 5);

--- a/e2e-tests/profiling/scenario-1.txt
+++ b/e2e-tests/profiling/scenario-1.txt
@@ -1,11 +1,11 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 32202, ins_remove_inputs: 1013, ins_insert_outputs: 28755, ins_txids: 792, ins_insert_utxos: 26819 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6144888619, ins_remove_inputs: 2026, ins_insert_outputs: 6144881762, ins_txids: 7973410, ins_insert_utxos: 6128957438 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 15896666692, ins_remove_inputs: 10336957168, ins_insert_outputs: 5554777986, ins_txids: 9809495, ins_insert_utxos: 5533526239 }
-Ingest Block 3: BlockIngestionStats { num_rounds: 1, ins_total: 559949, ins_remove_inputs: 1013, ins_insert_outputs: 556502, ins_txids: 785, ins_insert_utxos: 554573 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 557366, ins_apply_unstable_blocks: 92928 }
-GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 454646, ins_apply_unstable_blocks: 47385 }
-GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 146177808, ins_apply_unstable_blocks: 34064728, ins_build_utxos_vec: 111489404 }
-GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 75885922, ins_apply_unstable_blocks: 70942035, ins_build_utxos_vec: 4318124 }
-GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 26915206, ins_apply_unstable_blocks: 26509980 }
-get_current_fee_percentiles: 40573758
-get_current_fee_percentiles: 307575
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 32253, ins_remove_inputs: 1141, ins_insert_outputs: 28651, ins_txids: 792, ins_insert_utxos: 26740 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 6145814932, ins_remove_inputs: 2282, ins_insert_outputs: 6145807778, ins_txids: 7973447, ins_insert_utxos: 6128983647 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 5, ins_total: 15896715307, ins_remove_inputs: 10338266254, ins_insert_outputs: 5553627421, ins_txids: 9809495, ins_insert_utxos: 5532626134 }
+Ingest Block 3: BlockIngestionStats { num_rounds: 1, ins_total: 547592, ins_remove_inputs: 1141, ins_insert_outputs: 543990, ins_txids: 792, ins_insert_utxos: 542079 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 415431, ins_apply_unstable_blocks: 9422 }
+GetBalanceRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", min_confirmations: Some(2) }: Stats { ins_total: 370867, ins_apply_unstable_blocks: 5629 }
+GetUtxosRequest { address: "bcrt1qxp8ercrmfxlu0s543najcj6fe6267j97tv7rgf", filter: None }: Stats { ins_total: 143264144, ins_apply_unstable_blocks: 33761076, ins_build_utxos_vec: 108929247 }
+GetUtxosRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", filter: None }: Stats { ins_total: 75958277, ins_apply_unstable_blocks: 70902197, ins_build_utxos_vec: 4494559 }
+GetBalanceRequest { address: "bcrt1qenhfslne5vdqld0djs0h0tfw225tkkzzc60exh", min_confirmations: None }: Stats { ins_total: 26785474, ins_apply_unstable_blocks: 26426474 }
+get_current_fee_percentiles: 40643494
+get_current_fee_percentiles: 241787

--- a/e2e-tests/profiling/scenario-2.txt
+++ b/e2e-tests/profiling/scenario-2.txt
@@ -1,6 +1,6 @@
-Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 34030, ins_remove_inputs: 1013, ins_insert_outputs: 30583, ins_txids: 792, ins_insert_utxos: 28647 }
-Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 4928579445, ins_remove_inputs: 10131013, ins_insert_outputs: 4913524091, ins_txids: 8210716, ins_insert_utxos: 4893872812 }
-Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5461730905, ins_remove_inputs: 10131013, ins_insert_outputs: 5446675551, ins_txids: 8210716, ins_insert_utxos: 5427024272 }
-Ingest Block 3: BlockIngestionStats { num_rounds: 2, ins_total: 5703279514, ins_remove_inputs: 10131013, ins_insert_outputs: 5688224160, ins_txids: 8210716, ins_insert_utxos: 5668572881 }
-GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 26706405, ins_apply_unstable_blocks: 26294392 }
-GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 75406328, ins_apply_unstable_blocks: 70053018, ins_build_utxos_vec: 4714942 }
+Ingest Block 0: BlockIngestionStats { num_rounds: 1, ins_total: 33496, ins_remove_inputs: 1141, ins_insert_outputs: 29894, ins_txids: 792, ins_insert_utxos: 27983 }
+Ingest Block 1: BlockIngestionStats { num_rounds: 2, ins_total: 4928599510, ins_remove_inputs: 11411141, ins_insert_outputs: 4912373976, ins_txids: 8210716, ins_insert_utxos: 4892972812 }
+Ingest Block 2: BlockIngestionStats { num_rounds: 2, ins_total: 5461750970, ins_remove_inputs: 11411141, ins_insert_outputs: 5445525436, ins_txids: 8210716, ins_insert_utxos: 5426124272 }
+Ingest Block 3: BlockIngestionStats { num_rounds: 2, ins_total: 5703299579, ins_remove_inputs: 11411141, ins_insert_outputs: 5687074045, ins_txids: 8210716, ins_insert_utxos: 5667672881 }
+GetBalanceRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", min_confirmations: None }: Stats { ins_total: 26675864, ins_apply_unstable_blocks: 26252658 }
+GetUtxosRequest { address: "bcrt1qg4cvn305es3k8j69x06t9hf4v5yx4mxdaeazl8", filter: None }: Stats { ins_total: 75309070, ins_apply_unstable_blocks: 69959705, ins_build_utxos_vec: 4756804 }


### PR DESCRIPTION
While we don't strictly need to upgrade stable structures, staying up to date will give us access to new features/enhancements in that library.

The upgrade to the new stable structures version is being done incrementally. While this approach has the downside of us having to copy some parts of the code to accommodate two versions of stable structures, it does have advantages:

* Changes are smaller and are easier to review.
* Changes in performance are more finely measured, allowing us to more easily detect and understand where performance regressions come from.