### PR TITLE
chore: refactoring storing mocked responses for ic-http

### DIFF
--- a/ic-http/src/mock.rs
+++ b/ic-http/src/mock.rs
@@ -87,9 +87,9 @@ pub(crate) async fn http_request(
         tokio::time::sleep(mock.delay).await;
     }
 
-    // Return the error if one is specified.
     let mock_response = match mock.result {
         None => panic!("Mock response is missing"),
+        // Return the error if one is specified.
         Some(Err(error)) => return Err(error),
         Some(Ok(response)) => response,
     };

--- a/ic-http/src/transform.rs
+++ b/ic-http/src/transform.rs
@@ -85,11 +85,8 @@ mod test {
         assert_eq!(names, vec!["transform_function_1", "transform_function_2"]);
     }
 
-    /// Transform function which is intentionally creates a new request
-    /// with itself as a transform function.
-    /// This is potentially causing to rewrite the transform function
-    /// in a thread-local storage while it is being executed, which
-    /// leads to a hang.
+    /// Transform function which intentionally creates a new request passing
+    /// itself as the target transform function.
     fn transform_function_with_overwrite(arg: TransformArgs) -> HttpResponse {
         create_request_with_transform();
         arg.response


### PR DESCRIPTION
This PR improves storing mocked response to be either result or an error.

This is a follow-up PR to address code review comments from #183.