### PR TITLE
feat: add watchdog stop-switch for bitcoin canister

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3240,6 +3240,7 @@ dependencies = [
  "candid 0.8.4",
  "futures",
  "hex",
+ "ic-btc-interface",
  "ic-cdk 0.7.4",
  "ic-cdk-macros 0.6.10",
  "ic-cdk-timers",

--- a/watchdog/Cargo.toml
+++ b/watchdog/Cargo.toml
@@ -23,6 +23,7 @@ futures = "0.3.27"
 ic-http = {path = "../ic-http"}
 serde_bytes = "0.11"
 ic-metrics-encoder = "1.0.0"
+ic-btc-interface = { path = "../interface" }
 
 [dev-dependencies]
 tokio = { version = "1.15.0", features = [ "full" ] }

--- a/watchdog/candid.did
+++ b/watchdog/candid.did
@@ -99,6 +99,6 @@ service : {
     /// Returns the configuration of the watchdog canister.
     get_config : () -> (config) query;
 
-    /// Returns the API access information for the Bitcoin canister.
-    get_api_access_flag : () -> (opt flag) query;
+    /// Returns the API access target for the Bitcoin canister.
+    get_api_access_target : () -> (opt flag) query;
 };

--- a/watchdog/candid.did
+++ b/watchdog/candid.did
@@ -87,10 +87,28 @@ type config = record {
     interval_between_fetches_sec : nat64;
 };
 
+type flag = variant {
+    enabled;
+    disabled;
+};
+
+/// Captures the expected and the actual value of the Bitcoin canister API access flag.
+/// They might be different if the Bitcoin canister is not reachable.
+type api_access = record {
+    /// Expected value of the Bitcoin canister API access flag.
+    target : opt flag;
+
+    /// Actual value of the Bitcoin canister API access flag.
+    actual : opt flag;
+};
+
 service : {
     /// Returns the health status of the Bitcoin canister.
     health_status : () -> (health_status) query;
 
     /// Returns the configuration of the watchdog canister.
     get_config : () -> (config) query;
+
+    /// Returns the API access information for the Bitcoin canister.
+    get_api_access : () -> (api_access) query;
 };

--- a/watchdog/candid.did
+++ b/watchdog/candid.did
@@ -92,16 +92,6 @@ type flag = variant {
     disabled;
 };
 
-/// Captures the expected and the actual value of the Bitcoin canister API access flag.
-/// They might be different if the Bitcoin canister is not reachable.
-type api_access = record {
-    /// Expected value of the Bitcoin canister API access flag.
-    target : opt flag;
-
-    /// Actual value of the Bitcoin canister API access flag.
-    actual : opt flag;
-};
-
 service : {
     /// Returns the health status of the Bitcoin canister.
     health_status : () -> (health_status) query;
@@ -110,5 +100,5 @@ service : {
     get_config : () -> (config) query;
 
     /// Returns the API access information for the Bitcoin canister.
-    get_api_access : () -> (api_access) query;
+    get_api_access_flag : () -> (opt flag) query;
 };

--- a/watchdog/candid.did
+++ b/watchdog/candid.did
@@ -77,8 +77,8 @@ type config = record {
     /// The minimum number of explorers to compare against.
     min_explorers : nat64;
 
-    /// Bitcoin canister endpoint.
-    bitcoin_canister_endpoint : text;
+    /// Bitcoin canister principal.
+    bitcoin_canister_principal : principal;
 
     /// The number of seconds to wait before the first data fetch.
     delay_before_first_fetch_sec : nat64;

--- a/watchdog/src/api_access.rs
+++ b/watchdog/src/api_access.rs
@@ -1,0 +1,66 @@
+use crate::health::{HealthStatus, HeightStatus};
+use ic_btc_interface::{Config as BitcoinCanisterConfig, Flag};
+
+#[derive(Clone, Debug)]
+pub struct ApiAccess {
+    /// Expected value of the Bitcoin canister API access flag.
+    pub target: Option<Flag>,
+
+    /// Actual value of the Bitcoin canister API access flag.
+    pub actual: Option<Flag>,
+}
+
+impl ApiAccess {
+    pub fn new() -> Self {
+        Self {
+            target: None,
+            actual: None,
+        }
+    }
+}
+
+impl Default for ApiAccess {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Calculates the target value of the Bitcoin canister API access flag.
+fn calculate_target(health: HealthStatus) -> Option<Flag> {
+    match health.height_status {
+        HeightStatus::Ok => Some(Flag::Enabled),
+        HeightStatus::Behind | HeightStatus::Ahead => Some(Flag::Disabled),
+        HeightStatus::NotEnoughData => None,
+    }
+}
+
+async fn get_bitcoin_canister_config() -> Option<BitcoinCanisterConfig> {
+    // TODO: read the configuration from the Bitcoin canister.
+    Some(BitcoinCanisterConfig::default())
+}
+
+/// Fetches the API access flag from the Bitcoin canister.
+pub async fn fetch_api_access() {
+    let health = crate::health::health_status();
+    let target = crate::api_access::calculate_target(health);
+
+    let bitcoin_canister_config = get_bitcoin_canister_config().await;
+    let actual = bitcoin_canister_config.map(|config| config.api_access);
+
+    let api_access = ApiAccess { target, actual };
+
+    crate::storage::set_api_access(api_access);
+}
+
+/// Sets the API access flag in the Bitcoin canister.
+pub async fn set_api_access() {
+    let api_access = crate::storage::get_api_access();
+    match (api_access.target, api_access.actual) {
+        (None, _) => (),
+        (Some(target), actual) => {
+            if Some(target) != actual {
+                // TODO: set the API access in the Bitcoin canister.
+            }
+        }
+    }
+}

--- a/watchdog/src/api_access.rs
+++ b/watchdog/src/api_access.rs
@@ -4,7 +4,6 @@ use candid::CandidType;
 use ic_btc_interface::{Config as BitcoinCanisterConfig, Flag, SetConfigRequest};
 
 /// Captures the expected and the actual value of the Bitcoin canister API access flag.
-/// They might be different if the Bitcoin canister is not reachable.
 #[derive(Clone, Debug, CandidType)]
 pub struct ApiAccess {
     /// Expected value of the Bitcoin canister API access flag.
@@ -20,6 +19,11 @@ impl ApiAccess {
             target: None,
             actual: None,
         }
+    }
+
+    /// Checks if the target and actual API access flags are in sync.
+    pub fn is_in_sync(&self) -> bool {
+        self.target == self.actual
     }
 }
 
@@ -42,19 +46,15 @@ fn calculate_target(health: HealthStatus) -> Option<Flag> {
 async fn get_bitcoin_canister_config() -> Option<BitcoinCanisterConfig> {
     let id = crate::storage::get_config().bitcoin_canister_principal;
     let result = ic_cdk::api::call::call(id, "get_config", ()).await;
-    match result {
-        Ok((config,)) => config,
-        Err(err) => {
-            print(&format!("Error getting Bitcoin canister config: {:?}", err));
-            None
-        }
-    }
+    result
+        .map(|(config,)| config)
+        .map_err(|err| print(&format!("Error getting Bitcoin canister config: {:?}", err)))
+        .ok()
 }
 
-/// Fetches the API access flag from the Bitcoin canister.
-pub async fn fetch_api_access() {
-    let health = crate::health::health_status();
-    let target = crate::api_access::calculate_target(health);
+/// Fetches the actual API access flag and calculates the target value.
+async fn fetch_actual_and_calculate_target_api_access() {
+    let target = calculate_target(crate::health::health_status());
 
     let bitcoin_canister_config = get_bitcoin_canister_config().await;
     let actual = bitcoin_canister_config.map(|config| config.api_access);
@@ -62,32 +62,37 @@ pub async fn fetch_api_access() {
         print("Error getting Bitcoin canister config: api_access is None");
     }
 
-    let api_access = ApiAccess { target, actual };
-
-    crate::storage::set_api_access(api_access);
+    crate::storage::set_api_access(ApiAccess { target, actual });
 }
 
-/// Sets the API access flag in the Bitcoin canister.
-pub async fn set_api_access() {
-    let api_access = crate::storage::get_api_access();
-    match (api_access.target, api_access.actual) {
-        (None, _) => (),
-        (Some(target), actual) => {
-            // Only set the API access flag if it is different from the actual value.
-            if Some(target) != actual {
-                let id = crate::storage::get_config().bitcoin_canister_principal;
-                let set_config_request = SetConfigRequest {
-                    api_access: Some(target),
-                    ..Default::default()
-                };
-                let result = ic_cdk::api::call::call(id, "set_config", (set_config_request,)).await;
-                match result {
-                    Ok(()) => (),
-                    Err(err) => {
-                        print(&format!("Error setting Bitcoin canister config: {:?}", err));
-                    }
-                }
-            }
+/// Updates the API access flag in the Bitcoin canister.
+async fn update_api_access(target: Option<Flag>) {
+    let id = crate::storage::get_config().bitcoin_canister_principal;
+    let set_config_request = SetConfigRequest {
+        api_access: target,
+        ..Default::default()
+    };
+    let result = ic_cdk::api::call::call(id, "set_config", (set_config_request,)).await;
+    match result {
+        Ok(()) => (),
+        Err(err) => {
+            print(&format!("Error setting Bitcoin canister config: {:?}", err));
         }
     }
+}
+
+/// Synchronizes the API access flag of the Bitcoin canister, attempting a limited number of times.
+pub async fn synchronise_api_access() {
+    const ATTEMPTS: u8 = 3;
+    for _ in 0..ATTEMPTS {
+        fetch_actual_and_calculate_target_api_access().await;
+        let api_access = crate::storage::get_api_access();
+        if api_access.target.is_none() || api_access.is_in_sync() {
+            return;
+        }
+        update_api_access(api_access.target).await;
+    }
+    print(&format!(
+        "Error: Unable to synchronize API access after {ATTEMPTS:?} attempts."
+    ));
 }

--- a/watchdog/src/api_access.rs
+++ b/watchdog/src/api_access.rs
@@ -4,6 +4,7 @@ use candid::CandidType;
 use ic_btc_interface::{Config as BitcoinCanisterConfig, Flag, SetConfigRequest};
 
 /// Captures the expected and the actual value of the Bitcoin canister API access flag.
+/// They might be different if the Bitcoin canister is not reachable.
 #[derive(Clone, Debug, CandidType)]
 pub struct ApiAccess {
     /// Expected value of the Bitcoin canister API access flag.

--- a/watchdog/src/api_access.rs
+++ b/watchdog/src/api_access.rs
@@ -2,6 +2,8 @@ use crate::health::{HealthStatus, HeightStatus};
 use crate::print;
 use ic_btc_interface::{Config as BitcoinCanisterConfig, Flag, SetConfigRequest};
 
+/// Captures the expected and the actual value of the Bitcoin canister API access flag.
+/// They might be different if the Bitcoin canister is not reachable.
 #[derive(Clone, Debug)]
 pub struct ApiAccess {
     /// Expected value of the Bitcoin canister API access flag.
@@ -35,6 +37,7 @@ fn calculate_target(health: HealthStatus) -> Option<Flag> {
     }
 }
 
+/// Fetches the Bitcoin canister config.
 async fn get_bitcoin_canister_config() -> Option<BitcoinCanisterConfig> {
     let id = crate::storage::get_config().bitcoin_canister_principal;
     let result = ic_cdk::api::call::call(id, "get_config", ()).await;
@@ -66,6 +69,7 @@ pub async fn set_api_access() {
     match (api_access.target, api_access.actual) {
         (None, _) => (),
         (Some(target), actual) => {
+            // Only set the API access flag if it is different from the actual value.
             if Some(target) != actual {
                 let id = crate::storage::get_config().bitcoin_canister_principal;
                 let set_config_request = SetConfigRequest {

--- a/watchdog/src/api_access.rs
+++ b/watchdog/src/api_access.rs
@@ -21,6 +21,7 @@ async fn get_bitcoin_canister_config() -> Option<BitcoinCanisterConfig> {
         .ok()
 }
 
+/// Fetches the actual API access flag from the Bitcoin canister.
 async fn fetch_actual_api_access() -> Option<Flag> {
     let bitcoin_canister_config = get_bitcoin_canister_config().await;
 
@@ -56,6 +57,8 @@ pub async fn synchronise_api_access() {
     if target.is_some() {
         let actual = fetch_actual_api_access().await;
         if target != actual {
+            // Only update the API access flag if the target is not None
+            // and it is different from the actual value.
             update_api_access(target).await;
         }
     }

--- a/watchdog/src/api_access.rs
+++ b/watchdog/src/api_access.rs
@@ -1,10 +1,11 @@
 use crate::health::{HealthStatus, HeightStatus};
 use crate::print;
+use candid::CandidType;
 use ic_btc_interface::{Config as BitcoinCanisterConfig, Flag, SetConfigRequest};
 
 /// Captures the expected and the actual value of the Bitcoin canister API access flag.
 /// They might be different if the Bitcoin canister is not reachable.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, CandidType)]
 pub struct ApiAccess {
     /// Expected value of the Bitcoin canister API access flag.
     pub target: Option<Flag>,
@@ -57,6 +58,9 @@ pub async fn fetch_api_access() {
 
     let bitcoin_canister_config = get_bitcoin_canister_config().await;
     let actual = bitcoin_canister_config.map(|config| config.api_access);
+    if actual.is_none() {
+        print("Error getting Bitcoin canister config: api_access is None");
+    }
 
     let api_access = ApiAccess { target, actual };
 

--- a/watchdog/src/api_access.rs
+++ b/watchdog/src/api_access.rs
@@ -88,8 +88,11 @@ pub async fn synchronise_api_access() {
         fetch_actual_and_calculate_target_api_access().await;
         let api_access = crate::storage::get_api_access();
         if api_access.target.is_none() || api_access.is_in_sync() {
+            // If the target is None, it means there's not enough data to calculate it.
+            // If the target and actual are in sync, there's no need to update the flag.
             return;
         }
+        // Target is not None and actual is not in sync, so update the flag.
         update_api_access(api_access.target).await;
     }
     print(&format!(

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 const BITCOIN_NETWORK: BitcoinNetwork = BitcoinNetwork::Mainnet;
 
 /// Below this threshold, the canister is considered to be behind.
+/// This value is positive, but it will be converted to negative.
 const BLOCKS_BEHIND_THRESHOLD: u64 = 2;
 
 /// Above this threshold, the canister is considered to be ahead.
@@ -51,6 +52,7 @@ pub struct Config {
     pub bitcoin_network: BitcoinNetwork,
 
     /// Below this threshold, the canister is considered to be behind.
+    /// This value is positive, but it must be converted to negative on every usage.
     pub blocks_behind_threshold: u64,
 
     /// Above this threshold, the canister is considered to be ahead.
@@ -130,5 +132,33 @@ mod test {
     #[test]
     fn test_bitcoin_canister_endpoint_contains_principal_testnet() {
         assert!(TESTNET_BITCOIN_CANISTER_ENDPOINT.contains(TESTNET_BITCOIN_CANISTER_PRINCIPAL));
+    }
+
+    #[test]
+    fn test_config_mainnet() {
+        let config = Config::mainnet();
+        assert_eq!(config.bitcoin_network, BitcoinNetwork::Mainnet);
+        assert_eq!(
+            config.bitcoin_canister_principal,
+            Principal::from_text(MAINNET_BITCOIN_CANISTER_PRINCIPAL).unwrap()
+        );
+        assert_eq!(
+            config.bitcoin_canister_endpoint,
+            MAINNET_BITCOIN_CANISTER_ENDPOINT
+        );
+    }
+
+    #[test]
+    fn test_config_testnet() {
+        let config = Config::testnet();
+        assert_eq!(config.bitcoin_network, BitcoinNetwork::Testnet);
+        assert_eq!(
+            config.bitcoin_canister_principal,
+            Principal::from_text(TESTNET_BITCOIN_CANISTER_PRINCIPAL).unwrap()
+        );
+        assert_eq!(
+            config.bitcoin_canister_endpoint,
+            TESTNET_BITCOIN_CANISTER_ENDPOINT
+        );
     }
 }

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -1,4 +1,5 @@
 use candid::CandidType;
+use ic_cdk::export::Principal;
 use serde::{Deserialize, Serialize};
 
 /// The Bitcoin network to use.
@@ -12,6 +13,12 @@ const BLOCKS_AHEAD_THRESHOLD: u64 = 2;
 
 /// The minimum number of explorers to compare against.
 const MIN_EXPLORERS: u64 = 2;
+
+/// Mainnet bitcoin canister principal.
+const MAINNET_BITCOIN_CANISTER_PRINCIPAL: &str = "ghsi2-tqaaa-aaaan-aaaca-cai";
+
+/// Testnet bitcoin canister principal.
+const TESTNET_BITCOIN_CANISTER_PRINCIPAL: &str = "g4xu7-jiaaa-aaaan-aaaaq-cai";
 
 /// Mainnet bitcoin canister endpoint.
 const MAINNET_BITCOIN_CANISTER_ENDPOINT: &str =
@@ -52,6 +59,9 @@ pub struct Config {
     /// The minimum number of explorers to compare against.
     pub min_explorers: u64,
 
+    /// Bitcoin canister principal.
+    pub bitcoin_canister_principal: Principal,
+
     /// Bitcoin canister endpoint.
     pub bitcoin_canister_endpoint: String,
 
@@ -78,6 +88,8 @@ impl Config {
             blocks_behind_threshold: BLOCKS_BEHIND_THRESHOLD,
             blocks_ahead_threshold: BLOCKS_AHEAD_THRESHOLD,
             min_explorers: MIN_EXPLORERS,
+            bitcoin_canister_principal: Principal::from_text(MAINNET_BITCOIN_CANISTER_PRINCIPAL)
+                .unwrap(),
             bitcoin_canister_endpoint: MAINNET_BITCOIN_CANISTER_ENDPOINT.to_string(),
             delay_before_first_fetch_sec: DELAY_BEFORE_FIRST_FETCH_SEC,
             interval_between_fetches_sec: INTERVAL_BETWEEN_FETCHES_SEC,
@@ -91,6 +103,8 @@ impl Config {
             blocks_behind_threshold: BLOCKS_BEHIND_THRESHOLD,
             blocks_ahead_threshold: BLOCKS_AHEAD_THRESHOLD,
             min_explorers: MIN_EXPLORERS,
+            bitcoin_canister_principal: Principal::from_text(TESTNET_BITCOIN_CANISTER_PRINCIPAL)
+                .unwrap(),
             bitcoin_canister_endpoint: TESTNET_BITCOIN_CANISTER_ENDPOINT.to_string(),
             delay_before_first_fetch_sec: DELAY_BEFORE_FIRST_FETCH_SEC,
             interval_between_fetches_sec: INTERVAL_BETWEEN_FETCHES_SEC,
@@ -101,5 +115,20 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_bitcoin_canister_endpoint_contains_principal_mainnet() {
+        assert!(MAINNET_BITCOIN_CANISTER_ENDPOINT.contains(MAINNET_BITCOIN_CANISTER_PRINCIPAL));
+    }
+
+    #[test]
+    fn test_bitcoin_canister_endpoint_contains_principal_testnet() {
+        assert!(TESTNET_BITCOIN_CANISTER_ENDPOINT.contains(TESTNET_BITCOIN_CANISTER_PRINCIPAL));
     }
 }

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -44,7 +44,6 @@ pub struct Config {
     pub bitcoin_network: BitcoinNetwork,
 
     /// Below this threshold, the canister is considered to be behind.
-    /// This value is positive, but it must be converted to negative on every usage.
     blocks_behind_threshold: u64,
 
     /// Above this threshold, the canister is considered to be ahead.

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -110,6 +110,7 @@ impl Config {
         self.blocks_ahead_threshold as i64
     }
 
+    /// Returns the Bitcoin canister metrics endpoint.
     pub fn get_bitcoin_canister_endpoint(&self) -> String {
         let principal = self.bitcoin_canister_principal.to_text();
         format!("https://{principal}.raw.ic0.app/metrics")

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -21,14 +21,6 @@ const MAINNET_BITCOIN_CANISTER_PRINCIPAL: &str = "ghsi2-tqaaa-aaaan-aaaca-cai";
 /// Testnet bitcoin canister principal.
 const TESTNET_BITCOIN_CANISTER_PRINCIPAL: &str = "g4xu7-jiaaa-aaaan-aaaaq-cai";
 
-/// Mainnet bitcoin canister endpoint.
-const MAINNET_BITCOIN_CANISTER_ENDPOINT: &str =
-    "https://ghsi2-tqaaa-aaaan-aaaca-cai.raw.ic0.app/metrics";
-
-/// Testnet bitcoin canister endpoint.
-const TESTNET_BITCOIN_CANISTER_ENDPOINT: &str =
-    "https://g4xu7-jiaaa-aaaan-aaaaq-cai.raw.ic0.app/metrics";
-
 /// The number of seconds to wait before the first data fetch.
 const DELAY_BEFORE_FIRST_FETCH_SEC: u64 = 1;
 
@@ -64,9 +56,6 @@ pub struct Config {
     /// Bitcoin canister principal.
     pub bitcoin_canister_principal: Principal,
 
-    /// Bitcoin canister endpoint.
-    pub bitcoin_canister_endpoint: String,
-
     /// The number of seconds to wait before the first data fetch.
     pub delay_before_first_fetch_sec: u64,
 
@@ -92,7 +81,6 @@ impl Config {
             min_explorers: MIN_EXPLORERS,
             bitcoin_canister_principal: Principal::from_text(MAINNET_BITCOIN_CANISTER_PRINCIPAL)
                 .unwrap(),
-            bitcoin_canister_endpoint: MAINNET_BITCOIN_CANISTER_ENDPOINT.to_string(),
             delay_before_first_fetch_sec: DELAY_BEFORE_FIRST_FETCH_SEC,
             interval_between_fetches_sec: INTERVAL_BETWEEN_FETCHES_SEC,
         }
@@ -107,7 +95,6 @@ impl Config {
             min_explorers: MIN_EXPLORERS,
             bitcoin_canister_principal: Principal::from_text(TESTNET_BITCOIN_CANISTER_PRINCIPAL)
                 .unwrap(),
-            bitcoin_canister_endpoint: TESTNET_BITCOIN_CANISTER_ENDPOINT.to_string(),
             delay_before_first_fetch_sec: DELAY_BEFORE_FIRST_FETCH_SEC,
             interval_between_fetches_sec: INTERVAL_BETWEEN_FETCHES_SEC,
         }
@@ -122,6 +109,11 @@ impl Config {
     pub fn get_blocks_ahead_threshold(&self) -> i64 {
         self.blocks_ahead_threshold as i64
     }
+
+    pub fn get_bitcoin_canister_endpoint(&self) -> String {
+        let principal = self.bitcoin_canister_principal.to_text();
+        format!("https://{principal}.raw.ic0.app/metrics")
+    }
 }
 
 impl Default for Config {
@@ -133,6 +125,14 @@ impl Default for Config {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// Mainnet bitcoin canister endpoint.
+    const MAINNET_BITCOIN_CANISTER_ENDPOINT: &str =
+        "https://ghsi2-tqaaa-aaaan-aaaca-cai.raw.ic0.app/metrics";
+
+    /// Testnet bitcoin canister endpoint.
+    const TESTNET_BITCOIN_CANISTER_ENDPOINT: &str =
+        "https://g4xu7-jiaaa-aaaan-aaaaq-cai.raw.ic0.app/metrics";
 
     #[test]
     fn test_bitcoin_canister_endpoint_contains_principal_mainnet() {
@@ -153,7 +153,7 @@ mod test {
             Principal::from_text(MAINNET_BITCOIN_CANISTER_PRINCIPAL).unwrap()
         );
         assert_eq!(
-            config.bitcoin_canister_endpoint,
+            config.get_bitcoin_canister_endpoint(),
             MAINNET_BITCOIN_CANISTER_ENDPOINT
         );
     }
@@ -167,7 +167,7 @@ mod test {
             Principal::from_text(TESTNET_BITCOIN_CANISTER_PRINCIPAL).unwrap()
         );
         assert_eq!(
-            config.bitcoin_canister_endpoint,
+            config.get_bitcoin_canister_endpoint(),
             TESTNET_BITCOIN_CANISTER_ENDPOINT
         );
     }

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -53,10 +53,10 @@ pub struct Config {
 
     /// Below this threshold, the canister is considered to be behind.
     /// This value is positive, but it must be converted to negative on every usage.
-    pub blocks_behind_threshold: u64,
+    blocks_behind_threshold: u64,
 
     /// Above this threshold, the canister is considered to be ahead.
-    pub blocks_ahead_threshold: u64,
+    blocks_ahead_threshold: u64,
 
     /// The minimum number of explorers to compare against.
     pub min_explorers: u64,
@@ -111,6 +111,16 @@ impl Config {
             delay_before_first_fetch_sec: DELAY_BEFORE_FIRST_FETCH_SEC,
             interval_between_fetches_sec: INTERVAL_BETWEEN_FETCHES_SEC,
         }
+    }
+
+    /// Returns the number of blocks behind threshold as a negative number.
+    pub fn get_blocks_behind_threshold(&self) -> i64 {
+        -(self.blocks_behind_threshold as i64)
+    }
+
+    /// Returns the number of blocks ahead threshold as a positive number.
+    pub fn get_blocks_ahead_threshold(&self) -> i64 {
+        self.blocks_ahead_threshold as i64
     }
 }
 

--- a/watchdog/src/endpoints.rs
+++ b/watchdog/src/endpoints.rs
@@ -120,7 +120,7 @@ fn parse_bitcoin_canister_height(text: String) -> Result<u64, String> {
 /// Creates a config for fetching block data from bitcoin_canister.
 pub fn endpoint_bitcoin_canister() -> HttpRequestConfig {
     HttpRequestConfig::new(
-        &crate::storage::get_config().bitcoin_canister_endpoint,
+        &crate::storage::get_config().get_bitcoin_canister_endpoint(),
         Some(transform_bitcoin_canister),
         |raw| {
             apply_to_body(raw, |text| {

--- a/watchdog/src/health.rs
+++ b/watchdog/src/health.rs
@@ -47,10 +47,10 @@ pub struct HealthStatus {
 pub fn health_status() -> HealthStatus {
     let bitcoin_network = crate::storage::get_config().bitcoin_network;
     compare(
-        crate::storage::get(&BitcoinBlockApi::BitcoinCanister),
+        crate::storage::get_block_info(&BitcoinBlockApi::BitcoinCanister),
         BitcoinBlockApi::network_explorers(bitcoin_network)
             .iter()
-            .filter_map(crate::storage::get)
+            .filter_map(crate::storage::get_block_info)
             .collect::<Vec<_>>(),
         crate::storage::get_config(),
     )

--- a/watchdog/src/health.rs
+++ b/watchdog/src/health.rs
@@ -72,10 +72,9 @@ fn compare(source: Option<BlockInfo>, explorers: Vec<BlockInfo>, config: Config)
         .zip(height_target)
         .map(|(source, target)| source as i64 - target as i64);
     let height_status = height_diff.map_or(HeightStatus::NotEnoughData, |diff| {
-        // blocks_behind_threshold must be converted to negative.
-        if diff < -(config.blocks_behind_threshold as i64) {
+        if diff < config.get_blocks_behind_threshold() {
             HeightStatus::Behind
-        } else if diff > config.blocks_ahead_threshold as i64 {
+        } else if diff > config.get_blocks_ahead_threshold() {
             HeightStatus::Ahead
         } else {
             HeightStatus::Ok

--- a/watchdog/src/health.rs
+++ b/watchdog/src/health.rs
@@ -72,6 +72,7 @@ fn compare(source: Option<BlockInfo>, explorers: Vec<BlockInfo>, config: Config)
         .zip(height_target)
         .map(|(source, target)| source as i64 - target as i64);
     let height_status = height_diff.map_or(HeightStatus::NotEnoughData, |diff| {
+        // blocks_behind_threshold must be converted to negative.
         if diff < -(config.blocks_behind_threshold as i64) {
             HeightStatus::Behind
         } else if diff > config.blocks_ahead_threshold as i64 {

--- a/watchdog/src/lib.rs
+++ b/watchdog/src/lib.rs
@@ -86,6 +86,12 @@ pub fn get_config() -> Config {
     crate::storage::get_config()
 }
 
+/// Returns the API access of the Bitcoin canister.
+#[query]
+pub fn get_api_access() -> ApiAccess {
+    crate::storage::get_api_access()
+}
+
 /// Processes external HTTP requests.
 #[query]
 pub fn http_request(request: CandidHttpRequest) -> CandidHttpResponse {

--- a/watchdog/src/lib.rs
+++ b/watchdog/src/lib.rs
@@ -22,19 +22,19 @@ use crate::types::{CandidHttpRequest, CandidHttpResponse};
 use ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs};
 use ic_cdk_macros::{init, post_upgrade, query};
 use serde_bytes::ByteBuf;
+use std::cell::RefCell;
 use std::collections::HashMap;
-use std::sync::RwLock;
 use std::time::Duration;
 
 thread_local! {
     /// The local storage for the data fetched from the external APIs.
-    static BLOCK_INFO_DATA: RwLock<HashMap<BitcoinBlockApi, BlockInfo>> = RwLock::new(HashMap::new());
+    static BLOCK_INFO_DATA: RefCell<HashMap<BitcoinBlockApi, BlockInfo>> = RefCell::new(HashMap::new());
 
     /// The local storage for the API access.
-    static API_ACCESS: RwLock<ApiAccess> = RwLock::new(ApiAccess::new());
+    static API_ACCESS: RefCell<ApiAccess> = RefCell::new(ApiAccess::new());
 
     /// The local storage for the configuration.
-    static CONFIG: RwLock<Config> = RwLock::new(Config::new());
+    static CONFIG: RefCell<Config> = RefCell::new(Config::new());
 }
 
 /// This function is called when the canister is created.

--- a/watchdog/src/lib.rs
+++ b/watchdog/src/lib.rs
@@ -12,13 +12,13 @@ mod types;
 #[cfg(test)]
 mod test_utils;
 
-use crate::api_access::ApiAccess;
 use crate::bitcoin_block_apis::BitcoinBlockApi;
 use crate::config::Config;
 use crate::endpoints::*;
 use crate::fetch::BlockInfo;
 use crate::health::HealthStatus;
 use crate::types::{CandidHttpRequest, CandidHttpResponse};
+use ic_btc_interface::Flag;
 use ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs};
 use ic_cdk_macros::{init, post_upgrade, query};
 use serde_bytes::ByteBuf;
@@ -27,14 +27,14 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 thread_local! {
+    /// The local storage for the configuration.
+    static CONFIG: RefCell<Config> = RefCell::new(Config::new());
+
     /// The local storage for the data fetched from the external APIs.
     static BLOCK_INFO_DATA: RefCell<HashMap<BitcoinBlockApi, BlockInfo>> = RefCell::new(HashMap::new());
 
-    /// The local storage for the API access.
-    static API_ACCESS: RefCell<ApiAccess> = RefCell::new(ApiAccess::new());
-
-    /// The local storage for the configuration.
-    static CONFIG: RefCell<Config> = RefCell::new(Config::new());
+    /// The local storage for the API access target.
+    static API_ACCESS_TARGET: RefCell<Option<Flag>> = RefCell::new(None);
 }
 
 /// This function is called when the canister is created.
@@ -85,10 +85,10 @@ pub fn get_config() -> Config {
     crate::storage::get_config()
 }
 
-/// Returns the API access of the Bitcoin canister as known by the watchdog.
+/// Returns the API access target for the Bitcoin canister.
 #[query]
-pub fn get_api_access() -> ApiAccess {
-    crate::storage::get_api_access()
+pub fn get_api_access_target() -> Option<Flag> {
+    crate::storage::get_api_access_target()
 }
 
 /// Processes external HTTP requests.

--- a/watchdog/src/lib.rs
+++ b/watchdog/src/lib.rs
@@ -70,8 +70,7 @@ async fn fetch_block_info_data() {
 /// Periodically fetches data and sets the API access to the Bitcoin canister.
 async fn tick() {
     fetch_block_info_data().await;
-    crate::api_access::fetch_api_access().await;
-    crate::api_access::set_api_access().await;
+    crate::api_access::synchronise_api_access().await;
 }
 
 /// Returns the health status of the Bitcoin canister.

--- a/watchdog/src/lib.rs
+++ b/watchdog/src/lib.rs
@@ -85,7 +85,7 @@ pub fn get_config() -> Config {
     crate::storage::get_config()
 }
 
-/// Returns the API access of the Bitcoin canister.
+/// Returns the API access of the Bitcoin canister as known by the watchdog.
 #[query]
 pub fn get_api_access() -> ApiAccess {
     crate::storage::get_api_access()

--- a/watchdog/src/metrics.rs
+++ b/watchdog/src/metrics.rs
@@ -57,6 +57,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         .value(&[("network", "testnet")], testnet)?;
     w.encode_gauge(
         "blocks_behind_threshold",
+        // blocks_behind_threshold must be converted to negative.
         -1.0 * config.blocks_behind_threshold as f64,
         "Below this threshold, the canister is considered to be behind.",
     )?;

--- a/watchdog/src/metrics.rs
+++ b/watchdog/src/metrics.rs
@@ -57,13 +57,12 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         .value(&[("network", "testnet")], testnet)?;
     w.encode_gauge(
         "blocks_behind_threshold",
-        // blocks_behind_threshold must be converted to negative.
-        -1.0 * config.blocks_behind_threshold as f64,
+        config.get_blocks_behind_threshold() as f64,
         "Below this threshold, the canister is considered to be behind.",
     )?;
     w.encode_gauge(
         "blocks_ahead_threshold",
-        config.blocks_ahead_threshold as f64,
+        config.get_blocks_ahead_threshold() as f64,
         "Above this threshold, the canister is considered to be ahead.",
     )?;
     w.encode_gauge(

--- a/watchdog/src/metrics.rs
+++ b/watchdog/src/metrics.rs
@@ -2,9 +2,12 @@ use crate::bitcoin_block_apis::BitcoinBlockApi;
 use crate::config::BitcoinNetwork;
 use crate::health::HeightStatus;
 use crate::types::CandidHttpResponse;
+use ic_btc_interface::Flag;
 use ic_metrics_encoder::MetricsEncoder;
 use serde_bytes::ByteBuf;
 use std::collections::HashMap;
+
+const NO_VALUE: f64 = f64::NAN;
 
 /// Returns the metrics in the Prometheus format.
 pub fn get_metrics() -> CandidHttpResponse {
@@ -33,18 +36,40 @@ pub fn get_metrics() -> CandidHttpResponse {
     }
 }
 
+/// Converts a flag to a gauge value.
+fn flag_to_gauge(flag: Option<Flag>) -> f64 {
+    match flag {
+        None => NO_VALUE,
+        Some(Flag::Enabled) => 1.0,
+        Some(Flag::Disabled) => 0.0,
+    }
+}
+
 /// Encodes the metrics in the Prometheus format.
 fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
-    const NO_VALUE: f64 = f64::NAN;
-
-    let bitcoin_network = crate::storage::get_config().bitcoin_network;
-    let (mainnet, testnet) = match bitcoin_network {
+    let config = crate::storage::get_config();
+    let (mainnet, testnet) = match config.bitcoin_network {
         BitcoinNetwork::Mainnet => (1.0, 0.0),
         BitcoinNetwork::Testnet => (0.0, 1.0),
     };
     w.gauge_vec("bitcoin_network", "Bitcoin network.")?
         .value(&[("network", "mainnet")], mainnet)?
         .value(&[("network", "testnet")], testnet)?;
+    w.encode_gauge(
+        "blocks_behind_threshold",
+        -1.0 * config.blocks_behind_threshold as f64,
+        "Below this threshold, the canister is considered to be behind.",
+    )?;
+    w.encode_gauge(
+        "blocks_ahead_threshold",
+        config.blocks_ahead_threshold as f64,
+        "Above this threshold, the canister is considered to be ahead.",
+    )?;
+    w.encode_gauge(
+        "min_explorers",
+        config.min_explorers as f64,
+        "The minimum number of explorers to compare against.",
+    )?;
 
     let health = crate::health::health_status();
     w.encode_gauge(
@@ -75,19 +100,40 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         .value(&[("code", "ahead")], ahead)?
         .value(&[("code", "behind")], behind)?;
 
+    let api_access = crate::storage::get_api_access();
+    w.encode_gauge(
+        "api_access_target",
+        flag_to_gauge(api_access.target),
+        "Expected value of the Bitcoin canister API access flag.",
+    )?;
+    w.encode_gauge(
+        "api_access_actual",
+        flag_to_gauge(api_access.actual),
+        "Actual value of the Bitcoin canister API access flag.",
+    )?;
+
     let mut available_explorers = HashMap::new();
     for explorer in health.explorers {
         available_explorers.insert(explorer.provider.clone(), explorer);
     }
     let mut gauge = w.gauge_vec("explorer_height", "Heights from the explorers.")?;
-    for explorer in BitcoinBlockApi::network_explorers(bitcoin_network) {
+    let mut available_explorers_count: u64 = 0;
+    for explorer in BitcoinBlockApi::network_explorers(config.bitcoin_network) {
         let height = available_explorers
             .get(&explorer)
             .map_or(NO_VALUE, |block_info| {
                 block_info.height.map_or(NO_VALUE, |x| x as f64)
             });
+        if !height.is_nan() {
+            available_explorers_count += 1;
+        }
         gauge = gauge.value(&[("explorer", &explorer.to_string())], height)?;
     }
+    w.encode_gauge(
+        "available_explorers",
+        available_explorers_count as f64,
+        "The number of available explorers to compare against.",
+    )?;
 
     Ok(())
 }

--- a/watchdog/src/metrics.rs
+++ b/watchdog/src/metrics.rs
@@ -100,21 +100,11 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         .value(&[("code", "ahead")], ahead)?
         .value(&[("code", "behind")], behind)?;
 
-    let api_access = crate::storage::get_api_access();
+    let api_access_target = crate::storage::get_api_access_target();
     w.encode_gauge(
         "api_access_target",
-        flag_to_gauge(api_access.target),
+        flag_to_gauge(api_access_target),
         "Expected value of the Bitcoin canister API access flag.",
-    )?;
-    w.encode_gauge(
-        "api_access_actual",
-        flag_to_gauge(api_access.actual),
-        "Actual value of the Bitcoin canister API access flag.",
-    )?;
-    w.encode_gauge(
-        "api_access_is_in_sync",
-        if api_access.is_in_sync() { 1.0 } else { 0.0 },
-        "Whether the actual and target values of the Bitcoin canister API access flag are in sync.",
     )?;
 
     let mut available_explorers = HashMap::new();

--- a/watchdog/src/metrics.rs
+++ b/watchdog/src/metrics.rs
@@ -112,6 +112,11 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         flag_to_gauge(api_access.actual),
         "Actual value of the Bitcoin canister API access flag.",
     )?;
+    w.encode_gauge(
+        "api_access_is_in_sync",
+        if api_access.is_in_sync() { 1.0 } else { 0.0 },
+        "Whether the actual and target values of the Bitcoin canister API access flag are in sync.",
+    )?;
 
     let mut available_explorers = HashMap::new();
     for explorer in health.explorers {

--- a/watchdog/src/storage.rs
+++ b/watchdog/src/storage.rs
@@ -36,5 +36,5 @@ pub fn set_api_access_target(flag: Option<Flag>) {
 
 /// Returns the API access from the local storage.
 pub fn get_api_access_target() -> Option<Flag> {
-    API_ACCESS_TARGET.with(|cell| cell.borrow().clone())
+    API_ACCESS_TARGET.with(|cell| *cell.borrow())
 }

--- a/watchdog/src/storage.rs
+++ b/watchdog/src/storage.rs
@@ -1,19 +1,31 @@
+use crate::api_access::ApiAccess;
 use crate::bitcoin_block_apis::BitcoinBlockApi;
 use crate::config::Config;
 use crate::fetch::BlockInfo;
+use crate::API_ACCESS;
 use crate::BLOCK_INFO_DATA;
 use crate::CONFIG;
 
 /// Inserts the data into the local storage.
-pub fn insert(info: BlockInfo) {
+pub fn insert_block_info(info: BlockInfo) {
     BLOCK_INFO_DATA.with(|data| {
         data.write().unwrap().insert(info.provider.clone(), info);
     });
 }
 
 /// Returns the data from the local storage.
-pub fn get(provider: &BitcoinBlockApi) -> Option<BlockInfo> {
+pub fn get_block_info(provider: &BitcoinBlockApi) -> Option<BlockInfo> {
     BLOCK_INFO_DATA.with(|data| data.read().unwrap().get(provider).cloned())
+}
+
+/// Sets the API access into the local storage.
+pub fn set_api_access(api_access: ApiAccess) {
+    API_ACCESS.with(|cell| *cell.write().unwrap() = api_access);
+}
+
+/// Returns the API access from the local storage.
+pub fn get_api_access() -> ApiAccess {
+    API_ACCESS.with(|cell| cell.read().unwrap().clone())
 }
 
 /// Returns the configuration from the local storage.

--- a/watchdog/src/storage.rs
+++ b/watchdog/src/storage.rs
@@ -8,33 +8,33 @@ use crate::CONFIG;
 
 /// Inserts the data into the local storage.
 pub fn insert_block_info(info: BlockInfo) {
-    BLOCK_INFO_DATA.with(|data| {
-        data.write().unwrap().insert(info.provider.clone(), info);
+    BLOCK_INFO_DATA.with(|cell| {
+        cell.borrow_mut().insert(info.provider.clone(), info);
     });
 }
 
 /// Returns the data from the local storage.
 pub fn get_block_info(provider: &BitcoinBlockApi) -> Option<BlockInfo> {
-    BLOCK_INFO_DATA.with(|data| data.read().unwrap().get(provider).cloned())
+    BLOCK_INFO_DATA.with(|cell| cell.borrow().get(provider).cloned())
 }
 
 /// Sets the API access into the local storage.
 pub fn set_api_access(api_access: ApiAccess) {
-    API_ACCESS.with(|cell| *cell.write().unwrap() = api_access);
+    API_ACCESS.with(|cell| *cell.borrow_mut() = api_access);
 }
 
 /// Returns the API access from the local storage.
 pub fn get_api_access() -> ApiAccess {
-    API_ACCESS.with(|cell| cell.read().unwrap().clone())
+    API_ACCESS.with(|cell| cell.borrow().clone())
 }
 
 /// Returns the configuration from the local storage.
 pub fn get_config() -> Config {
-    CONFIG.with(|cell: &std::sync::RwLock<Config>| cell.read().unwrap().clone())
+    CONFIG.with(|cell| cell.borrow().clone())
 }
 
 /// Sets the configuration in the local storage.
 #[cfg(test)]
 pub fn set_config(config: Config) {
-    CONFIG.with(|cell| *cell.write().unwrap() = config);
+    CONFIG.with(|cell| *cell.borrow_mut() = config);
 }

--- a/watchdog/src/storage.rs
+++ b/watchdog/src/storage.rs
@@ -1,10 +1,21 @@
-use crate::api_access::ApiAccess;
 use crate::bitcoin_block_apis::BitcoinBlockApi;
 use crate::config::Config;
 use crate::fetch::BlockInfo;
-use crate::API_ACCESS;
+use crate::API_ACCESS_TARGET;
 use crate::BLOCK_INFO_DATA;
 use crate::CONFIG;
+use ic_btc_interface::Flag;
+
+/// Returns the configuration from the local storage.
+pub fn get_config() -> Config {
+    CONFIG.with(|cell| cell.borrow().clone())
+}
+
+/// Sets the configuration in the local storage.
+#[cfg(test)]
+pub fn set_config(config: Config) {
+    CONFIG.with(|cell| *cell.borrow_mut() = config);
+}
 
 /// Inserts the data into the local storage.
 pub fn insert_block_info(info: BlockInfo) {
@@ -19,22 +30,11 @@ pub fn get_block_info(provider: &BitcoinBlockApi) -> Option<BlockInfo> {
 }
 
 /// Sets the API access into the local storage.
-pub fn set_api_access(api_access: ApiAccess) {
-    API_ACCESS.with(|cell| *cell.borrow_mut() = api_access);
+pub fn set_api_access_target(flag: Option<Flag>) {
+    API_ACCESS_TARGET.with(|cell| *cell.borrow_mut() = flag);
 }
 
 /// Returns the API access from the local storage.
-pub fn get_api_access() -> ApiAccess {
-    API_ACCESS.with(|cell| cell.borrow().clone())
-}
-
-/// Returns the configuration from the local storage.
-pub fn get_config() -> Config {
-    CONFIG.with(|cell| cell.borrow().clone())
-}
-
-/// Sets the configuration in the local storage.
-#[cfg(test)]
-pub fn set_config(config: Config) {
-    CONFIG.with(|cell| *cell.borrow_mut() = config);
+pub fn get_api_access_target() -> Option<Flag> {
+    API_ACCESS_TARGET.with(|cell| cell.borrow().clone())
 }

--- a/watchdog/tests/get_config.sh
+++ b/watchdog/tests/get_config.sh
@@ -13,8 +13,7 @@ dfx deploy --no-wallet watchdog
 # Request config.
 config=$(dfx canister call watchdog get_config --query)
 
-# Check that the config is correct.
-
+# Check config contains all the following fields.
 config_fields=(
   "bitcoin_network"
   "blocks_behind_threshold"

--- a/watchdog/tests/get_config.sh
+++ b/watchdog/tests/get_config.sh
@@ -13,10 +13,23 @@ dfx deploy --no-wallet watchdog
 # Request config.
 config=$(dfx canister call watchdog get_config --query)
 
-# Check that the config is correct, eg. by checking it has min_explores field.
-if ! [[ $config == *"min_explorers = "* ]]; then
-  echo "FAIL"
-  exit 1
-fi
+# Check that the config is correct.
+
+config_fields=(
+  "bitcoin_network"
+  "blocks_behind_threshold"
+  "blocks_ahead_threshold"
+  "min_explorers"
+  "bitcoin_canister_principal"
+  "delay_before_first_fetch_sec"
+  "interval_between_fetches_sec"
+)
+
+for field in "${config_fields[@]}"; do
+  if ! [[ $config == *"$field = "* ]]; then
+    echo "FAIL: $field not found in config"
+    exit 1
+  fi
+done
 
 echo "SUCCESS"

--- a/watchdog/tests/health_status.sh
+++ b/watchdog/tests/health_status.sh
@@ -26,7 +26,7 @@ health_status=$(dfx canister call watchdog health_status --query)
 
 for field in "${fields[@]}"; do
   if ! [[ $health_status == *"$field = "* ]]; then
-    echo "FAIL: $field not found in metrics page"
+    echo "FAIL: $field not found in health status"
     exit 1
   fi
 done

--- a/watchdog/tests/health_status.sh
+++ b/watchdog/tests/health_status.sh
@@ -13,6 +13,24 @@ dfx start --background --clean
 # Deploy the watchdog canister.
 dfx deploy --no-wallet watchdog
 
+# Check health status has specific fields.
+health_status=$(dfx canister call watchdog health_status --query)
+
+fields=(
+  "height_source"
+  "height_target"
+  "height_diff"
+  "height_status"
+  "explorers"
+)
+
+for field in "${fields[@]}"; do
+  if ! [[ $health_status == *"$field = "* ]]; then
+    echo "FAIL: $field not found in metrics page"
+    exit 1
+  fi
+done
+
 # Request health status repeatedly, break when the data is available.
 has_enough_data=0
 for ((i=1; i<=ITERATIONS; i++))

--- a/watchdog/tests/health_status.sh
+++ b/watchdog/tests/health_status.sh
@@ -14,8 +14,6 @@ dfx start --background --clean
 dfx deploy --no-wallet watchdog
 
 # Check health status has specific fields.
-health_status=$(dfx canister call watchdog health_status --query)
-
 fields=(
   "height_source"
   "height_target"
@@ -23,6 +21,8 @@ fields=(
   "height_status"
   "explorers"
 )
+
+health_status=$(dfx canister call watchdog health_status --query)
 
 for field in "${fields[@]}"; do
   if ! [[ $health_status == *"$field = "* ]]; then

--- a/watchdog/tests/metrics.sh
+++ b/watchdog/tests/metrics.sh
@@ -14,10 +14,26 @@ dfx deploy --no-wallet watchdog
 CANISTER_ID=$(dfx canister id watchdog)
 METRICS=$(curl "http://127.0.0.1:8000/metrics?canisterId=$CANISTER_ID")
 
-# Check that metrics report contains some information.
-if ! [[ "$METRICS" == *"bitcoin_network"* ]]; then
-  echo "FAIL"
-  exit 1
-fi
+# Check that metrics page contains specific metric names.
+metric_names=(
+  "bitcoin_network"
+  "blocks_behind_threshold"
+  "blocks_ahead_threshold"
+  "min_explorers"
+  "bitcoin_canister_height"
+  "height_target"
+  "height_diff"
+  "height_status"
+  "api_access_target"
+  "explorer_height"
+  "available_explorers"
+)
+
+for name in "${metric_names[@]}"; do
+  if ! [[ $METRICS == *"$name"* ]]; then
+    echo "FAIL: $name not found in metrics page"
+    exit 1
+  fi
+done
 
 echo "SUCCESS"


### PR DESCRIPTION
This change adds reading and writing bitcoin canister API access config flag.

API access target is calculated based on the height health status, actual value is read from the bitcoin canister. If there is a difference between the target and actual values, then watchdog tries to rewrite the bitcoin canister API access config flag.

This change also exposes additional metrics: 
- blocks behind/ahead thresholds
- minimum and actual number of explorers
- API access target
