### PR TITLE
chore: add watchdog_canister to set_config_request api

### DIFF
--- a/canister/candid.did
+++ b/canister/candid.did
@@ -88,7 +88,7 @@ type set_config_request = record {
   fees : opt fees;
   api_access : opt flag;
   disable_api_if_not_fully_synced : opt flag;
-  watchdog_canister : opt principal;
+  watchdog_canister : opt opt principal;
 };
 
 service bitcoin : (config) -> {

--- a/canister/candid.did
+++ b/canister/candid.did
@@ -88,6 +88,7 @@ type set_config_request = record {
   fees : opt fees;
   api_access : opt flag;
   disable_api_if_not_fully_synced : opt flag;
+  watchdog_canister : opt principal;
 };
 
 service bitcoin : (config) -> {

--- a/canister/src/api/set_config.rs
+++ b/canister/src/api/set_config.rs
@@ -55,6 +55,9 @@ fn set_config_no_verification(request: SetConfigRequest) {
         if let Some(disable_api_if_not_fully_synced) = request.disable_api_if_not_fully_synced {
             s.disable_api_if_not_fully_synced = disable_api_if_not_fully_synced;
         }
+        if let Some(watchdog_canister) = request.watchdog_canister {
+            s.watchdog_canister = watchdog_canister;
+        }
     });
 }
 

--- a/canister/src/api/set_config.rs
+++ b/canister/src/api/set_config.rs
@@ -87,6 +87,7 @@ async fn verify_caller() {
 mod test {
     use super::*;
     use crate::{init, with_state};
+    use candid::Principal;
     use ic_btc_interface::{Config, Fees, Flag};
     use proptest::prelude::*;
 
@@ -222,6 +223,25 @@ mod test {
             });
 
             assert_eq!(with_state(|s| s.disable_api_if_not_fully_synced), *flag);
+        }
+    }
+
+    #[test]
+    fn test_set_watchdog_canister() {
+        init(Config::default());
+
+        for watchdog_canister in [
+            None,
+            Some(Principal::anonymous()),
+            Some(Principal::management_canister()),
+            Some(Principal::from_text("g4xu7-jiaaa-aaaan-aaaaq-cai").unwrap()),
+        ] {
+            set_config_no_verification(SetConfigRequest {
+                watchdog_canister: Some(watchdog_canister),
+                ..Default::default()
+            });
+
+            assert_eq!(with_state(|s| s.watchdog_canister), watchdog_canister);
         }
     }
 }

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -299,6 +299,11 @@ pub struct SetConfigRequest {
 
     /// Whether or not to enable/disable the bitcoin apis if not fully synced.
     pub disable_api_if_not_fully_synced: Option<Flag>,
+
+    /// The principal of the watchdog canister.
+    /// The watchdog canister has the authority to disable the Bitcoin canister's API
+    /// if it suspects that there is a problem.
+    pub watchdog_canister: Option<Option<Principal>>,
 }
 
 #[derive(CandidType, Serialize, Deserialize, PartialEq, Eq, Copy, Clone, Debug, Default)]


### PR DESCRIPTION
This PR adds the ability to set a watchdog canister principal in a bitcoin canister config via `set_config` API, which is used to update the bitcoin canister config via proposals.

The watchdog_canister principal ID can be flexibly configured according to your needs. You can either assign an actual principal ID or reset it back to None, providing more control and customization for your canister settings.