### PR TITLE
chore: add WDC upgradability test and refactor similar bitcoin-canister upgradability test

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -447,6 +447,38 @@ jobs:
         run: |
           bash watchdog/e2e-tests/metrics.sh
 
+  watchdog_upgradability:
+    runs-on: ubuntu-20.04
+    needs: cargo-build
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+
+      - name: Install Rust
+        run: |
+          rustup update ${{ matrix.rust }} --no-self-update
+          rustup default ${{ matrix.rust }}
+          rustup target add wasm32-unknown-unknown
+
+      - name: Install DFX
+        run: |
+          wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
+          bash install-dfx.sh < <(yes Y)
+          rm install-dfx.sh
+          dfx cache install
+          echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Run upgradability test
+        run: |
+          bash watchdog/e2e-tests/upgradability.sh
+
   canister-build-reproducibility:
     runs-on: ubuntu-20.04
 

--- a/dfx.json
+++ b/dfx.json
@@ -13,6 +13,11 @@
       "build": "./scripts/build-canister.sh watchdog-canister",
       "wasm": "./target/wasm32-unknown-unknown/release/watchdog-canister.wasm.gz"
     },
+    "watchdog-upgradability-test": {
+      "type": "custom",
+      "candid": "./watchdog/candid.did",
+      "wasm": "watchdog-upgradability-test.wasm.gz"
+    },
     "benchmarks": {
       "candid": "./benchmarks/candid.did",
       "package": "benchmarks",

--- a/e2e-tests/upgradability.sh
+++ b/e2e-tests/upgradability.sh
@@ -13,7 +13,7 @@ set -Eexuo pipefail
 
 # Constants.
 MANAGEMENT_CANISTER="aaaaa-aa"
-REFERENCE_CANISTER_NAME="reference-canister"
+REFERENCE_CANISTER_NAME="upgradability-test"
 ARGUMENT="(record { 
  stability_threshold = 2;
  network = variant { regtest };

--- a/e2e-tests/upgradability.sh
+++ b/e2e-tests/upgradability.sh
@@ -65,7 +65,7 @@ dfx deploy --no-wallet ${REFERENCE_CANISTER_NAME} --argument "${ARGUMENT}"
 dfx canister stop ${REFERENCE_CANISTER_NAME}
 
 # Update the local dfx configuration to point to the 'bitcoin' canister 
-# in the current branch, rather than the 'reference-canister'.
+# in the current branch, rather than the reference canister.
 sed -i'' -e 's/'${REFERENCE_CANISTER_NAME}'/bitcoin/' .dfx/local/canister_ids.json
 
 # Verify that the bitcoin canister now exists and is already stopped.

--- a/e2e-tests/upgradability.sh
+++ b/e2e-tests/upgradability.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
+
+# This script tests the upgradability of a bitcoin canister.
+#
+# The process follows these steps:
+# - Fetches and downloads the latest release of the bitcoin canister (a reference canister).
+# - Deploys this reference canister on a local IC network.
+# - Upgrades the reference canister to a recent 'bitcoin' canister from the current branch.
+# - Verifies that the 'bitcoin' canister is in a 'stopped' state.
+# - Tests canister upgradability by redeploying and restarting it.
+
 set -Eexuo pipefail
 
-# Run dfx stop if we run into errors and remove the downloaded wasm.
-trap "dfx stop & rm upgradability-test.wasm.gz" EXIT SIGINT
-
-SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-PARENT_DIR="$(dirname "$SCRIPT_DIR")"
-
-pushd "$PARENT_DIR"
-
-# The URL of the latest release.
-LATEST_RELEASE="$(curl -s https://api.github.com/repos/dfinity/bitcoin-canister/releases/latest | grep "browser_download_url" | awk '{ print $2 }' | sed 's/,$//' | sed 's/"//g' | grep "ic-btc-canister.wasm.gz")"
+# Constants.
 MANAGEMENT_CANISTER="aaaaa-aa"
+REFERENCE_CANISTER_NAME="reference-canister"
 ARGUMENT="(record { 
  stability_threshold = 2;
  network = variant { regtest };
@@ -32,27 +34,46 @@ ARGUMENT="(record {
  watchdog_canister = null;
 })"
 
-# Download the latest release
-wget -O upgradability-test.wasm.gz "${LATEST_RELEASE}"
+# Run dfx stop if we run into errors and remove the downloaded wasm.
+trap "dfx stop & rm ${REFERENCE_CANISTER_NAME}.wasm.gz" EXIT SIGINT
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PARENT_DIR="$(dirname "$SCRIPT_DIR")"
+
+pushd "$PARENT_DIR"
+
+# Get the URL of the latest release.
+get_latest_release_url() {
+  curl -s https://api.github.com/repos/dfinity/bitcoin-canister/releases/latest | 
+  grep "browser_download_url.*ic-btc-canister.wasm.gz" | 
+  cut -d '"' -f 4
+}
+
+# Download the latest release.
+download_latest_release() {
+  local url=$(get_latest_release_url)
+  wget -O "${REFERENCE_CANISTER_NAME}.wasm.gz" "${url}"
+}
+download_latest_release
 
 dfx start --background --clean
 
