### PR TITLE
refactor: introduce Txid type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,8 +537,19 @@ name = "ciborium"
 version = "0.2.0"
 source = "git+https://github.com/enarx/ciborium?rev=e719537c99b564c3674a56defe53713c702c6f46#e719537c99b564c3674a56defe53713c702c6f46"
 dependencies = [
- "ciborium-io",
- "ciborium-ll",
+ "ciborium-io 0.2.0",
+ "ciborium-ll 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+dependencies = [
+ "ciborium-io 0.2.1",
+ "ciborium-ll 0.2.1",
  "serde",
 ]
 
@@ -548,11 +559,27 @@ version = "0.2.0"
 source = "git+https://github.com/enarx/ciborium?rev=e719537c99b564c3674a56defe53713c702c6f46#e719537c99b564c3674a56defe53713c702c6f46"
 
 [[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
 name = "ciborium-ll"
 version = "0.2.0"
 source = "git+https://github.com/enarx/ciborium?rev=e719537c99b564c3674a56defe53713c702c6f46#e719537c99b564c3674a56defe53713c702c6f46"
 dependencies = [
- "ciborium-io",
+ "ciborium-io 0.2.0",
+ "half",
+]
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io 0.2.1",
  "half",
 ]
 
@@ -1333,7 +1360,7 @@ dependencies = [
  "bitcoin",
  "byteorder",
  "candid 0.9.0-beta.4",
- "ciborium",
+ "ciborium 0.2.0",
  "hex",
  "ic-btc-interface",
  "ic-btc-test-utils",
@@ -1344,7 +1371,7 @@ dependencies = [
  "ic-stable-structures",
  "lazy_static",
  "maplit",
- "proptest",
+ "proptest 0.9.6",
  "serde",
  "serde_bytes",
  "tempfile",
@@ -1355,6 +1382,8 @@ name = "ic-btc-interface"
 version = "0.1.0"
 dependencies = [
  "candid 0.9.0-beta.4",
+ "ciborium 0.2.1",
+ "proptest 1.2.0",
  "serde",
  "serde_bytes",
 ]
@@ -1643,6 +1672,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1754,6 +1789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg 1.1.0",
+ "libm",
 ]
 
 [[package]]
@@ -1985,10 +2021,30 @@ dependencies = [
  "quick-error",
  "rand 0.6.5",
  "rand_chacha 0.1.1",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "regex-syntax 0.6.29",
- "rusty-fork",
+ "rusty-fork 0.2.2",
  "tempfile",
+]
+
+[[package]]
+name = "proptest"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift 0.3.0",
+ "regex-syntax 0.6.29",
+ "rusty-fork 0.3.0",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -2030,7 +2086,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "winapi",
 ]
 
@@ -2190,6 +2246,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2400,6 +2465,18 @@ name = "rusty-fork"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dd93264e10c577503e926bd1430193eeb5d21b059148910082245309b424fae"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
  "quick-error",
@@ -2765,7 +2842,7 @@ dependencies = [
  "async-std",
  "bitcoin",
  "byteorder",
- "ciborium",
+ "ciborium 0.2.0",
  "clap",
  "hex",
  "ic-btc-canister",
@@ -3054,6 +3131,12 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"

--- a/canister/src/api/get_utxos.rs
+++ b/canister/src/api/get_utxos.rs
@@ -235,7 +235,7 @@ fn get_utxos_from_chain(
                 height: utxo.height,
                 outpoint: ic_btc_interface::OutPoint {
                     vout: utxo.outpoint.vout,
-                    txid: utxo.outpoint.txid.to_vec(),
+                    txid: utxo.outpoint.txid.into(),
                 },
             }
         })
@@ -247,7 +247,7 @@ fn get_utxos_from_chain(
         Page {
             tip_block_hash: tip_block_hash.clone(),
             height: next.height,
-            outpoint: OutPoint::new(Txid::from(next.outpoint.txid.clone()), next.outpoint.vout),
+            outpoint: OutPoint::new(Txid::from(next.outpoint.txid), next.outpoint.vout),
         }
         .to_bytes()
     });
