### PR TITLE
feat: add watchdog canister config

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -351,6 +351,70 @@ jobs:
         run: |
           bash e2e-tests/set_config.sh
 
+  watchdog_health_status:
+    runs-on: ubuntu-20.04
+    needs: cargo-build
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+
+      - name: Install Rust
+        run: |
+          rustup update ${{ matrix.rust }} --no-self-update
+          rustup default ${{ matrix.rust }}
+          rustup target add wasm32-unknown-unknown
+
+      - name: Install DFX
+        run: |
+          wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
+          bash install-dfx.sh < <(yes Y)
+          rm install-dfx.sh
+          dfx cache install
+          echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Run health_status test
+        run: |
+          bash watchdog/tests/health_status.sh
+
+  watchdog_get_config:
+    runs-on: ubuntu-20.04
+    needs: cargo-build
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+
+      - name: Install Rust
+        run: |
+          rustup update ${{ matrix.rust }} --no-self-update
+          rustup default ${{ matrix.rust }}
+          rustup target add wasm32-unknown-unknown
+
+      - name: Install DFX
+        run: |
+          wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
+          bash install-dfx.sh < <(yes Y)
+          rm install-dfx.sh
+          dfx cache install
+          echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Run get_config test
+        run: |
+          bash watchdog/tests/get_config.sh
+
   checks-pass:
     needs: ["cargo-tests", "shell-checks", "cargo-clippy", "rustfmt", "e2e-disable-api-if-not-fully-synced-flag", "e2e-scenario-1", "e2e-scenario-2", "e2e-scenario-3", "charge-cycles-on-reject", "upgradability", "set_config"]
     runs-on: ubuntu-20.04

--- a/watchdog/candid.did
+++ b/watchdog/candid.did
@@ -39,7 +39,33 @@ type health_status = record {
     status : status_code;
 };
 
+type config = record {
+    /// Below this threshold, the canister is considered to be behind.
+    blocks_behind_threshold : nat64;
+
+    /// Above this threshold, the canister is considered to be ahead.
+    blocks_ahead_threshold : nat64;
+
+    /// The minimum number of explorers to compare against.
+    min_explores : nat64;
+
+    /// Bitcoin canister endpoint.
+    bitcoin_canister_endpoint : text;
+
+    /// The number of seconds to wait before the first data fetch.
+    delay_before_first_fetch_sec : nat64;
+
+    /// The number of seconds to wait between all the other data fetches.
+    interval_between_fetches_sec : nat64;
+};
+
 service : {
-    // Returns the health status of the Bitcoin canister.
+    /// Returns the health status of the Bitcoin canister.
     health_status : () -> (health_status) query;
+
+    /// Returns the configuration of the watchdog canister.
+    get_config : () -> (config) query;
+
+    /// Sets the configuration of the watchdog canister.
+    set_config : (config) -> ();
 };

--- a/watchdog/candid.did
+++ b/watchdog/candid.did
@@ -65,7 +65,4 @@ service : {
 
     /// Returns the configuration of the watchdog canister.
     get_config : () -> (config) query;
-
-    /// Sets the configuration of the watchdog canister.
-    set_config : (config) -> ();
 };

