### PR TITLE
chore: add tests for explorer api abuse to watchdog canister

### DIFF
--- a/watchdog/src/endpoints.rs
+++ b/watchdog/src/endpoints.rs
@@ -207,7 +207,9 @@ fn apply_to_body_json(
 ) -> HttpResponse {
     apply_to_body(raw, |text| match serde_json::from_str(&text) {
         Err(e) => {
-            print(&format!("Failed to parse response body: err = {:?}", e));
+            print(&format!(
+                "Failed to parse JSON in response body, error: {e:?}, text: {text:?}"
+            ));
             String::default()
         }
         Ok(original) => {

--- a/watchdog/src/test_utils.rs
+++ b/watchdog/src/test_utils.rs
@@ -62,6 +62,30 @@ pub fn mock_all_outcalls_404() {
     }
 }
 
+/// Mocks all the outcalls to abuse the API.
+pub fn mock_all_outcalls_abusing_api() {
+    let mocks = [
+        endpoint_api_blockchair_com_block(),
+        endpoint_api_blockcypher_com_block(),
+        endpoint_bitcoin_canister(),
+        endpoint_blockchain_info_hash(),
+        endpoint_blockchain_info_height(),
+        endpoint_blockstream_info_hash(),
+        endpoint_blockstream_info_height(),
+        endpoint_chain_api_btc_com_block(),
+    ];
+    for config in mocks {
+        let request = config.request();
+        let mock_response = ic_http::create_response()
+            .status(200)
+            .body(DONT_ABUSE_THE_API)
+            .build();
+        ic_http::mock::mock(request, mock_response);
+    }
+}
+
+pub const DONT_ABUSE_THE_API: &str = r#"Don't abuse the API. Please contact support."#;
+
 // https://api.blockchair.com/bitcoin/stats
 pub const API_BLOCKCHAIR_COM_RESPONSE: &str = r#"{
     "data":


### PR DESCRIPTION
This PR adds a test case when API provider responds with a text string instead of a valid JSON.