### PR TITLE
feat: add configurable explorers for watchdog canister

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 target
 .dfx
+canister_ids.json

--- a/watchdog/candid.did
+++ b/watchdog/candid.did
@@ -85,6 +85,9 @@ type config = record {
 
     /// The number of seconds to wait between all the other data fetches.
     interval_between_fetches_sec : nat64;
+
+    /// Bitcoin Explorers to use for fetching bitcoin block data.
+    explorers : vec bitcoin_block_api;
 };
 
 type flag = variant {

--- a/watchdog/scripts/deploy.sh
+++ b/watchdog/scripts/deploy.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Hardcoded values.
+BITCOIN_CANISTER_ID_MAINNET=ghsi2-tqaaa-aaaan-aaaca-cai
+BITCOIN_CANISTER_ID_TESTNET=g4xu7-jiaaa-aaaan-aaaaq-cai
+CANISTER_IDS_JSON=./canister_ids.json
+WATCHDOG_CANISTER_ID_MAINNET=gatoo-6iaaa-aaaan-aaacq-cai
+WATCHDOG_CANISTER_ID_TESTNET=gjqfs-iaaaa-aaaan-aaada-cai
+
+# Verify that an argument was provided.
+if [ $# -eq 0 ]; then
+  echo "No arguments provided"
+  echo "Usage: $0 [mainnet|testnet]"
+  exit 1
+fi
+
+# Read network type from command line argument.
+NETWORK_TYPE=$1
+
+# Verify that network type is either mainnet or testnet.
+if [ "$NETWORK_TYPE" != "mainnet" ] && [ "$NETWORK_TYPE" != "testnet" ]; then
+  echo "Invalid network type: $NETWORK_TYPE"
+  echo "Usage: $0 [mainnet|testnet]"
+  exit 1
+fi
+
+# Populate variables depending on network type.
+if [ "$NETWORK_TYPE" == "mainnet" ]; then
+  BITCOIN_CANISTER_ID=$BITCOIN_CANISTER_ID_MAINNET
+  WATCHDOG_CANISTER_ID=$WATCHDOG_CANISTER_ID_MAINNET
+  EXPLORERS="vec {
+    variant { api_blockchair_com_mainnet };
+    variant { api_blockcypher_com_mainnet };
+    variant { blockchain_info_mainnet };
+    variant { blockstream_info_mainnet };
+    variant { chain_api_btc_com_mainnet };
+  }"
+  # Below are disabled explorers (misbehaving, obsolete, etc).
+  #  variant { api_bitaps_com_mainnet };
+else
+  BITCOIN_CANISTER_ID=$BITCOIN_CANISTER_ID_TESTNET
+  WATCHDOG_CANISTER_ID=$WATCHDOG_CANISTER_ID_TESTNET
+  EXPLORERS="vec {
+    variant { api_bitaps_com_testnet };
+    variant { api_blockchair_com_testnet };
+    variant { api_blockcypher_com_testnet };
+    variant { blockstream_info_testnet };
+  }"
+fi
+
+# Run cargo tests, if they fail, exit.
+cargo test -p watchdog
+
+# Create canister_ids.json file.
+echo "{
+    \"watchdog\": {
+        \"ic\": \"$WATCHDOG_CANISTER_ID\"
+    }
+}" > $CANISTER_IDS_JSON
+
+# Deploy the canister.
+dfx deploy --network ic watchdog --no-wallet --argument "(opt record {
+    bitcoin_network = variant { $NETWORK_TYPE };
+    blocks_behind_threshold = 2;
+    blocks_ahead_threshold = 2;
+    min_explorers = 2;
+    bitcoin_canister_principal = principal \"${BITCOIN_CANISTER_ID}\";
+    delay_before_first_fetch_sec = 1;
+    interval_between_fetches_sec = 240;
+    explorers = $EXPLORERS;
+})"

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -1,3 +1,4 @@
+use crate::bitcoin_block_apis::BitcoinBlockApi;
 use candid::CandidType;
 use ic_cdk::export::Principal;
 use serde::{Deserialize, Serialize};
@@ -25,7 +26,7 @@ const TESTNET_BITCOIN_CANISTER_PRINCIPAL: &str = "g4xu7-jiaaa-aaaan-aaaaq-cai";
 const DELAY_BEFORE_FIRST_FETCH_SEC: u64 = 1;
 
 /// The number of seconds to wait between all the other data fetches.
-const INTERVAL_BETWEEN_FETCHES_SEC: u64 = 120;
+const INTERVAL_BETWEEN_FETCHES_SEC: u64 = 240;
 
 /// Bitcoin network.
 #[derive(Clone, Debug, CandidType, PartialEq, Eq, Serialize, Deserialize)]
@@ -60,6 +61,9 @@ pub struct Config {
 
     /// The number of seconds to wait between all the other data fetches.
     pub interval_between_fetches_sec: u64,
+
+    /// Bitcoin Explorers to use for fetching bitcoin block data.
+    pub explorers: Vec<BitcoinBlockApi>,
 }
 
 impl Config {
@@ -82,6 +86,14 @@ impl Config {
                 .unwrap(),
             delay_before_first_fetch_sec: DELAY_BEFORE_FIRST_FETCH_SEC,
             interval_between_fetches_sec: INTERVAL_BETWEEN_FETCHES_SEC,
+            explorers: vec![
+                BitcoinBlockApi::ApiBitapsComMainnet,
+                BitcoinBlockApi::ApiBlockchairComMainnet,
+                BitcoinBlockApi::ApiBlockcypherComMainnet,
+                BitcoinBlockApi::BlockchainInfoMainnet,
+                BitcoinBlockApi::BlockstreamInfoMainnet,
+                BitcoinBlockApi::ChainApiBtcComMainnet,
+            ],
         }
     }
 
