### PR TITLE
fix: watchdog canister running out of cycles when sending http_request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ version = "0.1.0"
 dependencies = [
  "candid 0.8.4",
  "futures",
- "ic-cdk 0.6.10",
+ "ic-cdk 0.7.4",
  "ic-cdk-macros 0.6.10",
  "ic-http",
  "serde",
@@ -1457,7 +1457,7 @@ version = "0.1.0"
 dependencies = [
  "candid 0.8.4",
  "futures",
- "ic-cdk 0.6.10",
+ "ic-cdk 0.7.4",
  "ic-cdk-macros 0.6.10",
  "serde_json",
  "tokio",
@@ -3240,7 +3240,7 @@ dependencies = [
  "candid 0.8.4",
  "futures",
  "hex",
- "ic-cdk 0.6.10",
+ "ic-cdk 0.7.4",
  "ic-cdk-macros 0.6.10",
  "ic-cdk-timers",
  "ic-http",

--- a/ic-http/Cargo.toml
+++ b/ic-http/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 
 [dependencies]
 candid = "0.8.2"
-ic-cdk = "0.6.0"
-ic-cdk-macros = "0.6.0"
+ic-cdk = "0.7.4"
+ic-cdk-macros = "0.6.10"
 
 # Added to use non-blocking sleep to mock delayed responses.
 # Currently wasm32 does not support tokio, so we need to disable it for wasm32.

--- a/ic-http/example_canister/src/canister_backend/Cargo.toml
+++ b/ic-http/example_canister/src/canister_backend/Cargo.toml
@@ -11,8 +11,8 @@ path = "src/main.rs"
 
 [dependencies]
 candid = "0.8.2"
-ic-cdk = "0.6.0"
-ic-cdk-macros = "0.6.0"
+ic-cdk = "0.7.4"
+ic-cdk-macros = "0.6.10"
 ic-http = {path = "../../../"}
 serde = { version = "1.0.158", features = [ "derive" ] }
 serde_json = "1.0.94"

--- a/ic-http/src/http_request.rs
+++ b/ic-http/src/http_request.rs
@@ -15,5 +15,23 @@ pub async fn http_request(arg: CanisterHttpRequestArgument) -> CallResult<(HttpR
 /// Make an HTTP request to a given URL and return the HTTP response, possibly after a transformation.
 #[cfg(target_arch = "wasm32")]
 pub async fn http_request(arg: CanisterHttpRequestArgument) -> CallResult<(HttpResponse,)> {
-    ic_cdk::api::management_canister::http_request::http_request_with_cycles(arg, 0).await
+    ic_cdk::api::management_canister::http_request::http_request(arg).await
+}
+
+/// Make a HTTP request to a given URL and return HTTP response, possibly after a transformation.
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn http_request_with_cycles(
+    arg: CanisterHttpRequestArgument,
+    _cycles: u128,
+) -> CallResult<(HttpResponse,)> {
+    crate::mock::http_request(arg).await
+}
+
+/// Make an HTTP request to a given URL and return the HTTP response, possibly after a transformation.
+#[cfg(target_arch = "wasm32")]
+pub async fn http_request_with_cycles(
+    arg: CanisterHttpRequestArgument,
+    cycles: u128,
+) -> CallResult<(HttpResponse,)> {
+    ic_cdk::api::management_canister::http_request::http_request_with_cycles(arg, cycles).await
 }

--- a/ic-http/src/http_request.rs
+++ b/ic-http/src/http_request.rs
@@ -15,5 +15,5 @@ pub async fn http_request(arg: CanisterHttpRequestArgument) -> CallResult<(HttpR
 /// Make an HTTP request to a given URL and return the HTTP response, possibly after a transformation.
 #[cfg(target_arch = "wasm32")]
 pub async fn http_request(arg: CanisterHttpRequestArgument) -> CallResult<(HttpResponse,)> {
-    ic_cdk::api::management_canister::http_request::http_request(arg).await
+    ic_cdk::api::management_canister::http_request::http_request_with_cycles(arg, 0).await
 }

--- a/ic-http/src/http_request.rs
+++ b/ic-http/src/http_request.rs
@@ -24,6 +24,7 @@ pub async fn http_request_with_cycles(
     arg: CanisterHttpRequestArgument,
     _cycles: u128,
 ) -> CallResult<(HttpResponse,)> {
+    // Mocking cycles is not implemented at the moment.
     crate::mock::http_request(arg).await
 }
 

--- a/ic-http/src/lib.rs
+++ b/ic-http/src/lib.rs
@@ -126,5 +126,6 @@ pub mod mock;
 
 // Re-export.
 pub use crate::http_request::http_request;
+pub use crate::http_request::http_request_with_cycles;
 pub use crate::request::create_request;
 pub use crate::response::create_response;

--- a/watchdog/Cargo.toml
+++ b/watchdog/Cargo.toml
@@ -11,8 +11,8 @@ path = "src/main.rs"
 
 [dependencies]
 candid = "0.8.2"
-ic-cdk = "0.6.0"
-ic-cdk-macros = "0.6.0"
+ic-cdk = "0.7.4"
+ic-cdk-macros = "0.6.10"
 ic-cdk-timers = "0.1"
 serde = { version = "1.0.158", features = [ "derive" ] }
 serde_json = "1.0.94"

--- a/watchdog/src/bitcoin_block_apis.rs
+++ b/watchdog/src/bitcoin_block_apis.rs
@@ -115,7 +115,10 @@ impl BitcoinBlockApi {
 
 /// Makes an HTTP request to the given endpoint and returns the response as a JSON value.
 async fn http_request(config: crate::http::HttpRequestConfig) -> serde_json::Value {
-    let result = ic_http::http_request_with_cycles(config.request(), 0).await;
+    // Send zero cycles with the request to avoid the canister
+    // to run out of cycles when deployed on a system subnet.
+    let cycles = 0;
+    let result = ic_http::http_request_with_cycles(config.request(), cycles).await;
 
     match result {
         Ok((response,)) if response.status == 200 => parse_response(response),

--- a/watchdog/src/bitcoin_block_apis.rs
+++ b/watchdog/src/bitcoin_block_apis.rs
@@ -115,7 +115,7 @@ impl BitcoinBlockApi {
 
 /// Makes an HTTP request to the given endpoint and returns the response as a JSON value.
 async fn http_request(config: crate::http::HttpRequestConfig) -> serde_json::Value {
-    let result = ic_http::http_request(config.request()).await;
+    let result = ic_http::http_request_with_cycles(config.request(), 0).await;
 
     match result {
         Ok((response,)) if response.status == 200 => parse_response(response),


### PR DESCRIPTION
Attach zero cycles to `http_request` in order not to run out of cycles when running on a system subnet.