### PR TITLE
chore: derive Serialize for SetConfigRequest

### DIFF
--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -284,7 +284,7 @@ impl std::fmt::Display for SendTransactionError {
 }
 
 /// A request to update the canister's config.
-#[derive(CandidType, Deserialize, Default)]
+#[derive(CandidType, Deserialize, Default, Serialize)]
 pub struct SetConfigRequest {
     pub stability_threshold: Option<u128>,
 


### PR DESCRIPTION
Adding serialize allows us dapps like the NNS dapp to display a SetConfigRequest in JSON