### PR TITLE
chore: add watchdog-canister to docker

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -447,6 +447,17 @@ jobs:
         run: |
           bash watchdog/e2e-tests/metrics.sh
 
+  reproducibility:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Verify Reproducibility
+        run: |
+          ./scripts/verify_reproducibility.sh Dockerfile
+
   checks-pass:
     needs:
       - cargo-tests
@@ -463,6 +474,7 @@ jobs:
       - watchdog_health_status
       - watchdog_get_config
       - watchdog_metrics
+      - reproducibility
     runs-on: ubuntu-20.04
     steps:
        - name: Checks workflow passes

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -447,7 +447,7 @@ jobs:
         run: |
           bash watchdog/e2e-tests/metrics.sh
 
-  reproducibility:
+  canister-build-reproducibility:
     runs-on: ubuntu-20.04
 
     steps:
@@ -474,7 +474,7 @@ jobs:
       - watchdog_health_status
       - watchdog_get_config
       - watchdog_metrics
-      - reproducibility
+      - canister-build-reproducibility
     runs-on: ubuntu-20.04
     steps:
        - name: Checks workflow passes

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -456,7 +456,7 @@ jobs:
 
       - name: Verify Reproducibility
         run: |
-          ./scripts/reproducibility.sh Dockerfile
+          ./e2e-tests/reproducibility.sh Dockerfile
 
   checks-pass:
     needs:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -456,7 +456,7 @@ jobs:
 
       - name: Verify Reproducibility
         run: |
-          ./scripts/verify_reproducibility.sh Dockerfile
+          ./scripts/reproducibility.sh Dockerfile
 
   checks-pass:
     needs:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 target
 .dfx
 canister_ids.json
+
+*.wasm.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,16 @@
 # reproducibility and consistency of builds within this isolated setup.
 #
 # Use the following commands:
+#
 # docker build -t canisters .
+#
 # docker run --rm --entrypoint cat canisters /ic-btc-canister.wasm.gz > ic-btc-canister.wasm.gz
 # docker run --rm --entrypoint cat canisters /uploader-canister.wasm.gz > uploader-canister.wasm.gz
 # docker run --rm --entrypoint cat canisters /watchdog-canister.wasm.gz > watchdog-canister.wasm.gz
+#
+# sha256sum ic-btc-canister.wasm.gz
+# sha256sum uploader-canister.wasm.gz
+# sha256sum watchdog-canister.wasm.gz
 
 # The docker image. To update, run `docker pull ubuntu` locally, and update the
 # sha256:... accordingly.
@@ -46,21 +52,19 @@ RUN curl --fail https://sh.rustup.rs -sSf \
 
 ENV PATH=/cargo/bin:$PATH
 
-# Copy the current directory (containing your source code and build scripts) into the Docker image.
+# Copy the current directory (containing source code and build scripts) into the Docker image.
 COPY . .
 
 RUN \
-    echo "Building bitcoin canister..." && \
+    # Building bitcoin canister...
     scripts/build-canister.sh ic-btc-canister && \
     cp target/wasm32-unknown-unknown/release/ic-btc-canister.wasm.gz ic-btc-canister.wasm.gz && \
     sha256sum ic-btc-canister.wasm.gz && \
-    \
-    echo "Building uploader canister..." && \
+    # Building uploader canister...
     scripts/build-canister.sh uploader-canister && \
     cp target/wasm32-unknown-unknown/release/uploader-canister.wasm.gz uploader-canister.wasm.gz && \
     sha256sum uploader-canister.wasm.gz && \
-    \
-    echo "Building watchdog canister..." && \
+    # Building watchdog canister...
     scripts/build-canister.sh watchdog-canister && \
     cp target/wasm32-unknown-unknown/release/watchdog-canister.wasm.gz watchdog-canister.wasm.gz && \
     sha256sum watchdog-canister.wasm.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,12 +54,12 @@ RUN \
     scripts/build-canister.sh ic-btc-canister && \
     cp target/wasm32-unknown-unknown/release/ic-btc-canister.wasm.gz ic-btc-canister.wasm.gz && \
     sha256sum ic-btc-canister.wasm.gz && \