@@ -96,6 +108,12 @@ impl Config {
                 .unwrap(),
             delay_before_first_fetch_sec: DELAY_BEFORE_FIRST_FETCH_SEC,
             interval_between_fetches_sec: INTERVAL_BETWEEN_FETCHES_SEC,
+            explorers: vec![
+                BitcoinBlockApi::ApiBitapsComTestnet,
+                BitcoinBlockApi::ApiBlockchairComTestnet,
+                BitcoinBlockApi::ApiBlockcypherComTestnet,
+                BitcoinBlockApi::BlockstreamInfoTestnet,
+            ],
         }
     }
 

--- a/watchdog/src/fetch.rs
+++ b/watchdog/src/fetch.rs
@@ -52,6 +52,7 @@ mod test {
 
     #[tokio::test]
     async fn test_fetch_all_data_mainnet() {
+        crate::storage::set_config(crate::config::Config::mainnet());
         crate::test_utils::mock_mainnet_outcalls();
 
         let result = fetch_all_data(BitcoinNetwork::Mainnet).await;
@@ -71,10 +72,6 @@ mod test {
                     height: Some(700003),
                 },
                 BlockInfo {
-                    provider: BitcoinBlockApi::BitcoinCanister,
-                    height: Some(700007),
-                },
-                BlockInfo {
                     provider: BitcoinBlockApi::BlockchainInfoMainnet,
                     height: Some(700004),
                 },
@@ -85,13 +82,18 @@ mod test {
                 BlockInfo {
                     provider: BitcoinBlockApi::ChainApiBtcComMainnet,
                     height: Some(700006),
-                }
+                },
+                BlockInfo {
+                    provider: BitcoinBlockApi::BitcoinCanister,
+                    height: Some(700007),
+                },
             ]
         );
     }
 
     #[tokio::test]
     async fn test_fetch_all_data_testnet() {
+        crate::storage::set_config(crate::config::Config::testnet());
         crate::test_utils::mock_testnet_outcalls();
 
         let result = fetch_all_data(BitcoinNetwork::Testnet).await;
@@ -111,12 +113,12 @@ mod test {
                     height: Some(2000003),
                 },
                 BlockInfo {
-                    provider: BitcoinBlockApi::BitcoinCanister,
-                    height: Some(2000007),
-                },
-                BlockInfo {
                     provider: BitcoinBlockApi::BlockstreamInfoTestnet,
                     height: Some(2000004),
+                },
+                BlockInfo {
+                    provider: BitcoinBlockApi::BitcoinCanister,
+                    height: Some(2000007),
                 },
             ]
         );
@@ -124,6 +126,7 @@ mod test {
 
     #[tokio::test]
     async fn test_fetch_all_data_failed_404_mainnet() {
+        crate::storage::set_config(crate::config::Config::mainnet());
         crate::test_utils::mock_all_outcalls_404();
 
         let result = fetch_all_data(BitcoinNetwork::Mainnet).await;
@@ -143,10 +146,6 @@ mod test {
                     height: None,
                 },
                 BlockInfo {
-                    provider: BitcoinBlockApi::BitcoinCanister,
-                    height: None,
-                },
-                BlockInfo {
                     provider: BitcoinBlockApi::BlockchainInfoMainnet,
                     height: None,
                 },
@@ -157,13 +156,18 @@ mod test {
                 BlockInfo {
                     provider: BitcoinBlockApi::ChainApiBtcComMainnet,
                     height: None,
-                }
+                },
+                BlockInfo {
+                    provider: BitcoinBlockApi::BitcoinCanister,
+                    height: None,
+                },
             ]
         );
     }
 
     #[tokio::test]
     async fn test_fetch_all_data_failed_404_testnet() {
+        crate::storage::set_config(crate::config::Config::testnet());
         crate::test_utils::mock_all_outcalls_404();
 
         let result = fetch_all_data(BitcoinNetwork::Testnet).await;
@@ -183,11 +187,11 @@ mod test {
                     height: None,
                 },
                 BlockInfo {
-                    provider: BitcoinBlockApi::BitcoinCanister,
+                    provider: BitcoinBlockApi::BlockstreamInfoTestnet,
                     height: None,
                 },
                 BlockInfo {
-                    provider: BitcoinBlockApi::BlockstreamInfoTestnet,
+                    provider: BitcoinBlockApi::BitcoinCanister,
                     height: None,
                 },
             ]


### PR DESCRIPTION
This PR adds configurable bitcoin explorers to the watchdog canister.

Additionally
- change the fetching duration from 2 to 4 minutes (not to abuse explorer APIs)
- add deployment script to simplify deploying watchdog canister to mainnet/testnet
- updates some tests due to the changed `providers` order (bitcoin canister now comes at the end)