### PR TITLE
fix: fix mocking concurrent http requests with transform functions in ic-http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,7 @@ name = "canister_backend"
 version = "0.1.0"
 dependencies = [
  "candid 0.8.4",
+ "futures",
  "ic-cdk 0.6.10",
  "ic-cdk-macros 0.6.10",
  "ic-http",

--- a/ic-http/example_canister/src/canister_backend/Cargo.toml
+++ b/ic-http/example_canister/src/canister_backend/Cargo.toml
@@ -19,3 +19,4 @@ serde_json = "1.0.94"
 
 [dev-dependencies]
 tokio = { version = "1.15.0", features = [ "full" ] }
+futures = "0.3.27"

--- a/ic-http/example_canister/src/canister_backend/canister_backend.did
+++ b/ic-http/example_canister/src/canister_backend/canister_backend.did
@@ -1,3 +1,4 @@
 service : {
-    "fetch": () -> (text);
-}
+    fetch_quote : () -> (text);
+    fetch_user : () -> (text);
+};

--- a/ic-http/example_canister/src/canister_backend/src/main.rs
+++ b/ic-http/example_canister/src/canister_backend/src/main.rs
@@ -18,7 +18,7 @@ fn parse_json(body: Vec<u8>) -> serde_json::Value {
     serde_json::from_str(&json_str).expect("Failed to parse JSON from string")
 }
 