-# Deploy the latest release
-dfx deploy --no-wallet upgradability-test --argument "${ARGUMENT}"
+# Deploy the latest release.
+dfx deploy --no-wallet ${REFERENCE_CANISTER_NAME} --argument "${ARGUMENT}"
 
-dfx canister stop upgradability-test
+dfx canister stop ${REFERENCE_CANISTER_NAME}
 
-# replace from upgradability-test with bitcoin in .dfx/local/canister_ids.json
+# Replace from reference-canister with bitcoin in .dfx/local/canister_ids.json
 # so that the canister is upgraded to the bitcoin canister of the current branch.
-sed -i'' -e 's/upgradability-test/bitcoin/' .dfx/local/canister_ids.json
+sed -i'' -e 's/'${REFERENCE_CANISTER_NAME}'/bitcoin/' .dfx/local/canister_ids.json
 
 # Verify that the bitcoin canister now exists and is already stopped.
 if ! [[ $(dfx canister status bitcoin 2>&1) == *"Status: Stopped"* ]]; then
-  echo "Bitcoin canister must be already created and stopped."
+  echo "Failed to create and stop Bitcoin canister."
   exit 1
 fi
 
-# Deploy upgraded canister
+# Deploy upgraded canister.
 dfx deploy --no-wallet bitcoin --argument "${ARGUMENT}"
 
 dfx canister start bitcoin

--- a/e2e-tests/upgradability.sh
+++ b/e2e-tests/upgradability.sh
@@ -63,8 +63,8 @@ dfx deploy --no-wallet ${REFERENCE_CANISTER_NAME} --argument "${ARGUMENT}"
 
 dfx canister stop ${REFERENCE_CANISTER_NAME}
 
-# Replace from reference-canister with bitcoin in .dfx/local/canister_ids.json
-# so that the canister is upgraded to the bitcoin canister of the current branch.
+# Update the local dfx configuration to point to the 'bitcoin' canister 
+# in the current branch, rather than the 'reference-canister'.
 sed -i'' -e 's/'${REFERENCE_CANISTER_NAME}'/bitcoin/' .dfx/local/canister_ids.json
 
 # Verify that the bitcoin canister now exists and is already stopped.

--- a/e2e-tests/upgradability.sh
+++ b/e2e-tests/upgradability.sh
@@ -35,7 +35,7 @@ ARGUMENT="(record {
 })"
 
 # Run dfx stop if we run into errors and remove the downloaded wasm.
-trap "dfx stop & rm ${REFERENCE_CANISTER_NAME}.wasm.gz" EXIT SIGINT
+trap 'dfx stop & rm ${REFERENCE_CANISTER_NAME}.wasm.gz' EXIT SIGINT
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 PARENT_DIR="$(dirname "$SCRIPT_DIR")"
@@ -51,7 +51,8 @@ get_latest_release_url() {
 
 # Download the latest release.
 download_latest_release() {
-  local url=$(get_latest_release_url)
+  local url
+  url=$(get_latest_release_url)
   wget -O "${REFERENCE_CANISTER_NAME}.wasm.gz" "${url}"
 }
 download_latest_release

--- a/e2e-tests/upgradability.sh
+++ b/e2e-tests/upgradability.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script tests the upgradability of a bitcoin canister.
+# This script tests the upgradability of the bitcoin canister.
 #
 # The process follows these steps:
 # - Fetches and downloads the latest release of the bitcoin canister (a reference canister).

--- a/watchdog/e2e-tests/upgradability.sh
+++ b/watchdog/e2e-tests/upgradability.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# This script tests the upgradability of a watchdog canister.
+# The process follows these steps:
+# - Fetches and downloads the latest release of the watchdog canister (a reference canister).
+# - Deploys this reference canister on a local IC network.
+# - Upgrades the reference canister to a recent 'watchdog' canister from the current branch.
+# - Verifies that the 'watchdog' canister is in a 'stopped' state.
+# - Tests canister upgradability by redeploying and restarting it.
+
+set -Eexuo pipefail
+
+# Constants.
+REFERENCE_CANISTER_NAME="reference-canister"
+BITCOIN_NETWORK=mainnet
+BITCOIN_CANISTER_ID=ghsi2-tqaaa-aaaan-aaaca-cai
+ARGUMENT="(opt record {
+  bitcoin_network = variant { ${BITCOIN_NETWORK} };
+  blocks_behind_threshold = 2;
+  blocks_ahead_threshold = 2;
+  min_explorers = 3;
+  bitcoin_canister_principal = principal \"${BITCOIN_CANISTER_ID}\";
+  delay_before_first_fetch_sec = 1;
+  interval_between_fetches_sec = 300;
+  explorers = vec {
+    variant { api_blockchair_com_mainnet };
+    variant { api_blockcypher_com_mainnet };
+    variant { blockchain_info_mainnet };
+    variant { blockstream_info_mainnet };
+    variant { chain_api_btc_com_mainnet };
+  };
+})"
+
+# Source the utility functions.
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source "${SCRIPT_DIR}/utils.sh"
+
+# Run dfx stop if we run into errors and remove the downloaded wasm.
+trap "dfx stop & rm ${REFERENCE_CANISTER_NAME}.wasm.gz" EXIT SIGINT
+
+# Get the URL of the latest release.
+get_latest_release_url() {
+  curl -s https://api.github.com/repos/dfinity/bitcoin-canister/releases/latest | 
+  grep "browser_download_url.*watchdog-canister.wasm.gz" | 
+  cut -d '"' -f 4
+}
+
+# Download the latest release.
+download_latest_release() {
+  local url=$(get_latest_release_url)
+  wget -O "${REFERENCE_CANISTER_NAME}.wasm.gz" "${url}"
+}
+download_latest_release
+
+dfx start --background --clean
+
+# Deploy the latest release.
+dfx deploy --no-wallet ${REFERENCE_CANISTER_NAME} --argument "${ARGUMENT}"
+
+dfx canister stop ${REFERENCE_CANISTER_NAME}
+
+# Update the local dfx configuration to point to the 'watchdog' canister 
+# in the current branch, rather than the 'reference-canister'.
+sed -i'' -e 's/'${REFERENCE_CANISTER_NAME}'/watchdog/' .dfx/local/canister_ids.json
+
+# Verify that the watchdog canister now exists and is already stopped.
+if ! [[ $(dfx canister status watchdog 2>&1) == *"Status: Stopped"* ]]; then
+  echo "Failed to create and stop watchdog canister."
+  exit 1
+fi
+
+# Deploy upgraded canister.
+dfx deploy --no-wallet watchdog --argument "${ARGUMENT}"
+
+dfx canister start watchdog
+dfx canister stop watchdog
+
+# Redeploy the canister to test the pre-upgrade hook.
+dfx deploy --upgrade-unchanged watchdog --argument "${ARGUMENT}"
+dfx canister start watchdog
+
+echo "SUCCESS"