--- a/watchdog/candid.did
+++ b/watchdog/candid.did
@@ -47,7 +47,7 @@ type config = record {
     blocks_ahead_threshold : nat64;
 
     /// The minimum number of explorers to compare against.
-    min_explores : nat64;
+    min_explorers : nat64;
 
     /// Bitcoin canister endpoint.
     bitcoin_canister_endpoint : text;

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -1,18 +1,60 @@
+use candid::CandidType;
+use serde::{Deserialize, Serialize};
+
 /// Below this threshold, the canister is considered to be behind.
-pub const BLOCKS_BEHIND_THRESHOLD: i64 = -2;
+const BLOCKS_BEHIND_THRESHOLD: u64 = 2;
 
 /// Above this threshold, the canister is considered to be ahead.
-pub const BLOCKS_AHEAD_THRESHOLD: i64 = 2;
+const BLOCKS_AHEAD_THRESHOLD: u64 = 2;
 
 /// The minimum number of explorers to compare against.
-pub const MIN_EXPLORERS: u64 = 3;
+const MIN_EXPLORERS: u64 = 3;
 
 /// Bitcoin canister endpoint.
-pub const BITCOIN_CANISTER_ENDPOINT: &str =
-    "https://ghsi2-tqaaa-aaaan-aaaca-cai.raw.ic0.app/metrics";
+const BITCOIN_CANISTER_ENDPOINT: &str = "https://ghsi2-tqaaa-aaaan-aaaca-cai.raw.ic0.app/metrics";
 
 /// The number of seconds to wait before the first data fetch.
-pub const DELAY_BEFORE_FIRST_FETCH_SEC: u64 = 1;
+const DELAY_BEFORE_FIRST_FETCH_SEC: u64 = 1;
 
 /// The number of seconds to wait between all the other data fetches.
-pub const INTERVAL_BETWEEN_FETCHES_SEC: u64 = 60;
+const INTERVAL_BETWEEN_FETCHES_SEC: u64 = 60;
+
+#[derive(Clone, Debug, CandidType, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Config {
+    /// Below this threshold, the canister is considered to be behind.
+    pub blocks_behind_threshold: u64,
+
+    /// Above this threshold, the canister is considered to be ahead.
+    pub blocks_ahead_threshold: u64,
+
+    /// The minimum number of explorers to compare against.
+    pub min_explores: u64,
+
+    /// Bitcoin canister endpoint.
+    pub bitcoin_canister_endpoint: String,
+
+    /// The number of seconds to wait before the first data fetch.
+    pub delay_before_first_fetch_sec: u64,
+
+    /// The number of seconds to wait between all the other data fetches.
+    pub interval_between_fetches_sec: u64,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Self {
+            blocks_behind_threshold: BLOCKS_BEHIND_THRESHOLD,
+            blocks_ahead_threshold: BLOCKS_AHEAD_THRESHOLD,
+            min_explores: MIN_EXPLORERS,
+            bitcoin_canister_endpoint: BITCOIN_CANISTER_ENDPOINT.to_string(),
+            delay_before_first_fetch_sec: DELAY_BEFORE_FIRST_FETCH_SEC,
+            interval_between_fetches_sec: INTERVAL_BETWEEN_FETCHES_SEC,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -28,7 +28,7 @@ pub struct Config {
     pub blocks_ahead_threshold: u64,
 
     /// The minimum number of explorers to compare against.
-    pub min_explores: u64,
+    pub min_explorers: u64,
 
     /// Bitcoin canister endpoint.
     pub bitcoin_canister_endpoint: String,
@@ -45,7 +45,7 @@ impl Config {
         Self {
             blocks_behind_threshold: BLOCKS_BEHIND_THRESHOLD,
             blocks_ahead_threshold: BLOCKS_AHEAD_THRESHOLD,
-            min_explores: MIN_EXPLORERS,
+            min_explorers: MIN_EXPLORERS,
             bitcoin_canister_endpoint: BITCOIN_CANISTER_ENDPOINT.to_string(),
             delay_before_first_fetch_sec: DELAY_BEFORE_FIRST_FETCH_SEC,
             interval_between_fetches_sec: INTERVAL_BETWEEN_FETCHES_SEC,

--- a/watchdog/src/endpoints.rs
+++ b/watchdog/src/endpoints.rs
@@ -89,7 +89,7 @@ fn parse_bitcoin_canister_height(text: String) -> Result<u64, String> {
 /// Creates a new HttpRequestConfig for fetching block data from bitcoin_canister.
 pub fn endpoint_bitcoin_canister() -> HttpRequestConfig {
     HttpRequestConfig::new(
-        crate::config::BITCOIN_CANISTER_ENDPOINT,
+        &crate::storage::get_config().bitcoin_canister_endpoint,
         Some(transform_bitcoin_canister),
         |raw| {
             apply_to_body(raw, |text| {

--- a/watchdog/src/health.rs
+++ b/watchdog/src/health.rs
@@ -1,3 +1,4 @@
+use crate::config::Config;
 use crate::fetch::BlockInfo;
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
@@ -47,7 +48,7 @@ pub struct HealthStatus {
 }
 
 /// Compares the source with the other explorers.
-pub fn compare(source: Option<BlockInfo>, other: Vec<BlockInfo>) -> HealthStatus {
+pub fn compare(source: Option<BlockInfo>, other: Vec<BlockInfo>, config: Config) -> HealthStatus {
     let source_height = source.and_then(|block| block.height);
     let heights = other
         .iter()
@@ -55,7 +56,7 @@ pub fn compare(source: Option<BlockInfo>, other: Vec<BlockInfo>) -> HealthStatus
         .collect::<Vec<_>>();
     let other_number = heights.len() as u64;
     let other_heights = heights.clone();
-    let target_height = if other_number < crate::config::MIN_EXPLORERS {
+    let target_height = if other_number < config.min_explores {
         None // Not enough data from explorers.
     } else {
         median(heights)
@@ -64,9 +65,9 @@ pub fn compare(source: Option<BlockInfo>, other: Vec<BlockInfo>) -> HealthStatus
         .zip(target_height)
         .map(|(source, target)| source as i64 - target as i64);
     let status = height_diff.map_or(StatusCode::NotEnoughData, |diff| {
-        if diff < crate::config::BLOCKS_BEHIND_THRESHOLD {
+        if diff < -(config.blocks_behind_threshold as i64) {
             StatusCode::Behind
-        } else if diff > crate::config::BLOCKS_AHEAD_THRESHOLD {
+        } else if diff > config.blocks_ahead_threshold as i64 {
             StatusCode::Ahead
         } else {
             StatusCode::Ok
@@ -128,7 +129,7 @@ mod test {
 
         // Assert
         assert_eq!(
-            compare(source, other),
+            compare(source, other, crate::storage::get_config()),
             HealthStatus {
                 source_height: None,
                 other_number: 0,
@@ -148,7 +149,7 @@ mod test {
 
         // Assert
         assert_eq!(
-            compare(source, other),
+            compare(source, other, crate::storage::get_config()),
             HealthStatus {
                 source_height: Some(1_000),
                 other_number: 0,
@@ -171,7 +172,7 @@ mod test {
 
         // Assert
         assert_eq!(
-            compare(source, other),
+            compare(source, other, crate::storage::get_config()),
             HealthStatus {
                 source_height: Some(1_000),
                 other_number: 2,
@@ -195,7 +196,7 @@ mod test {
 
         // Assert
         assert_eq!(
-            compare(source, other),
+            compare(source, other, crate::storage::get_config()),
             HealthStatus {
                 source_height: Some(1_000),
                 other_number: 3,
@@ -219,7 +220,7 @@ mod test {
 
         // Assert
         assert_eq!(
-            compare(source, other),
+            compare(source, other, crate::storage::get_config()),
             HealthStatus {
                 source_height: Some(1_000),
                 other_number: 3,

--- a/watchdog/src/health.rs
+++ b/watchdog/src/health.rs
@@ -56,7 +56,7 @@ pub fn compare(source: Option<BlockInfo>, other: Vec<BlockInfo>, config: Config)
         .collect::<Vec<_>>();
     let other_number = heights.len() as u64;
     let other_heights = heights.clone();
-    let target_height = if other_number < config.min_explores {
+    let target_height = if other_number < config.min_explorers {
         None // Not enough data from explorers.
     } else {
         median(heights)

--- a/watchdog/src/lib.rs
+++ b/watchdog/src/lib.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 use std::time::Duration;
 
-use ic_cdk_macros::{init, post_upgrade, query, update};
+use ic_cdk_macros::{init, post_upgrade, query};
 
 thread_local! {
     /// The local storage for the data fetched from the external APIs.
@@ -75,12 +75,6 @@ fn health_status() -> HealthStatus {
 #[query]
 pub fn get_config() -> Config {
     crate::storage::get_config()
-}
-
-/// Sets the configuration of the watchdog canister.
-#[update]
-pub fn set_config(config: Config) {
-    crate::storage::set_config(config)
 }
 
 /// Prints a message to the console.

--- a/watchdog/src/lib.rs
+++ b/watchdog/src/lib.rs
@@ -10,6 +10,7 @@ mod storage;
 mod test_utils;
 
 use crate::bitcoin_block_apis::BitcoinBlockApi;
+use crate::config::Config;
 use crate::endpoints::*;
 use crate::fetch::BlockInfo;
 use crate::health::HealthStatus;
@@ -18,21 +19,26 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 use std::time::Duration;
 
+use ic_cdk_macros::{init, post_upgrade, query, update};
+
 thread_local! {
     /// The local storage for the data fetched from the external APIs.
     static BLOCK_INFO_DATA: RwLock<HashMap<BitcoinBlockApi, BlockInfo>> = RwLock::new(HashMap::new());
+
+    /// The local storage for the configuration.
+    static CONFIG: RwLock<Config> = RwLock::new(Config::new());
 }
 
 /// This function is called when the canister is created.
-#[ic_cdk_macros::init]
+#[init]
 fn init() {
     ic_cdk_timers::set_timer(
-        Duration::from_secs(crate::config::DELAY_BEFORE_FIRST_FETCH_SEC),
+        Duration::from_secs(crate::storage::get_config().delay_before_first_fetch_sec),
         || {
             ic_cdk::spawn(async {
                 fetch_data().await;
                 ic_cdk_timers::set_timer_interval(
-                    Duration::from_secs(crate::config::INTERVAL_BETWEEN_FETCHES_SEC),
+                    Duration::from_secs(crate::storage::get_config().interval_between_fetches_sec),
                     || ic_cdk::spawn(fetch_data()),
                 );
             })
@@ -41,7 +47,7 @@ fn init() {
 }
 
 /// This function is called after the canister is upgraded.
-#[ic_cdk_macros::post_upgrade]
+#[post_upgrade]
 fn post_upgrade() {
     init()
 }
@@ -53,7 +59,7 @@ async fn fetch_data() {
 }
 
 /// Returns the health status of the Bitcoin canister.
-#[ic_cdk_macros::query]
+#[query]
 fn health_status() -> HealthStatus {
     crate::health::compare(
         crate::storage::get(&BitcoinBlockApi::BitcoinCanister),
@@ -61,7 +67,20 @@ fn health_status() -> HealthStatus {
             .iter()
             .filter_map(crate::storage::get)
             .collect::<Vec<_>>(),
+        crate::storage::get_config(),
     )
+}
+
+/// Returns the configuration of the watchdog canister.
+#[query]
+pub fn get_config() -> Config {
+    crate::storage::get_config()
+}
+
+/// Sets the configuration of the watchdog canister.
+#[update]
+pub fn set_config(config: Config) {
+    crate::storage::set_config(config)
 }
 
 /// Prints a message to the console.
@@ -76,47 +95,47 @@ pub fn print(msg: &str) {
 // Exposing the endpoints in `lib.rs` (not in `main.rs`) to make them available
 // to the downstream code which creates HTTP requests with transform functions.
 
-#[ic_cdk_macros::query]
+#[query]
 fn transform_api_bitaps_com_block(raw: TransformArgs) -> HttpResponse {
     endpoint_api_bitaps_com_block().transform(raw)
 }
 
-#[ic_cdk_macros::query]
+#[query]
 fn transform_api_blockchair_com_block(raw: TransformArgs) -> HttpResponse {
     endpoint_api_blockchair_com_block().transform(raw)
 }
 
-#[ic_cdk_macros::query]
+#[query]
 fn transform_api_blockcypher_com_block(raw: TransformArgs) -> HttpResponse {
     endpoint_api_blockcypher_com_block().transform(raw)
 }
 
-#[ic_cdk_macros::query]
+#[query]
 fn transform_bitcoin_canister(raw: TransformArgs) -> HttpResponse {
     endpoint_bitcoin_canister().transform(raw)
 }
 
-#[ic_cdk_macros::query]
+#[query]
 fn transform_blockchain_info_hash(raw: TransformArgs) -> HttpResponse {
     endpoint_blockchain_info_hash().transform(raw)
 }
 
-#[ic_cdk_macros::query]
+#[query]
 fn transform_blockchain_info_height(raw: TransformArgs) -> HttpResponse {
     endpoint_blockchain_info_height().transform(raw)
 }
 
-#[ic_cdk_macros::query]
+#[query]
 fn transform_blockstream_info_hash(raw: TransformArgs) -> HttpResponse {
     endpoint_blockstream_info_hash().transform(raw)
 }
 
-#[ic_cdk_macros::query]
+#[query]
 fn transform_blockstream_info_height(raw: TransformArgs) -> HttpResponse {
     endpoint_blockstream_info_height().transform(raw)
 }
 
-#[ic_cdk_macros::query]
+#[query]
 fn transform_chain_api_btc_com_block(raw: TransformArgs) -> HttpResponse {
     endpoint_chain_api_btc_com_block().transform(raw)
 }

--- a/watchdog/src/storage.rs
+++ b/watchdog/src/storage.rs
@@ -20,8 +20,3 @@ pub fn get(provider: &BitcoinBlockApi) -> Option<BlockInfo> {
 pub fn get_config() -> Config {
     CONFIG.with(|config| config.read().unwrap().clone())
 }
-
-/// Sets the configuration in the local storage.
-pub fn set_config(config: Config) {
-    CONFIG.with(|c| *c.write().unwrap() = config);
-}

--- a/watchdog/src/storage.rs
+++ b/watchdog/src/storage.rs
@@ -1,6 +1,8 @@
 use crate::bitcoin_block_apis::BitcoinBlockApi;
+use crate::config::Config;
 use crate::fetch::BlockInfo;
 use crate::BLOCK_INFO_DATA;
+use crate::CONFIG;
 
 /// Inserts the data into the local storage.
 pub fn insert(info: BlockInfo) {
@@ -12,4 +14,14 @@ pub fn insert(info: BlockInfo) {
 /// Returns the data from the local storage.
 pub fn get(provider: &BitcoinBlockApi) -> Option<BlockInfo> {
     BLOCK_INFO_DATA.with(|data| data.read().unwrap().get(provider).cloned())
+}
+
+/// Returns the configuration from the local storage.
+pub fn get_config() -> Config {
+    CONFIG.with(|config| config.read().unwrap().clone())
+}
+
+/// Sets the configuration in the local storage.
+pub fn set_config(config: Config) {
+    CONFIG.with(|c| *c.write().unwrap() = config);
 }

--- a/watchdog/tests/get_config.sh
+++ b/watchdog/tests/get_config.sh
@@ -14,7 +14,7 @@ dfx deploy --no-wallet watchdog
 config=$(dfx canister call watchdog get_config --query)
 
 # Check that the config is correct, eg. by checking the min_explores value.
-if ! [[ $config == *"min_explores = 3"* ]]; then
+if ! [[ $config == *"min_explorers = 3"* ]]; then
   echo "FAIL"
   exit 1
 fi

--- a/watchdog/tests/get_config.sh
+++ b/watchdog/tests/get_config.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# A test that verifies that the `get_config` endpoint works as expected.
+
+ITERATIONS=30
+DELAY_SEC=1
+
+# Run dfx stop if we run into errors.
+trap "dfx stop" EXIT SIGINT
+
+dfx start --background --clean
+
+# Deploy the watchdog canister.
+dfx deploy --no-wallet watchdog
+
+# Request config.
+config=$(dfx canister call watchdog get_config --query)
+
+# Check that the config is correct, eg. by checking the min_explores value.
+if ! [[ $config == *"min_explores = 3"* ]]; then
+  echo "FAIL"
+  exit 1
+fi
+
+echo "SUCCESS"

--- a/watchdog/tests/get_config.sh
+++ b/watchdog/tests/get_config.sh
@@ -2,9 +2,6 @@
 #
 # A test that verifies that the `get_config` endpoint works as expected.
 
-ITERATIONS=30
-DELAY_SEC=1
-
 # Run dfx stop if we run into errors.
 trap "dfx stop" EXIT SIGINT
 

--- a/watchdog/tests/health_status.sh
+++ b/watchdog/tests/health_status.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# A test that verifies that the `health_status` endpoint works as expected.
+
+ITERATIONS=30
+DELAY_SEC=1
+
+# Run dfx stop if we run into errors.
+trap "dfx stop" EXIT SIGINT
+
+dfx start --background --clean
+
+# Deploy the watchdog canister.
+dfx deploy --no-wallet watchdog
+
+# Request health status repeatedly, break when the data is available.
+has_enough_data=0
+for ((i=1; i<=$ITERATIONS; i++))
+do
+    health_status=$(dfx canister call watchdog health_status --query)
+
+    if ! [[ $health_status == *"status = variant { not_enough_data }"* ]]; then
+        has_enough_data=1
+        break
+    fi
+
+    sleep $DELAY_SEC
+done
+
+if [ $has_enough_data -eq 0 ]; then
+  echo "FAIL"
+  exit 1
+fi
+
+echo "SUCCESS"

--- a/watchdog/tests/health_status.sh
+++ b/watchdog/tests/health_status.sh
@@ -15,7 +15,7 @@ dfx deploy --no-wallet watchdog
 
 # Request health status repeatedly, break when the data is available.
 has_enough_data=0
-for ((i=1; i<=$ITERATIONS; i++))
+for ((i=1; i<=ITERATIONS; i++))
 do
     health_status=$(dfx canister call watchdog health_status --query)
 


### PR DESCRIPTION
This PR adds the option to read a watchdog canister's configuration.

Adds a `get_config` endpoint and corresponding bash-tests.