-/// Apply a transform function to the HTTP response.
+/// Apply a transform function to the quote HTTP response.
 #[ic_cdk_macros::query]
 fn transform_quote(raw: TransformArgs) -> HttpResponse {
     let mut response = HttpResponse {
@@ -40,7 +40,7 @@ fn transform_quote(raw: TransformArgs) -> HttpResponse {
     response
 }
 
-/// Create a request to the dummyjson.com API.
+/// Create a request to the dummyjson.com API for quotes.
 fn build_quote_request(url: &str) -> CanisterHttpRequestArgument {
     ic_http::create_request()
         .get(url)
@@ -52,6 +52,7 @@ fn build_quote_request(url: &str) -> CanisterHttpRequestArgument {
         .build()
 }
 
+/// Fetch data by making an HTTP request.
 async fn fetch(request: CanisterHttpRequestArgument) -> String {
     let result = ic_http::http_request(request).await;
 
@@ -73,6 +74,7 @@ async fn fetch_quote() -> String {
     fetch(request).await
 }
 
+/// Apply a transform function to the user HTTP response.
 #[ic_cdk_macros::query]
 fn transform_user(raw: TransformArgs) -> HttpResponse {
     let mut response = HttpResponse {
@@ -94,6 +96,7 @@ fn transform_user(raw: TransformArgs) -> HttpResponse {
     response
 }
 
+/// Create a request to the dummyjson.com API for users.
 fn build_user_request(url: &str) -> CanisterHttpRequestArgument {
     ic_http::create_request()
         .get(url)
@@ -105,6 +108,7 @@ fn build_user_request(url: &str) -> CanisterHttpRequestArgument {
         .build()
 }
 
+/// Fetch a user from the dummyjson.com API.
 #[ic_cdk_macros::update]
 async fn fetch_user() -> String {
     let request = build_user_request("https://dummyjson.com/users/1");
@@ -118,7 +122,7 @@ mod test {
     use super::*;
 
     #[tokio::test]
-    async fn test_http_request_transform_body() {
+    async fn test_http_request_transform_body_quote() {
         // Arrange.
         let request = build_quote_request("https://dummyjson.com/quotes/1");
         let mock_response = ic_http::create_response()
@@ -145,7 +149,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_http_request_transform_body_for_many() {
+    async fn test_http_request_transform_body_for_both_quote_and_user() {
         // Arrange.
         let input = [
             (

--- a/ic-http/example_canister/src/canister_backend/src/main.rs
+++ b/ic-http/example_canister/src/canister_backend/src/main.rs
@@ -20,7 +20,7 @@ fn parse_json(body: Vec<u8>) -> serde_json::Value {
 
 /// Apply a transform function to the HTTP response.
 #[ic_cdk_macros::query]
-fn transform(raw: TransformArgs) -> HttpResponse {
+fn transform_quote(raw: TransformArgs) -> HttpResponse {
     let mut response = HttpResponse {
         status: raw.response.status.clone(),
         ..Default::default()
@@ -41,21 +41,18 @@ fn transform(raw: TransformArgs) -> HttpResponse {
 }
 
 /// Create a request to the dummyjson.com API.
-fn build_request() -> CanisterHttpRequestArgument {
+fn build_quote_request(url: &str) -> CanisterHttpRequestArgument {
     ic_http::create_request()
-        .get("https://dummyjson.com/quotes/1")
+        .get(url)
         .header(HttpHeader {
             name: "User-Agent".to_string(),
             value: "ic-http-example-canister".to_string(),
         })
-        .transform_func(transform, vec![])
+        .transform_func(transform_quote, vec![])
         .build()
 }
 
-/// Fetch a quote from the dummyjson.com API.
-#[ic_cdk_macros::update]
-async fn fetch() -> String {
-    let request = build_request();
+async fn fetch(request: CanisterHttpRequestArgument) -> String {
     let result = ic_http::http_request(request).await;
 
     match result {
@@ -69,6 +66,51 @@ async fn fetch() -> String {
     }
 }
 
+/// Fetch a quote from the dummyjson.com API.
+#[ic_cdk_macros::update]
+async fn fetch_quote() -> String {
+    let request = build_quote_request("https://dummyjson.com/quotes/1");
+    fetch(request).await
+}
+
+#[ic_cdk_macros::query]
+fn transform_user(raw: TransformArgs) -> HttpResponse {
+    let mut response = HttpResponse {
+        status: raw.response.status.clone(),
+        ..Default::default()
+    };
+    if response.status == 200 {
+        let original = parse_json(raw.response.body);
+
+        // Extract the firstName from the JSON response.
+        print(&format!("Before transform: {:?}", original.to_string()));
+        let transformed = original.get("firstName").cloned().unwrap_or_default();
+        print(&format!("After transform: {:?}", transformed.to_string()));
+
+        response.body = transformed.to_string().into_bytes();
+    } else {
+        print(&format!("Transform error: err = {:?}", raw));
+    }
+    response
+}
+
+fn build_user_request(url: &str) -> CanisterHttpRequestArgument {
+    ic_http::create_request()
+        .get(url)
+        .header(HttpHeader {
+            name: "User-Agent".to_string(),
+            value: "ic-http-example-canister".to_string(),
+        })
+        .transform_func(transform_user, vec![])
+        .build()
+}
+
+#[ic_cdk_macros::update]
+async fn fetch_user() -> String {
+    let request = build_user_request("https://dummyjson.com/users/1");
+    fetch(request).await
+}
+
 fn main() {}
 
 #[cfg(test)]
@@ -77,8 +119,8 @@ mod test {
 
     #[tokio::test]
     async fn test_http_request_transform_body() {
-        // Arrange
-        let request = build_request();
+        // Arrange.
+        let request = build_quote_request("https://dummyjson.com/quotes/1");
         let mock_response = ic_http::create_response()
             .status(200)
             .body(
@@ -91,14 +133,58 @@ mod test {
             .build();
         ic_http::mock::mock(request.clone(), mock_response);
 
-        // Act
+        // Act.
         let (response,) = ic_http::http_request(request.clone()).await.unwrap();
 
-        // Assert
+        // Assert.
         assert_eq!(
             String::from_utf8(response.body).unwrap(),
             r#""Kevin Kruse""#.to_string()
         );
         assert_eq!(ic_http::mock::times_called(request), 1);
+    }
+
+    #[tokio::test]
+    async fn test_http_request_transform_body_for_many() {
+        // Arrange.
+        let input = [
+            (
+                build_quote_request("https://dummyjson.com/quotes/1"),
+                r#"{ "id": 1, "author": "AAA", "quote": "quote_from_aaa"}"#,
+            ),
+            (
+                build_user_request("https://dummyjson.com/users/2"),
+                r#"{ "id": 2, "firstName": "BBB", "lastName": "last_name_for_bbb"}"#,
+            ),
+        ];
+        for (request, body) in &input {
+            ic_http::mock::mock(
+                request.clone(),
+                ic_http::create_response().status(200).body(body).build(),
+            );
+        }
+
+        // Act.
+        let futures: Vec<_> = input
+            .into_iter()
+            .map(|(request, _)| ic_http::http_request(request))
+            .collect();
+        let results = futures::future::join_all(futures).await;
+        let responses: Vec<_> = results
+            .into_iter()
+            .filter(|result| result.is_ok())
+            .map(|result| result.unwrap().0)
+            .collect();
+
+        // Assert.
+        assert_eq!(responses.len(), 2);
+        assert_eq!(
+            String::from_utf8(responses[0].body.clone()).unwrap(),
+            r#""AAA""#.to_string()
+        );
+        assert_eq!(
+            String::from_utf8(responses[1].body.clone()).unwrap(),
+            r#""BBB""#.to_string()
+        );
     }
 }

--- a/ic-http/src/lib.rs
+++ b/ic-http/src/lib.rs
@@ -125,23 +125,29 @@ pub mod mock;
 pub use crate::http_request::http_request;
 pub use crate::request::create_request;
 pub use crate::response::create_response;
-pub use crate::transform::TransformFn;
 
-use crate::mock::{hash, Mock};
-use ic_cdk::api::management_canister::http_request::CanisterHttpRequestArgument;
-use std::collections::HashMap;
-use std::sync::RwLock;
+#[cfg(not(target_arch = "wasm32"))]
+use {
+    crate::mock::{hash, Mock},
+    crate::transform::TransformFn,
+    ic_cdk::api::management_canister::http_request::CanisterHttpRequestArgument,
+    ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs},
+    std::collections::HashMap,
+    std::sync::RwLock,
+};
 
 // A thread-local hashmap.
+#[cfg(not(target_arch = "wasm32"))]
 thread_local! {
     /// A thread-local hashmap of mocks.
     static MOCKS: RwLock<HashMap<String, Mock>> = RwLock::new(HashMap::new());
 
     /// A thread-local hashmap of transform functions.
-    static TRANSFORM_FUNCTIONS: RwLock<HashMap<String, TransformFn>> = RwLock::new(HashMap::new());
+    static TRANSFORM_FUNCTIONS: RwLock<HashMap<String, Box<TransformFn>>> = RwLock::new(HashMap::new());
 }
 
 /// Inserts the provided mock into a thread-local hashmap.
+#[cfg(not(target_arch = "wasm32"))]
 fn mock_insert(mock: Mock) {
     MOCKS.with(|cell| {
         cell.write().unwrap().insert(hash(&mock.request), mock);
@@ -149,18 +155,38 @@ fn mock_insert(mock: Mock) {
 }
 
 /// Returns a cloned mock from the thread-local hashmap that corresponds to the provided request.
+#[cfg(not(target_arch = "wasm32"))]
 fn mock_get(request: &CanisterHttpRequestArgument) -> Option<Mock> {
     MOCKS.with(|cell| cell.read().unwrap().get(&hash(request)).cloned())
 }
 
 /// Inserts the provided transform function into a thread-local hashmap.
-fn transform_function_insert(function_name: String, func: TransformFn) {
+/// If a transform function with the same name already exists, it is not inserted.
+#[cfg(not(target_arch = "wasm32"))]
+fn transform_function_insert(name: String, func: Box<TransformFn>) {
     TRANSFORM_FUNCTIONS.with(|cell| {
-        cell.write().unwrap().insert(function_name, func);
+        // This is a workaround to prevent the transform function from being
+        // overridden when it might be used by another async call.
+        if cell.read().unwrap().get(&name).is_none() {
+            cell.write().unwrap().insert(name, func);
+        }
     });
 }
 
-/// Returns a cloned transform function from the thread-local hashmap.
-fn transform_function_get(function_name: String) -> Option<TransformFn> {
-    TRANSFORM_FUNCTIONS.with(|cell| cell.read().unwrap().get(&function_name).cloned())
+/// Executes the transform function that corresponds to the provided name.
+#[cfg(not(target_arch = "wasm32"))]
+fn transform_function_call(name: String, arg: TransformArgs) -> Option<HttpResponse> {
+    TRANSFORM_FUNCTIONS.with(|cell| cell.read().unwrap().get(&name).map(|f| f(arg)))
+}
+
+/// Returns a sorted list of transform function names.
+/// This is used for testing.
+#[allow(dead_code)]
+#[cfg(not(target_arch = "wasm32"))]
+fn transform_function_names() -> Vec<String> {
+    TRANSFORM_FUNCTIONS.with(|cell| {
+        let mut names: Vec<String> = cell.read().unwrap().keys().cloned().collect();
+        names.sort();
+        names
+    })
 }

--- a/ic-http/src/lib.rs
+++ b/ic-http/src/lib.rs
@@ -181,7 +181,6 @@ fn transform_function_call(name: String, arg: TransformArgs) -> Option<HttpRespo
 
 /// Returns a sorted list of transform function names.
 /// This is used for testing.
-#[allow(dead_code)]
 #[cfg(not(target_arch = "wasm32"))]
 fn transform_function_names() -> Vec<String> {
     TRANSFORM_FUNCTIONS.with(|cell| {

--- a/ic-http/src/lib.rs
+++ b/ic-http/src/lib.rs
@@ -117,6 +117,9 @@ mod request;
 mod response;
 mod transform;
 
+#[cfg(not(target_arch = "wasm32"))]
+mod storage;
+
 // Export.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod mock;
@@ -125,67 +128,3 @@ pub mod mock;
 pub use crate::http_request::http_request;
 pub use crate::request::create_request;
 pub use crate::response::create_response;
-
-#[cfg(not(target_arch = "wasm32"))]
-use {
-    crate::mock::{hash, Mock},
-    crate::transform::TransformFn,
-    ic_cdk::api::management_canister::http_request::CanisterHttpRequestArgument,
-    ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs},
-    std::collections::HashMap,
-    std::sync::RwLock,
-};
-
-// A thread-local hashmap.
-#[cfg(not(target_arch = "wasm32"))]
-thread_local! {
-    /// A thread-local hashmap of mocks.
-    static MOCKS: RwLock<HashMap<String, Mock>> = RwLock::new(HashMap::new());
-
-    /// A thread-local hashmap of transform functions.
-    static TRANSFORM_FUNCTIONS: RwLock<HashMap<String, Box<TransformFn>>> = RwLock::new(HashMap::new());
-}
-
-/// Inserts the provided mock into a thread-local hashmap.
-#[cfg(not(target_arch = "wasm32"))]
-fn mock_insert(mock: Mock) {
-    MOCKS.with(|cell| {
-        cell.write().unwrap().insert(hash(&mock.request), mock);
-    });
-}
-
-/// Returns a cloned mock from the thread-local hashmap that corresponds to the provided request.
-#[cfg(not(target_arch = "wasm32"))]
-fn mock_get(request: &CanisterHttpRequestArgument) -> Option<Mock> {
-    MOCKS.with(|cell| cell.read().unwrap().get(&hash(request)).cloned())
-}
-
-/// Inserts the provided transform function into a thread-local hashmap.
-/// If a transform function with the same name already exists, it is not inserted.
-#[cfg(not(target_arch = "wasm32"))]
-fn transform_function_insert(name: String, func: Box<TransformFn>) {
-    TRANSFORM_FUNCTIONS.with(|cell| {
-        // This is a workaround to prevent the transform function from being
-        // overridden when it might be used by another async call.
-        if cell.read().unwrap().get(&name).is_none() {
-            cell.write().unwrap().insert(name, func);
-        }
-    });
-}
-
-/// Executes the transform function that corresponds to the provided name.
-#[cfg(not(target_arch = "wasm32"))]
-fn transform_function_call(name: String, arg: TransformArgs) -> Option<HttpResponse> {
-    TRANSFORM_FUNCTIONS.with(|cell| cell.read().unwrap().get(&name).map(|f| f(arg)))
-}
-
-/// Returns a sorted list of transform function names.
-/// This is used for testing.
-#[cfg(not(target_arch = "wasm32"))]
-fn transform_function_names() -> Vec<String> {
-    TRANSFORM_FUNCTIONS.with(|cell| {
-        let mut names: Vec<String> = cell.read().unwrap().keys().cloned().collect();
-        names.sort();
-        names
-    })
-}

--- a/ic-http/src/mock.rs
+++ b/ic-http/src/mock.rs
@@ -69,20 +69,18 @@ pub(crate) async fn http_request(
     }
 
     // Apply the transform function if one is specified.
-    let transform = match request.transform {
-        Some(ref t) => crate::transform_function_call(
-            t.function.0.method.clone(),
-            TransformArgs {
-                response: mock.response.clone(),
-                context: vec![],
-            },
-        ),
-        None => None,
-    };
-    let transformed_response = match transform {
-        Some(response) => response,
-        None => mock.response.clone(),
-    };
+    let transformed_response = request
+        .transform
+        .and_then(|t| {
+            crate::transform_function_call(
+                t.function.0.method,
+                TransformArgs {
+                    response: mock.response.clone(),
+                    context: vec![],
+                },
+            )
+        })
+        .unwrap_or_else(|| mock.response.clone());
 
     Ok((transformed_response,))
 }

--- a/ic-http/src/mock.rs
+++ b/ic-http/src/mock.rs
@@ -80,7 +80,7 @@ pub(crate) async fn http_request(
                 },
             )
         })
-        .unwrap_or_else(|| mock.response.clone());
+        .unwrap_or(mock.response.clone());
 
     Ok((transformed_response,))
 }

--- a/ic-http/src/mock.rs
+++ b/ic-http/src/mock.rs
@@ -93,6 +93,11 @@ pub fn times_called(request: CanisterHttpRequestArgument) -> u64 {
         .unwrap_or(0)
 }
 
+/// Returns a sorted list of registered transform function names.
+pub fn registered_transform_function_names() -> Vec<String> {
+    crate::transform_function_names()
+}
+
 /// Create a hash from a `CanisterHttpRequestArgument`, which includes its URL,
 /// method, headers, body, and optionally, its transform function name.
 /// This is because `CanisterHttpRequestArgument` does not have `Hash` implemented.

--- a/ic-http/src/mock.rs
+++ b/ic-http/src/mock.rs
@@ -70,14 +70,17 @@ pub(crate) async fn http_request(
 
     // Apply the transform function if one is specified.
     let transform = match request.transform {
-        Some(ref t) => crate::transform_function_get(t.function.0.method.clone()),
+        Some(ref t) => crate::transform_function_call(
+            t.function.0.method.clone(),
+            TransformArgs {
+                response: mock.response.clone(),
+                context: vec![],
+            },
+        ),
         None => None,
     };
     let transformed_response = match transform {
-        Some(function) => function(TransformArgs {
-            response: mock.response.clone(),
-            context: vec![],
-        }),
+        Some(response) => response,
         None => mock.response.clone(),
     };
 

--- a/ic-http/src/mock.rs
+++ b/ic-http/src/mock.rs
@@ -28,7 +28,7 @@ pub fn mock_with_delay(
     response: HttpResponse,
     delay: Duration,
 ) {
-    crate::mock_insert(Mock {
+    crate::storage::mock_insert(Mock {
         request,
         response,
         delay,
@@ -42,10 +42,10 @@ pub fn mock_with_delay(
 pub(crate) async fn http_request(
     request: CanisterHttpRequestArgument,
 ) -> Result<(HttpResponse,), (RejectionCode, String)> {
-    let mut mock = crate::mock_get(&request)
+    let mut mock = crate::storage::mock_get(&request)
         .ok_or((RejectionCode::CanisterReject, "No mock found".to_string()))?;
     mock.times_called += 1;
-    crate::mock_insert(mock.clone());
+    crate::storage::mock_insert(mock.clone());
 
     // Delay the response if necessary.
     if mock.delay > Duration::from_secs(0) {
@@ -72,7 +72,7 @@ pub(crate) async fn http_request(
     let transformed_response = request
         .transform
         .and_then(|t| {
-            crate::transform_function_call(
+            crate::storage::transform_function_call(
                 t.function.0.method,
                 TransformArgs {
                     response: mock.response.clone(),
@@ -88,14 +88,14 @@ pub(crate) async fn http_request(
 /// Returns the number of times the given request has been called.
 /// Returns 0 if no mock has been found for the request.
 pub fn times_called(request: CanisterHttpRequestArgument) -> u64 {
-    crate::mock_get(&request)
+    crate::storage::mock_get(&request)
         .map(|mock| mock.times_called)
         .unwrap_or(0)
 }
 
 /// Returns a sorted list of registered transform function names.
 pub fn registered_transform_function_names() -> Vec<String> {
-    crate::transform_function_names()
+    crate::storage::transform_function_names()
 }
 
 /// Create a hash from a `CanisterHttpRequestArgument`, which includes its URL,

--- a/ic-http/src/request.rs
+++ b/ic-http/src/request.rs
@@ -1,6 +1,7 @@
-use crate::transform::{create_transform_context, TransformFn};
+use crate::transform::create_transform_context;
 use ic_cdk::api::management_canister::http_request::{
-    CanisterHttpRequestArgument, HttpHeader, HttpMethod, TransformContext,
+    CanisterHttpRequestArgument, HttpHeader, HttpMethod, HttpResponse, TransformArgs,
+    TransformContext,
 };
 
 /// Creates a new `HttpRequestBuilder` to construct an HTTP request.
@@ -72,16 +73,9 @@ impl HttpRequestBuilder {
         self
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn transform_func(mut self, func: TransformFn, context: Vec<u8>) -> Self {
-        self.transform = Some(create_transform_context(func, context));
-        self
-    }
-
-    #[cfg(target_arch = "wasm32")]
     pub fn transform_func<T>(mut self, func: T, context: Vec<u8>) -> Self
     where
-        T: Fn(TransformArgs) -> HttpResponse,
+        T: Fn(TransformArgs) -> HttpResponse + 'static,
     {
         self.transform = Some(create_transform_context(func, context));
         self

--- a/ic-http/src/storage.rs
+++ b/ic-http/src/storage.rs
@@ -1,0 +1,54 @@
+use crate::mock::{hash, Mock};
+use crate::transform::TransformFn;
+use ic_cdk::api::management_canister::http_request::CanisterHttpRequestArgument;
+use ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs};
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+// A thread-local hashmap.
+thread_local! {
+    /// A thread-local hashmap of mocks.
+    static MOCKS: RwLock<HashMap<String, Mock>> = RwLock::new(HashMap::new());
+
+    /// A thread-local hashmap of transform functions.
+    static TRANSFORM_FUNCTIONS: RwLock<HashMap<String, Box<TransformFn>>> = RwLock::new(HashMap::new());
+}
+
+/// Inserts the provided mock into a thread-local hashmap.
+pub(crate) fn mock_insert(mock: Mock) {
+    MOCKS.with(|cell| {
+        cell.write().unwrap().insert(hash(&mock.request), mock);
+    });
+}
+
+/// Returns a cloned mock from the thread-local hashmap that corresponds to the provided request.
+pub(crate) fn mock_get(request: &CanisterHttpRequestArgument) -> Option<Mock> {
+    MOCKS.with(|cell| cell.read().unwrap().get(&hash(request)).cloned())
+}
+
+/// Inserts the provided transform function into a thread-local hashmap.
+/// If a transform function with the same name already exists, it is not inserted.
+pub(crate) fn transform_function_insert(name: String, func: Box<TransformFn>) {
+    TRANSFORM_FUNCTIONS.with(|cell| {
+        // This is a workaround to prevent the transform function from being
+        // overridden when it might be used by another async call.
+        if cell.read().unwrap().get(&name).is_none() {
+            cell.write().unwrap().insert(name, func);
+        }
+    });
+}
+
+/// Executes the transform function that corresponds to the provided name.
+pub(crate) fn transform_function_call(name: String, arg: TransformArgs) -> Option<HttpResponse> {
+    TRANSFORM_FUNCTIONS.with(|cell| cell.read().unwrap().get(&name).map(|f| f(arg)))
+}
+
+/// Returns a sorted list of transform function names.
+/// This is used for testing.
+pub(crate) fn transform_function_names() -> Vec<String> {
+    TRANSFORM_FUNCTIONS.with(|cell| {
+        let mut names: Vec<String> = cell.read().unwrap().keys().cloned().collect();
+        names.sort();
+        names
+    })
+}

--- a/ic-http/src/transform.rs
+++ b/ic-http/src/transform.rs
@@ -16,7 +16,7 @@ where
     T: Fn(TransformArgs) -> HttpResponse + 'static,
 {
     let function_name = get_function_name(&func).to_string();
-    crate::transform_function_insert(function_name.clone(), Box::new(func));
+    crate::storage::transform_function_insert(function_name.clone(), Box::new(func));
 
     TransformContext {
         function: TransformFunc(candid::Func {
@@ -66,7 +66,7 @@ mod test {
         T: Fn(TransformArgs) -> HttpResponse + 'static,
     {
         let name = get_function_name(&f).to_string();
-        crate::transform_function_insert(name, Box::new(f));
+        crate::storage::transform_function_insert(name, Box::new(f));
     }
 
     /// This test makes sure that transform function names are preserved
@@ -78,7 +78,7 @@ mod test {
         insert(transform_function_2);
 
         // Act.
-        let names = crate::transform_function_names();
+        let names = crate::mock::registered_transform_function_names();
 
         // Assert.
         assert_eq!(names, vec!["transform_function_1", "transform_function_2"]);

--- a/ic-http/src/transform.rs
+++ b/ic-http/src/transform.rs
@@ -1,16 +1,22 @@
-use candid::Principal;
 use ic_cdk::api::management_canister::http_request::{
-    HttpResponse, TransformArgs, TransformContext, TransformFunc,
+    HttpResponse, TransformArgs, TransformContext,
 };
 
-pub type TransformFn = fn(TransformArgs) -> HttpResponse;
+#[cfg(not(target_arch = "wasm32"))]
+use {candid::Principal, ic_cdk::api::management_canister::http_request::TransformFunc};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub type TransformFn = dyn Fn(TransformArgs) -> HttpResponse + 'static;
 
 /// Creates a `TransformContext` from a transform function and a context.
 /// Also inserts the transform function into a thread-local hashmap.
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) fn create_transform_context(func: TransformFn, context: Vec<u8>) -> TransformContext {
-    let function_name = get_function_name(func).to_string();
-    crate::transform_function_insert(function_name.clone(), func);
+pub(crate) fn create_transform_context<T>(func: T, context: Vec<u8>) -> TransformContext
+where
+    T: Fn(TransformArgs) -> HttpResponse + 'static,
+{
+    let function_name = get_function_name(&func).to_string();
+    crate::transform_function_insert(function_name.clone(), Box::new(func));
 
     TransformContext {
         function: TransformFunc(candid::Func {
@@ -25,16 +31,56 @@ pub(crate) fn create_transform_context(func: TransformFn, context: Vec<u8>) -> T
 #[cfg(target_arch = "wasm32")]
 pub(crate) fn create_transform_context<T>(func: T, context: Vec<u8>) -> TransformContext
 where
-    T: Fn(TransformArgs) -> HttpResponse,
+    T: Fn(TransformArgs) -> HttpResponse + 'static,
 {
     TransformContext::new(func, context)
 }
 
 /// Returns the name of a function as a string.
-fn get_function_name<F>(_: F) -> &'static str {
+#[cfg(not(target_arch = "wasm32"))]
+fn get_function_name<F>(_: &F) -> &'static str {
     let full_name = std::any::type_name::<F>();
     match full_name.rfind(':') {
         Some(index) => &full_name[index + 1..],
         None => full_name,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// A test transform function.
+    fn transform_function_1(arg: TransformArgs) -> HttpResponse {
+        arg.response
+    }
+
+    /// A test transform function.
+    fn transform_function_2(arg: TransformArgs) -> HttpResponse {
+        arg.response
+    }
+
+    /// Inserts the provided transform function into a thread-local hashmap.
+    fn insert<T>(f: T)
+    where
+        T: Fn(TransformArgs) -> HttpResponse + 'static,
+    {
+        let name = get_function_name(&f).to_string();
+        crate::transform_function_insert(name, Box::new(f));
+    }
+
+    /// This test makes sure that transform function names are preserved
+    /// when passing to the function.
+    #[test]
+    fn test_transform_function_names() {
+        // Arrange.
+        insert(transform_function_1);
+        insert(transform_function_2);
+
+        // Act.
+        let names = crate::transform_function_names();
+
+        // Assert.
+        assert_eq!(names, vec!["transform_function_1", "transform_function_2"]);
     }
 }


### PR DESCRIPTION
This PR fixes storing transform functions in a thread-local storage which was preventing to test concurrent http requests.

Previously it was incorrectly calculating the name of the function, since it was called inside `create_transform_context` function with a specific type of `TransformFn`, which loses the name of the function (in contrast to a template parameter) and only stores the function signature (which is always the same).

To fix this it had to convert `create_transform_context` to a template and store a boxed function pointer in a thread-local storage. Added tests to make sure function names are stored properly now.

