### PR TITLE
chore: expose main_chain_height endpoint for watchdog

### DIFF
--- a/canister/candid.did
+++ b/canister/candid.did
@@ -102,4 +102,6 @@ service bitcoin : (config) -> {
   get_config : () -> (config) query;
 
   set_config : (set_config_request) -> ();
+
+  get_main_chain_height : () -> (nat32) query;
 };

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -67,6 +67,11 @@ async fn set_config(request: SetConfigRequest) {
 }
 
 #[query]
+pub fn get_main_chain_height() -> u32 {
+    ic_btc_canister::with_state(ic_btc_canister::state::main_chain_height)
+}
+
+#[query]
 pub fn http_request(request: HttpRequest) -> HttpResponse {
     ic_btc_canister::http_request(request)
 }


### PR DESCRIPTION
This change exposes `main_chain_height` for the watchdog.

The goal is to switch from reading it via metrics page parsing to making an inter-canister call.