--- a/watchdog/e2e-tests/upgradability.sh
+++ b/watchdog/e2e-tests/upgradability.sh
@@ -11,7 +11,7 @@
 set -Eexuo pipefail
 
 # Constants.
-REFERENCE_CANISTER_NAME="reference-canister"
+REFERENCE_CANISTER_NAME="watchdog-upgradability-test"
 BITCOIN_NETWORK=mainnet
 BITCOIN_CANISTER_ID=ghsi2-tqaaa-aaaan-aaaca-cai
 ARGUMENT="(opt record {

--- a/watchdog/e2e-tests/upgradability.sh
+++ b/watchdog/e2e-tests/upgradability.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# This script tests the upgradability of a watchdog canister.
+# This script tests the upgradability of the watchdog canister.
 # The process follows these steps:
 # - Fetches and downloads the latest release of the watchdog canister (a reference canister).
 # - Deploys this reference canister on a local IC network.

--- a/watchdog/e2e-tests/upgradability.sh
+++ b/watchdog/e2e-tests/upgradability.sh
@@ -61,7 +61,7 @@ dfx deploy --no-wallet ${REFERENCE_CANISTER_NAME} --argument "${ARGUMENT}"
 dfx canister stop ${REFERENCE_CANISTER_NAME}
 
 # Update the local dfx configuration to point to the 'watchdog' canister 
-# in the current branch, rather than the 'reference-canister'.
+# in the current branch, rather than the reference canister.
 sed -i'' -e 's/'${REFERENCE_CANISTER_NAME}'/watchdog/' .dfx/local/canister_ids.json
 
 # Verify that the watchdog canister now exists and is already stopped.

--- a/watchdog/e2e-tests/upgradability.sh
+++ b/watchdog/e2e-tests/upgradability.sh
@@ -36,7 +36,7 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "${SCRIPT_DIR}/utils.sh"
 
 # Run dfx stop if we run into errors and remove the downloaded wasm.
-trap "dfx stop & rm ${REFERENCE_CANISTER_NAME}.wasm.gz" EXIT SIGINT
+trap 'dfx stop & rm ${REFERENCE_CANISTER_NAME}.wasm.gz' EXIT SIGINT
 
 # Get the URL of the latest release.
 get_latest_release_url() {
@@ -47,7 +47,8 @@ get_latest_release_url() {
 
 # Download the latest release.
 download_latest_release() {
-  local url=$(get_latest_release_url)
+  local url
+  url=$(get_latest_release_url)
   wget -O "${REFERENCE_CANISTER_NAME}.wasm.gz" "${url}"
 }
 download_latest_release


### PR DESCRIPTION
This PR adds an upgradability test for watchdog canister (WDC), similar to the one bitcoin canister has.

Added WDC upgradability test to the github CI.
Both upgradability tests (for watchdog and bitcoin canisters) are made to be similar with improved readability:
- added top-level summary comment
- some comments were rewritten for readability
- fetching and downloading operations were modularised into separate functions