@@ -356,7 +356,7 @@ mod test {
             GetUtxosResponse {
                 utxos: vec![Utxo {
                     outpoint: OutPoint {
-                        txid: coinbase_tx.txid().to_vec(),
+                        txid: coinbase_tx.txid().into(),
                         vout: 0
                     },
                     value: 1000,
@@ -423,7 +423,7 @@ mod test {
         for i in (0..num_blocks).rev() {
             let expected_utxo = Utxo {
                 outpoint: OutPoint {
-                    txid: transactions[i as usize].txid().to_vec(),
+                    txid: transactions[i as usize].txid().into(),
                     vout: 0,
                 },
                 value: i + 1,
@@ -514,7 +514,7 @@ mod test {
             GetUtxosResponse {
                 utxos: vec![Utxo {
                     outpoint: OutPoint {
-                        txid: coinbase_tx.txid().to_vec(),
+                        txid: coinbase_tx.txid().into(),
                         vout: 0,
                     },
                     value: 1000,
@@ -576,7 +576,7 @@ mod test {
                 GetUtxosResponse {
                     utxos: vec![Utxo {
                         outpoint: OutPoint {
-                            txid: tx.txid().to_vec(),
+                            txid: tx.txid().into(),
                             vout: 0,
                         },
                         value: 1000,
@@ -627,7 +627,7 @@ mod test {
             GetUtxosResponse {
                 utxos: vec![Utxo {
                     outpoint: OutPoint {
-                        txid: coinbase_tx.txid().to_vec(),
+                        txid: coinbase_tx.txid().into(),
                         vout: 0,
                     },
                     value: 1000,
@@ -710,7 +710,7 @@ mod test {
         let block_0_utxos = GetUtxosResponse {
             utxos: vec![Utxo {
                 outpoint: OutPoint {
-                    txid: coinbase_tx.txid().to_vec(),
+                    txid: coinbase_tx.txid().into(),
                     vout: 0,
                 },
                 value: 1000,
@@ -754,7 +754,7 @@ mod test {
             GetUtxosResponse {
                 utxos: vec![Utxo {
                     outpoint: OutPoint {
-                        txid: tx.txid().to_vec(),
+                        txid: tx.txid().into(),
                         vout: 0,
                     },
                     value: 1000,
@@ -895,7 +895,7 @@ mod test {
             GetUtxosResponse {
                 utxos: vec![Utxo {
                     outpoint: OutPoint {
-                        txid: tx.txid().to_vec(),
+                        txid: tx.txid().into(),
                         vout: 0,
                     },
                     value: 1000,
@@ -941,7 +941,7 @@ mod test {
             GetUtxosResponse {
                 utxos: vec![Utxo {
                     outpoint: OutPoint {
-                        txid: tx.txid().to_vec(),
+                        txid: tx.txid().into(),
                         vout: 0
                     },
                     value: 1000,

--- a/canister/src/tests.rs
+++ b/canister/src/tests.rs
@@ -12,12 +12,10 @@ use crate::{
     verify_synced, with_state, SYNCED_THRESHOLD,
 };
 use crate::{init, test_utils::random_p2pkh_address, Config};
-use bitcoin::{
-    consensus::{Decodable, Encodable},
-};
+use bitcoin::consensus::{Decodable, Encodable};
 use bitcoin::{Block as BitcoinBlock, BlockHeader};
 use byteorder::{LittleEndian, ReadBytesExt};
-use ic_btc_interface::{GetUtxosResponse, Network, UtxosFilter, Txid};
+use ic_btc_interface::{GetUtxosResponse, Network, Txid, UtxosFilter};
 use ic_btc_interface::{OutPoint, Utxo};
 use ic_cdk::api::call::RejectionCode;
 use std::str::FromStr;

--- a/canister/src/tests.rs
+++ b/canister/src/tests.rs
@@ -14,11 +14,10 @@ use crate::{
 use crate::{init, test_utils::random_p2pkh_address, Config};
 use bitcoin::{
     consensus::{Decodable, Encodable},
-    Txid,
 };
 use bitcoin::{Block as BitcoinBlock, BlockHeader};
 use byteorder::{LittleEndian, ReadBytesExt};
-use ic_btc_interface::{GetUtxosResponse, Network, UtxosFilter};
+use ic_btc_interface::{GetUtxosResponse, Network, UtxosFilter, Txid};
 use ic_btc_interface::{OutPoint, Utxo};
 use ic_cdk::api::call::RejectionCode;
 use std::str::FromStr;
@@ -180,8 +179,7 @@ async fn mainnet_100k_blocks() {
                     txid: Txid::from_str(
                         "1a592a31c79f817ed787b6acbeef29b0f0324179820949d7da6215f0f4870c42",
                     )
-                    .unwrap()
-                    .to_vec(),
+                    .unwrap(),
                     vout: 1,
                 },
                 value: 4000000,
@@ -221,8 +219,7 @@ async fn mainnet_100k_blocks() {
                     txid: Txid::from_str(
                         "3371b3978e7285d962fd54656aca6b3191135a1db838b5c689b8a44a7ede6a31",
                     )
-                    .unwrap()
-                    .to_vec(),
+                    .unwrap(),
                     vout: 0,
                 },
                 value: 500000000,
@@ -283,8 +280,7 @@ async fn mainnet_100k_blocks() {
                     txid: Txid::from_str(
                         "2bdd8506980479fb57d848ddbbb29831b4d468f9dc5d572ccdea69edec677ed6",
                     )
-                    .unwrap()
-                    .to_vec(),
+                    .unwrap(),
                     vout: 1,
                 },
                 value: 48_0000_0000,

--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -6,8 +6,8 @@ use bitcoin::{
 use candid::CandidType;
 use ic_btc_interface::{
     Address as AddressStr, GetBalanceRequest as PublicGetBalanceRequest,
-    GetUtxosRequest as PublicGetUtxosRequest, Height, Network, Satoshi, UtxosFilter,
-    UtxosFilterInRequest,
+    GetUtxosRequest as PublicGetUtxosRequest, Height, Network, Satoshi, Txid as PublicTxid,
+    UtxosFilter, UtxosFilterInRequest,
 };
 use ic_stable_structures::{storable::Blob, BoundedStorable, Storable as StableStructuresStorable};
 use serde::{Deserialize, Serialize};
@@ -620,6 +620,20 @@ impl Txid {
 
     pub fn to_vec(self) -> Vec<u8> {
         self.bytes
+    }
+}
+
+impl From<Txid> for PublicTxid {
+    fn from(txid: Txid) -> Self {
+        Self::try_from(&txid.bytes[..]).expect("bug: txid is not 32 bytes long")
+    }
+}
+
+impl From<PublicTxid> for Txid {
+    fn from(txid: PublicTxid) -> Self {
+        Self {
+            bytes: txid.as_ref().to_vec(),
+        }
     }
 }
 

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 candid = "0.9.0-beta.3"
 serde = "1.0.132"
 serde_bytes = "0.11"
+
+[dev-dependencies]
+ciborium = "0.2.1"
+proptest = "1.0"

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -3,6 +3,7 @@
 use candid::{CandidType, Deserialize, Principal};
 use serde::Serialize;
 use serde_bytes::ByteBuf;
+use std::fmt;
 use std::str::FromStr;
 
 pub type Address = String;
@@ -22,8 +23,8 @@ pub enum Network {
     Regtest,
 }
 
-impl std::fmt::Display for Network {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Display for Network {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Mainnet => write!(f, "mainnet"),
             Self::Testnet => write!(f, "testnet"),
@@ -84,8 +85,8 @@ pub enum NetworkInRequest {
     regtest,
 }
 
-impl std::fmt::Display for NetworkInRequest {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Display for NetworkInRequest {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Mainnet => write!(f, "mainnet"),
             Self::Testnet => write!(f, "testnet"),
@@ -97,6 +98,125 @@ impl std::fmt::Display for NetworkInRequest {
     }
 }
 
+#[derive(CandidType, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Txid([u8; 32]);
+
+impl AsRef<[u8]> for Txid {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl serde::Serialize for Txid {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        serializer.serialize_bytes(&self.0)
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Txid {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        struct TxidVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for TxidVisitor {
+            type Value = Txid;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a 32-byte array")
+            }
+
+            fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                match TryInto::<[u8; 32]>::try_into(value) {
+                    Ok(txid) => Ok(Txid(txid)),
+                    Err(_) => Err(E::invalid_length(value.len(), &self)),
+                }
+            }
+        }
+
+        deserializer.deserialize_bytes(TxidVisitor)
+    }
+}
+
+impl fmt::Display for Txid {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // In Bitcoin, you display hash bytes in reverse order.
+        //
+        // > Due to historical accident, the tx and block hashes that bitcoin core
+        // > uses are byte-reversed. I’m not entirely sure why. Maybe something
+        // > like using openssl bignum to store hashes or something like that,
+        // > then printing them as a number.
+        // > -- Wladimir van der Laan
+        //
+        // Source: https://learnmeabitcoin.com/technical/txid
+        for b in self.0.iter().rev() {
+            write!(fmt, "{:02x}", *b)?
+        }
+        Ok(())
+    }
+}
+
+impl TryFrom<&'_ [u8]> for Txid {
+    type Error = core::array::TryFromSliceError;
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        let txid: [u8; 32] = bytes.try_into()?;
+        Ok(Txid(txid))
+    }
+}
+
+#[derive(Debug)]
+pub enum TxidFromStrError {
+    InvalidChar(u8),
+    InvalidLength { expected: usize, actual: usize },
+}
+
+impl fmt::Display for TxidFromStrError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::InvalidChar(c) => write!(f, "char {c} is not a valid hex"),
+            Self::InvalidLength { expected, actual } => write!(
+                f,
+                "Bitcoin transaction id must be precisely {expected} characters, got {actual}"
+            ),
+        }
+    }
+}
+
+impl FromStr for Txid {
+    type Err = TxidFromStrError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        fn decode_hex_char(c: u8) -> Result<u8, TxidFromStrError> {
+            match c {
+                b'A'..=b'F' => Ok(c - b'A' + 10),
+                b'a'..=b'f' => Ok(c - b'a' + 10),
+                b'0'..=b'9' => Ok(c - b'0'),
+                _ => Err(TxidFromStrError::InvalidChar(c)),
+            }
+        }
+        if s.len() != 64 {
+            return Err(TxidFromStrError::InvalidLength {
+                expected: 64,
+                actual: s.len(),
+            });
+        }
+        let mut bytes = [0u8; 32];
+        let chars = s.as_bytes();
+        for i in 0..32 {
+            bytes[31 - i] =
+                (decode_hex_char(chars[2 * i])? << 4) | decode_hex_char(chars[2 * i + 1])?;
+        }
+        Ok(Self(bytes))
+    }
+}
+
 /// A reference to a transaction output.
 #[derive(
     CandidType, Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash, PartialOrd, Ord,
@@ -104,8 +224,7 @@ impl std::fmt::Display for NetworkInRequest {
 pub struct OutPoint {
     /// A cryptographic hash of the transaction.
     /// A transaction can output multiple UTXOs.
-    #[serde(with = "serde_bytes")]
-    pub txid: Vec<u8>,
+    pub txid: Txid,
     /// The index of the output within the transaction.
     pub vout: u32,
 }
@@ -195,8 +314,8 @@ pub struct GetCurrentFeePercentilesRequest {
     pub network: NetworkInRequest,
 }
 
-impl std::fmt::Display for GetUtxosError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for GetUtxosError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::MalformedAddress => {
                 write!(f, "Malformed address.")
@@ -235,8 +354,8 @@ pub enum GetBalanceError {
     MinConfirmationsTooLarge { given: u32, max: u32 },
 }
 
-impl std::fmt::Display for GetBalanceError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for GetBalanceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::MalformedAddress => {
                 write!(f, "Malformed address.")
@@ -267,8 +386,8 @@ pub enum SendTransactionError {
     QueueFull,
 }
 
-impl std::fmt::Display for SendTransactionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for SendTransactionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::MalformedTransaction => {
                 write!(f, "Can't deserialize transaction because it's malformed.")

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -171,7 +171,7 @@ impl TryFrom<&'_ [u8]> for Txid {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TxidFromStrError {
     InvalidChar(u8),
     InvalidLength { expected: usize, actual: usize },

--- a/interface/tests/tests.rs
+++ b/interface/tests/tests.rs
@@ -1,6 +1,8 @@
 use ic_btc_interface::Txid;
 use proptest::array::uniform32;
+use proptest::collection::vec as pvec;
 use proptest::prelude::*;
+use serde_bytes::ByteBuf;
 use std::str::FromStr;
 
 proptest! {
@@ -11,10 +13,19 @@ proptest! {
     }
 
     #[test]
-    fn serde_cbor_decode(bytes in uniform32(any::<u8>())) {
+    fn serde_cbor_decode_byte_array(bytes in uniform32(any::<u8>())) {
         let mut encoded = vec![];
         ciborium::into_writer(&bytes, &mut encoded).unwrap();
         let txid: Txid = ciborium::from_reader(&encoded[..]).unwrap();
         prop_assert_eq!(txid, Txid::from(bytes));
+    }
+
+    #[test]
+    fn serde_cbor_decode_bytebuf(bytes in pvec(any::<u8>(), 32)) {
+        let mut encoded = vec![];
+        let original_txid = Txid::try_from(&bytes[..]).unwrap();
+        ciborium::into_writer(&ByteBuf::from(bytes), &mut encoded).unwrap();
+        let txid: Txid = ciborium::from_reader(&encoded[..]).unwrap();
+        prop_assert_eq!(txid, original_txid);
     }
 }

--- a/interface/tests/tests.rs
+++ b/interface/tests/tests.rs
@@ -1,0 +1,20 @@
+use ic_btc_interface::Txid;
+use proptest::array::uniform32;
+use proptest::prelude::*;
+use std::str::FromStr;
+
+proptest! {
+    #[test]
+    fn txid_display_roundtrip(bytes in uniform32(any::<u8>())) {
+        let txid = Txid::from(bytes);
+        prop_assert_eq!(txid, Txid::from_str(&txid.to_string()).unwrap());
+    }
+
+    #[test]
+    fn serde_cbor_decode(bytes in uniform32(any::<u8>())) {
+        let mut encoded = vec![];
+        ciborium::into_writer(&bytes, &mut encoded).unwrap();
+        let txid: Txid = ciborium::from_reader(&encoded[..]).unwrap();
+        prop_assert_eq!(txid, Txid::from(bytes));
+    }
+}


### PR DESCRIPTION
This change improves the type safety of the Bitcoin interface by introducing a newtype for Bitcoin transaction identifiers.