### PR TITLE
feat: add metrics to watchdog canister

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -415,6 +415,38 @@ jobs:
         run: |
           bash watchdog/tests/get_config.sh
 
+  watchdog_metrics:
+    runs-on: ubuntu-20.04
+    needs: cargo-build
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+
+      - name: Install Rust
+        run: |
+          rustup update ${{ matrix.rust }} --no-self-update
+          rustup default ${{ matrix.rust }}
+          rustup target add wasm32-unknown-unknown
+
+      - name: Install DFX
+        run: |
+          wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
+          bash install-dfx.sh < <(yes Y)
+          rm install-dfx.sh
+          dfx cache install
+          echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Run metrics test
+        run: |
+          bash watchdog/tests/metrics.sh
+
   checks-pass:
     needs: ["cargo-tests", "shell-checks", "cargo-clippy", "rustfmt", "e2e-disable-api-if-not-fully-synced-flag", "e2e-scenario-1", "e2e-scenario-2", "e2e-scenario-3", "charge-cycles-on-reject", "upgradability", "set_config"]
     runs-on: ubuntu-20.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3244,8 +3244,10 @@ dependencies = [
  "ic-cdk-macros 0.6.10",
  "ic-cdk-timers",
  "ic-http",
+ "ic-metrics-encoder",
  "regex",
  "serde",
+ "serde_bytes",
  "serde_json",
  "tokio",
 ]

--- a/watchdog/Cargo.toml
+++ b/watchdog/Cargo.toml
@@ -21,6 +21,8 @@ async-trait = "0.1.67"
 regex = "1.7.0"
 futures = "0.3.27"
 ic-http = {path = "../ic-http"}
+serde_bytes = "0.11"
+ic-metrics-encoder = "1.0.0"
 
 [dev-dependencies]
 tokio = { version = "1.15.0", features = [ "full" ] }

