### PR TITLE
chore: remove api.bitaps.com provider from watchdog canister

### DIFF
--- a/watchdog/src/bitcoin_block_apis.rs
+++ b/watchdog/src/bitcoin_block_apis.rs
@@ -7,9 +7,6 @@ use serde_json::json;
 /// APIs that serve Bitcoin block data.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, CandidType, Serialize, Deserialize)]
 pub enum BitcoinBlockApi {
-    #[serde(rename = "api_bitaps_com")]
-    ApiBitapsCom,
-
     #[serde(rename = "api_blockchair_com")]
     ApiBlockchairCom,
 
@@ -46,7 +43,6 @@ impl BitcoinBlockApi {
     /// Returns the list of all API providers.
     pub fn all_providers() -> Vec<Self> {
         vec![
-            BitcoinBlockApi::ApiBitapsCom,
             BitcoinBlockApi::ApiBlockchairCom,
             BitcoinBlockApi::ApiBlockcypherCom,
             BitcoinBlockApi::BitcoinCanister, // Not an explorer.
@@ -59,7 +55,6 @@ impl BitcoinBlockApi {
     /// Returns the list of explorers only.
     pub fn explorers() -> Vec<Self> {
         vec![
-            BitcoinBlockApi::ApiBitapsCom,
             BitcoinBlockApi::ApiBlockchairCom,
             BitcoinBlockApi::ApiBlockcypherCom,
             BitcoinBlockApi::BlockchainInfo,
@@ -71,7 +66,6 @@ impl BitcoinBlockApi {
     /// Fetches the block data from the API.
     pub async fn fetch_data(&self) -> serde_json::Value {
         match self {
-            BitcoinBlockApi::ApiBitapsCom => http_request(endpoint_api_bitaps_com_block()).await,
             BitcoinBlockApi::ApiBlockchairCom => {
                 http_request(endpoint_api_blockchair_com_block()).await
             }
@@ -168,19 +162,6 @@ mod test {
             let request = config.request();
             assert_eq!(ic_http::mock::times_called(request), count);
         }
-    }
-
-    #[tokio::test]
-    async fn test_api_bitaps_com() {
-        run_test(
-            BitcoinBlockApi::ApiBitapsCom,
-            vec![(endpoint_api_bitaps_com_block(), 1)],
-            json!({
-                "height": 700001,
-                "hash": "0000000000000000000aaa111111111111111111111111111111111111111111",
-            }),
-        )
-        .await;
     }
 
     #[tokio::test]
@@ -281,7 +262,6 @@ mod test {
     #[test]
     fn test_names() {
         let expected: std::collections::HashMap<BitcoinBlockApi, &str> = [
-            (BitcoinBlockApi::ApiBitapsCom, "api_bitaps_com"),
             (BitcoinBlockApi::ApiBlockchairCom, "api_blockchair_com"),
             (BitcoinBlockApi::ApiBlockcypherCom, "api_blockcypher_com"),
             (BitcoinBlockApi::BitcoinCanister, "bitcoin_canister"),

--- a/watchdog/src/endpoints.rs
+++ b/watchdog/src/endpoints.rs
@@ -1,32 +1,14 @@
 use crate::http::HttpRequestConfig;
 use crate::print;
 use crate::{
-    transform_api_bitaps_com_block, transform_api_blockchair_com_block,
-    transform_api_blockcypher_com_block, transform_bitcoin_canister,
-    transform_blockchain_info_hash, transform_blockchain_info_height,
+    transform_api_blockchair_com_block, transform_api_blockcypher_com_block,
+    transform_bitcoin_canister, transform_blockchain_info_hash, transform_blockchain_info_height,
     transform_blockstream_info_hash, transform_blockstream_info_height,
     transform_chain_api_btc_com_block,
 };
 use ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs};
 use regex::Regex;
 use serde_json::json;
-
-/// Creates a new HttpRequestConfig for fetching block data from api.bitaps.com.
-pub fn endpoint_api_bitaps_com_block() -> HttpRequestConfig {
-    HttpRequestConfig::new(
-        "https://api.bitaps.com/btc/v1/blockchain/block/last",
-        Some(transform_api_bitaps_com_block),
-        |raw| {
-            apply_to_body_json(raw, |json| {
-                let data = json["data"].clone();
-                json!({
-                    "height": data["height"].as_u64(),
-                    "hash": data["hash"].as_str(),
-                })
-            })
-        },
-    )
-}
 
 /// Creates a new HttpRequestConfig for fetching block data from api.blockchair.com.
 pub fn endpoint_api_blockchair_com_block() -> HttpRequestConfig {
@@ -270,20 +252,6 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_api_bitaps_com_block() {
-        run_http_request_test(
-            endpoint_api_bitaps_com_block(),
-            "https://api.bitaps.com/btc/v1/blockchain/block/last",
-            test_utils::API_BITAPS_COM_RESPONSE,
-            json!({
-                "height": 700001,
-                "hash": "0000000000000000000aaa111111111111111111111111111111111111111111",
-            }),
-        )
-        .await;
-    }
-
-    #[tokio::test]
     async fn test_api_blockchair_com_block() {
         run_http_request_test(
             endpoint_api_blockchair_com_block(),
@@ -402,7 +370,6 @@ mod test {
         assert_eq!(
             names,
             vec![
-                "transform_api_bitaps_com_block",
                 "transform_api_blockchair_com_block",
                 "transform_api_blockcypher_com_block",
                 "transform_bitcoin_canister",
@@ -451,7 +418,6 @@ mod test {
     async fn test_http_response_404() {
         let expected_status = candid::Nat::from(404);
         let test_cases = [
-            endpoint_api_bitaps_com_block(),
             endpoint_api_blockchair_com_block(),
             endpoint_api_blockcypher_com_block(),
             endpoint_bitcoin_canister(),

--- a/watchdog/src/fetch.rs
+++ b/watchdog/src/fetch.rs
@@ -59,10 +59,6 @@ mod test {
             result,
             vec![
                 BlockInfo {
-                    provider: BitcoinBlockApi::ApiBitapsCom,
-                    height: Some(700001),
-                },
-                BlockInfo {
                     provider: BitcoinBlockApi::ApiBlockchairCom,
                     height: Some(700002),
                 },
@@ -98,10 +94,6 @@ mod test {
         assert_eq!(
             result,
             vec![
-                BlockInfo {
-                    provider: BitcoinBlockApi::ApiBitapsCom,
-                    height: None,
-                },
                 BlockInfo {
                     provider: BitcoinBlockApi::ApiBlockchairCom,
                     height: None,

--- a/watchdog/src/lib.rs
+++ b/watchdog/src/lib.rs
@@ -100,11 +100,6 @@ pub fn print(msg: &str) {
 // to the downstream code which creates HTTP requests with transform functions.
 
 #[query]
-fn transform_api_bitaps_com_block(raw: TransformArgs) -> HttpResponse {
-    endpoint_api_bitaps_com_block().transform(raw)
-}
-
-#[query]
 fn transform_api_blockchair_com_block(raw: TransformArgs) -> HttpResponse {
     endpoint_api_blockchair_com_block().transform(raw)
 }

--- a/watchdog/src/test_utils.rs
+++ b/watchdog/src/test_utils.rs
@@ -3,7 +3,6 @@ use crate::endpoints::*;
 /// Mocks all the outcalls to be successful.
 pub fn mock_all_outcalls() {
     let mocks = [
-        (endpoint_api_bitaps_com_block(), API_BITAPS_COM_RESPONSE),
         (
             endpoint_api_blockchair_com_block(),
             API_BLOCKCHAIR_COM_RESPONSE,
@@ -47,7 +46,6 @@ pub fn mock_all_outcalls() {
 /// Mocks all the outcalls to fail with status code 404.
 pub fn mock_all_outcalls_404() {
     let mocks = [
-        endpoint_api_bitaps_com_block(),
         endpoint_api_blockchair_com_block(),
         endpoint_api_blockcypher_com_block(),
         endpoint_bitcoin_canister(),
@@ -63,17 +61,6 @@ pub fn mock_all_outcalls_404() {
         ic_http::mock::mock(request, mock_response);
     }
 }
-
-// https://api.bitaps.com/btc/v1/blockchain/block/last
-pub const API_BITAPS_COM_RESPONSE: &str = r#"{
-    "data": {
-        "height": 700001,
-        "hash": "0000000000000000000aaa111111111111111111111111111111111111111111",
-        "header": "AGAAILqkI+SFlsu4FRCwVNiwU3Eku+N/g9sEAAAAAAAAAAAAH1tWFGtObfxfaOeXVwH9txRFHWS4V+N24n9AyliR1S4Yvghko4kGFwdzNef9XA4=",
-        "adjustedTimestamp": 1678294552
-    },
-    "time": 0.0018
-}"#;
 
 // https://api.blockchair.com/bitcoin/stats
 pub const API_BLOCKCHAIR_COM_RESPONSE: &str = r#"{


### PR DESCRIPTION
This PR removes `api.bitaps.com` block info API provider because of an invalid block height.

A recent measurement revealed a data discrepancy, `api_bitaps_com` explorer height was way behind comparing to others (`358676` vs `786248`). Therefore removing this API provider as invalid.

```
# HELP explorer_height Heights from the explorers.
# TYPE explorer_height gauge
explorer_height{explorer="api_bitaps_com"} 358676 1681989756988
explorer_height{explorer="api_blockchair_com"} 786248 1681989756988
explorer_height{explorer="api_blockcypher_com"} 786248 1681989756988
explorer_height{explorer="blockchain_info"} 786248 1681989756988
explorer_height{explorer="blockstream_info"} 786248 1681989756988
explorer_height{explorer="chain_api_btc_com"} 786248 1681989756988
```