-
+    \
     echo "Building uploader canister..." && \
     scripts/build-canister.sh uploader-canister && \
     cp target/wasm32-unknown-unknown/release/uploader-canister.wasm.gz uploader-canister.wasm.gz && \
     sha256sum uploader-canister.wasm.gz && \
-
+    \
     echo "Building watchdog canister..." && \
     scripts/build-canister.sh watchdog-canister && \
     cp target/wasm32-unknown-unknown/release/watchdog-canister.wasm.gz watchdog-canister.wasm.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,9 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone &
     apt -yq update && \
     apt -yqq install --no-install-recommends curl ca-certificates \
     build-essential pkg-config libssl-dev llvm-dev liblmdb-dev clang cmake \
-    git
+    git && \
+    # Package cleanup to reduce image size.
+    rm -rf /var/lib/apt/lists/*
 
 # Install Rust and Cargo in /opt
 ENV RUSTUP_HOME=/opt/rustup \
@@ -44,19 +46,21 @@ RUN curl --fail https://sh.rustup.rs -sSf \
 
 ENV PATH=/cargo/bin:$PATH
 
+# Copy the current directory (containing your source code and build scripts) into the Docker image.
 COPY . .
 
-# Build bitcoin canister
-RUN scripts/build-canister.sh ic-btc-canister \
-    && cp target/wasm32-unknown-unknown/release/ic-btc-canister.wasm.gz ic-btc-canister.wasm.gz \
-    && sha256sum ic-btc-canister.wasm.gz
+RUN \
+    echo "Building bitcoin canister..." && \
+    scripts/build-canister.sh ic-btc-canister && \
+    cp target/wasm32-unknown-unknown/release/ic-btc-canister.wasm.gz ic-btc-canister.wasm.gz && \
+    sha256sum ic-btc-canister.wasm.gz && \
 
-# Build uploader canister
-RUN scripts/build-canister.sh uploader-canister \
-    && cp target/wasm32-unknown-unknown/release/uploader-canister.wasm.gz uploader-canister.wasm.gz \
-    && sha256sum uploader-canister.wasm.gz
+    echo "Building uploader canister..." && \
+    scripts/build-canister.sh uploader-canister && \
+    cp target/wasm32-unknown-unknown/release/uploader-canister.wasm.gz uploader-canister.wasm.gz && \
+    sha256sum uploader-canister.wasm.gz && \
 
-# Build watchdog canister
-RUN scripts/build-canister.sh watchdog-canister \
-    && cp target/wasm32-unknown-unknown/release/watchdog-canister.wasm.gz watchdog-canister.wasm.gz \
-    && sha256sum watchdog-canister.wasm.gz
+    echo "Building watchdog canister..." && \
+    scripts/build-canister.sh watchdog-canister && \
+    cp target/wasm32-unknown-unknown/release/watchdog-canister.wasm.gz watchdog-canister.wasm.gz && \
+    sha256sum watchdog-canister.wasm.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,3 +43,8 @@ RUN sha256sum ic-btc-canister.wasm.gz
 RUN scripts/build-canister.sh uploader-canister
 RUN cp target/wasm32-unknown-unknown/release/uploader-canister.wasm.gz uploader-canister.wasm.gz
 RUN sha256sum uploader-canister.wasm.gz
+
+# Build watchdog canister
+RUN scripts/build-canister.sh watchdog-canister
+RUN cp target/wasm32-unknown-unknown/release/watchdog-canister.wasm.gz watchdog-canister.wasm.gz
+RUN sha256sum watchdog-canister.wasm.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
-# Use this with
+# Dockerfile: Canister Build Environment
 #
+# This Dockerfile prepares an environment to build and verify the integrity of 
+# these specific WebAssembly canisters:
+#  - ic-btc-canister
+#  - uploader-canister
+#  - watchdog-canister
+#
+# Each canister is built, compressed, and checksum-verified, ensuring 
+# reproducibility and consistency of builds within this isolated setup.
+#
+# Use the following commands:
 # docker build -t canisters .
 # docker run --rm --entrypoint cat canisters /ic-btc-canister.wasm.gz > ic-btc-canister.wasm.gz
-# docker run --rm --entrypoint cat canisters /uploader-canister.wasm > uploader-canister.wasm
+# docker run --rm --entrypoint cat canisters /uploader-canister.wasm.gz > uploader-canister.wasm.gz
+# docker run --rm --entrypoint cat canisters /watchdog-canister.wasm.gz > watchdog-canister.wasm.gz
 
 # The docker image. To update, run `docker pull ubuntu` locally, and update the
 # sha256:... accordingly.
@@ -12,6 +23,7 @@ FROM ubuntu@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3
 # should be updated as well.
 ARG rust_version=1.68.0
 
+# Setting the timezone and installing the necessary dependencies
 ENV TZ=UTC
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
@@ -35,16 +47,16 @@ ENV PATH=/cargo/bin:$PATH
 COPY . .
 
 # Build bitcoin canister
-RUN scripts/build-canister.sh ic-btc-canister
-RUN cp target/wasm32-unknown-unknown/release/ic-btc-canister.wasm.gz ic-btc-canister.wasm.gz
-RUN sha256sum ic-btc-canister.wasm.gz
+RUN scripts/build-canister.sh ic-btc-canister \
+    && cp target/wasm32-unknown-unknown/release/ic-btc-canister.wasm.gz ic-btc-canister.wasm.gz \
+    && sha256sum ic-btc-canister.wasm.gz
 
 # Build uploader canister
-RUN scripts/build-canister.sh uploader-canister
-RUN cp target/wasm32-unknown-unknown/release/uploader-canister.wasm.gz uploader-canister.wasm.gz
-RUN sha256sum uploader-canister.wasm.gz
+RUN scripts/build-canister.sh uploader-canister \
+    && cp target/wasm32-unknown-unknown/release/uploader-canister.wasm.gz uploader-canister.wasm.gz \
+    && sha256sum uploader-canister.wasm.gz
 
 # Build watchdog canister
-RUN scripts/build-canister.sh watchdog-canister
-RUN cp target/wasm32-unknown-unknown/release/watchdog-canister.wasm.gz watchdog-canister.wasm.gz
-RUN sha256sum watchdog-canister.wasm.gz
+RUN scripts/build-canister.sh watchdog-canister \
+    && cp target/wasm32-unknown-unknown/release/watchdog-canister.wasm.gz watchdog-canister.wasm.gz \
+    && sha256sum watchdog-canister.wasm.gz

--- a/dfx.json
+++ b/dfx.json
@@ -8,9 +8,10 @@
       "build": "./scripts/build-canister.sh ic-btc-canister"
     },
     "watchdog": {
-      "type": "rust",
-      "package": "watchdog",
-      "candid": "./watchdog/candid.did"
+      "type": "custom",
+      "candid": "./watchdog/candid.did",
+      "build": "./scripts/build-canister.sh watchdog-canister",
+      "wasm": "./target/wasm32-unknown-unknown/release/watchdog-canister.wasm.gz"
     },
     "benchmarks": {
       "candid": "./benchmarks/candid.did",

--- a/e2e-tests/reproducibility.sh
+++ b/e2e-tests/reproducibility.sh
@@ -52,8 +52,14 @@ sha256sum2=$(sha256sum "$tmpdir/watchdog-canister.wasm.gz" "$tmpdir/uploader-can
 # Compare the SHA256 sums
 if [ "$sha256sum1" = "$sha256sum2" ]; then
   echo "SUCCESS: Reproducible build, SHA256 sums match."
+  echo "Result SHA256 Sums:"
+  echo "$sha256sum1"
   exit 0
 else
   echo "FAIL: Non-reproducible build, SHA256 sums differ."
+  echo "Result SHA256 Sums 1st Build:"
+  echo "$sha256sum1"
+  echo "Result SHA256 Sums 2nd Build:"
+  echo "$sha256sum2"
   exit 1
 fi

--- a/e2e-tests/reproducibility.sh
+++ b/e2e-tests/reproducibility.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# To run it from the root folder:
+# ./e2e-tests/reproducibility.sh Dockerfile
+
+# Verify the argument count
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <dockerfile>"
+  exit 1
+fi
+
+# Get the absolute path of the Dockerfile
+dockerfile=$(realpath "$1")
+dockerfile_dir=$(dirname "$dockerfile")
+
+# Build the Docker image for the first time
+echo "Building Docker image (1st build)..."
+docker build -t canisters "$dockerfile_dir"
+
+# Create a temporary directory to store the wasm files
+tmpdir=$(mktemp -d)
+
+# Extract the wasm files from the first build
+docker run --rm -v "$tmpdir:/output" canisters cp /watchdog-canister.wasm.gz /output/watchdog-canister.wasm.gz
+docker run --rm -v "$tmpdir:/output" canisters cp /uploader-canister.wasm.gz /output/uploader-canister.wasm.gz
+docker run --rm -v "$tmpdir:/output" canisters cp /ic-btc-canister.wasm.gz /output/ic-btc-canister.wasm.gz
+
+# Calculate the SHA256 sums for the first build
+echo "Calculating SHA256 sums (1st build)..."
+sha256sum1=$(sha256sum "$tmpdir/watchdog-canister.wasm.gz" "$tmpdir/uploader-canister.wasm.gz" "$tmpdir/ic-btc-canister.wasm.gz")
+
+# Build the Docker image for the second time
+echo "Building Docker image (2nd build)..."
+docker build -t canisters "$dockerfile_dir"
+
+# Extract the wasm files from the second build
+docker run --rm -v "$tmpdir:/output" canisters cp /watchdog-canister.wasm.gz /output/watchdog-canister.wasm.gz
+docker run --rm -v "$tmpdir:/output" canisters cp /uploader-canister.wasm.gz /output/uploader-canister.wasm.gz
+docker run --rm -v "$tmpdir:/output" canisters cp /ic-btc-canister.wasm.gz /output/ic-btc-canister.wasm.gz
+
+# Calculate the SHA256 sums for the second build
+echo "Calculating SHA256 sums (2nd build)..."
+sha256sum2=$(sha256sum "$tmpdir/watchdog-canister.wasm.gz" "$tmpdir/uploader-canister.wasm.gz" "$tmpdir/ic-btc-canister.wasm.gz")
+
+# Compare the SHA256 sums
+if [ "$sha256sum1" = "$sha256sum2" ]; then
+  echo "SUCCESS: Reproducible build, SHA256 sums match."
+  exit 0
+else
+  echo "FAIL: Non-reproducible build, SHA256 sums differ."
+  exit 1
+fi

--- a/e2e-tests/reproducibility.sh
+++ b/e2e-tests/reproducibility.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-# To run it from the root folder:
+# This script verifies the reproducibility of a Docker build by
+# performing the following steps:
+# - Build the Docker image twice
+# - Copy the WebAssembly (wasm) files from each build
+# - Calculate the SHA256 sums of the wasm files
+# - Compare the SHA256 sums to check for reproducibility
+#
+# Example:
 # ./e2e-tests/reproducibility.sh Dockerfile
 
 # Verify the argument count

--- a/watchdog/Cargo.toml
+++ b/watchdog/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [[bin]]
-name = "watchdog"
+name = "watchdog-canister"
 path = "src/main.rs"
 
 [dependencies]


### PR DESCRIPTION
This PR adds a watchdog canister to a docker file to build and verify its integrity.

Additionally:
- added reproducibility CI check, which runs docker build 2 times and compares the check sums
- added top-level comment to Dockerfile
- minimised the number of layers by combining commands in a single `RUN` with `&&`
- added packet manager cache cleanup to reduce the image size