--- a/watchdog/candid.did
+++ b/watchdog/candid.did
@@ -18,24 +18,22 @@ type status_code = variant {
 
 // The health status of the Bitcoin canister.
 type health_status = record {
-    /// The height of the block from the Bitcoin canister.
+    /// Height of the block from the Bitcoin canister.
     source_height : opt nat64;
 
-    /// The number of explorers inspected.
+    /// Number of explorers inspected.
     other_number : nat64;
 
-    /// The heights of the blocks from the explorers.
+    /// Heights of the blocks from the explorers.
     other_heights : vec nat64;
 
-    /// The target height of the Bitcoin canister calculated
-    /// from the explorers.
+    /// Target height calculated from the explorers.
     target_height : opt nat64;
 
-    /// The difference between the source height
-    /// and the target height.
+    /// Difference between the source and the target heights.
     height_diff : opt int64;
 
-    /// The code of the health status.
+    /// Status code of the Bitcoin canister health.
     status : status_code;
 };
 

--- a/watchdog/src/metrics.rs
+++ b/watchdog/src/metrics.rs
@@ -10,7 +10,6 @@ pub fn get_metrics() -> CandidHttpResponse {
     let mut writer = MetricsEncoder::new(vec![], (now / 1_000_000) as i64);
     match encode_metrics(&mut writer) {
         Ok(()) => {
-            print("bla");
             let body = writer.into_inner();
             CandidHttpResponse {
                 status_code: 200,

--- a/watchdog/src/metrics.rs
+++ b/watchdog/src/metrics.rs
@@ -1,5 +1,4 @@
 use crate::health::StatusCode;
-use crate::print;
 use crate::types::CandidHttpResponse;
 use ic_metrics_encoder::MetricsEncoder;
 use serde_bytes::ByteBuf;

--- a/watchdog/src/metrics.rs
+++ b/watchdog/src/metrics.rs
@@ -1,0 +1,78 @@
+use crate::health::StatusCode;
+use crate::print;
+use crate::types::CandidHttpResponse;
+use ic_metrics_encoder::MetricsEncoder;
+use serde_bytes::ByteBuf;
+
+/// Returns the metrics in the Prometheus format.
+pub fn get_metrics() -> CandidHttpResponse {
+    let now = ic_cdk::api::time();
+    let mut writer = MetricsEncoder::new(vec![], (now / 1_000_000) as i64);
+    match encode_metrics(&mut writer) {
+        Ok(()) => {
+            print("bla");
+            let body = writer.into_inner();
+            CandidHttpResponse {
+                status_code: 200,
+                headers: vec![
+                    (
+                        "Content-Type".to_string(),
+                        "text/plain; version=0.0.4".to_string(),
+                    ),
+                    ("Content-Length".to_string(), body.len().to_string()),
+                ],
+                body: ByteBuf::from(body),
+            }
+        }
+        Err(err) => CandidHttpResponse {
+            status_code: 500,
+            headers: vec![],
+            body: ByteBuf::from(format!("Failed to encode metrics: {}", err)),
+        },
+    }
+}
+
+/// Encodes the metrics in the Prometheus format.
+fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
+    const NO_HEIGHT: f64 = -1.0;
+    const NO_HEIGHT_DIFF: f64 = -1_000.0;
+
+    let health = crate::health::health_status();
+    w.encode_gauge(
+        "bitcoin_canister_height",
+        health.source_height.map(|x| x as f64).unwrap_or(NO_HEIGHT),
+        "Height of the main chain of the Bitcoin canister.",
+    )?;
+    w.encode_gauge(
+        "explorers_number",
+        health.other_number as f64,
+        "Number of explorers inspected.",
+    )?;
+    w.encode_gauge(
+        "target_height",
+        health.target_height.map(|x| x as f64).unwrap_or(NO_HEIGHT),
+        "Target height calculated from the explorers.",
+    )?;
+    w.encode_gauge(
+        "height_diff",
+        health
+            .height_diff
+            .map(|x| x as f64)
+            .unwrap_or(NO_HEIGHT_DIFF),
+        "Difference between the source and the target heights.",
+    )?;
+
+    let (not_enough_data, ok, ahead, behind) = match health.status {
+        StatusCode::NotEnoughData => (1.0, 0.0, 0.0, 0.0),
+        StatusCode::Ok => (0.0, 1.0, 0.0, 0.0),
+        StatusCode::Ahead => (0.0, 0.0, 1.0, 0.0),
+        StatusCode::Behind => (0.0, 0.0, 0.0, 1.0),
+    };
+    w.gauge_vec("status", "Status code of the Bitcoin canister health.")?
+        .value(&[("height", "not_enough_data")], not_enough_data)?
+        .value(&[("height", "ok")], ok)?
+        .value(&[("height", "ahead")], ahead)?
+        .value(&[("height", "behind")], behind)?;
+
+    Ok(())
+}

--- a/watchdog/src/types.rs
+++ b/watchdog/src/types.rs
@@ -1,0 +1,20 @@
+use ic_cdk::export::candid::CandidType;
+use serde::{Deserialize, Serialize};
+use serde_bytes::ByteBuf;
+
+type HeaderField = (String, String);
+
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub struct CandidHttpRequest {
+    pub method: String,
+    pub url: String,
+    pub headers: Vec<HeaderField>,
+    pub body: ByteBuf,
+}
+
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub struct CandidHttpResponse {
+    pub status_code: u16,
+    pub headers: Vec<HeaderField>,
+    pub body: ByteBuf,
+}

--- a/watchdog/tests/metrics.sh
+++ b/watchdog/tests/metrics.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# A test that verifies that the `/metrics` endpoint works as expected.
+
+# Run dfx stop if we run into errors.
+trap "dfx stop" EXIT SIGINT
+
+dfx start --background --clean
+
+# Deploy the watchdog canister.
+dfx deploy --no-wallet watchdog
+
+# Request canister id.
+CANISTER_ID=$(dfx canister id watchdog)
+METRICS=$(curl "http://127.0.0.1:8000/metrics?canisterId=$CANISTER_ID")
+
+# Check that metrics report contains some information.
+if ! [[ "$METRICS" == *"bitcoin_canister_height"* ]]; then
+  echo "FAIL"
+  exit 1
+fi
+
+echo "SUCCESS"


### PR DESCRIPTION
This PR adds Prometheus metrics to a watchdog canister.

Metrics response example:
```
# HELP bitcoin_canister_height Height of the main chain of the Bitcoin canister.
# TYPE bitcoin_canister_height gauge
bitcoin_canister_height 786116 1681915083861
# HELP explorers_number Number of explorers inspected.
# TYPE explorers_number gauge
explorers_number 6 1681915083861
# HELP target_height Target height calculated from the explorers.
# TYPE target_height gauge
target_height 786116 1681915083861
# HELP height_diff Difference between the source and the target heights.
# TYPE height_diff gauge
height_diff 0 1681915083861
# HELP status Status code of the Bitcoin canister height.
# TYPE status gauge
status{height="not_enough_data"} 0 1681915083861
status{height="ok"} 1 1681915083861
status{height="ahead"} 0 1681915083861
status{height="behind"} 0 1681915083861
```