### PR TITLE
fix: fix finding next difficulty in chain for testnets

### DIFF
--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -668,7 +668,7 @@ mod test {
     #[test]
     fn test_find_next_difficulty_in_chain_pow_found() {
         // This test checks the chain of headers of different lengths
-        // with non-limit PoW in the first block header and Pow limit
+        // with non-limit PoW in the first block header and PoW limit
         // in all the other headers.
         // Expect difficulty to be equal to the non-limit PoW.
         // Expect headers inspected to be equal to the chain length.

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -254,6 +254,7 @@ fn find_next_difficulty_in_chain(
         Network::Testnet | Network::Regtest => {
             let mut current_header = *header;
             let mut current_height = height;
+            let mut current_hash = header.block_hash();
             let initial_header_hash = store.get_initial_hash();
 
             // Keep traversing the blockchain backwards from the recent block to initial
@@ -264,11 +265,12 @@ fn find_next_difficulty_in_chain(
                 {
                     return current_header.bits;
                 }
-                if current_header.block_hash() == initial_header_hash {
+                if current_hash == initial_header_hash {
                     break;
                 }
 
                 // Traverse to the previous header
+                current_hash = current_header.prev_blockhash;
                 current_header = store
                     .get_with_block_hash(&current_header.prev_blockhash)
                     .expect("previous header should be in the header store");

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -198,50 +198,6 @@ fn get_next_target(
 /// returns to its previous value." This function is used to compute the
 /// difficulty target in case the block has been found within 20
 /// minutes.
-fn find_next_difficulty_in_chain0(
-    network: &Network,
-    store: &impl HeaderStore,
-    prev_header: &BlockHeader,
-    prev_height: BlockHeight,
-) -> u32 {
-    // This is the maximum difficulty target for the network
-    let pow_limit_bits = pow_limit_bits(network);
-    match network {
-        Network::Testnet | Network::Regtest => {
-            let mut current_header = *prev_header;
-            let mut current_height = prev_height;
-            let mut current_hash = prev_header.block_hash();
-            let initial_header_hash = store.get_initial_hash();
-
-            // Keep traversing the blockchain backwards from the recent block to initial
-            // header hash.
-            while current_hash != initial_header_hash {
-                if current_header.bits != pow_limit_bits
-                    || current_height % DIFFICULTY_ADJUSTMENT_INTERVAL == 0
-                {
-                    return current_header.bits;
-                }
-
-                // Traverse to the previous header
-                current_header = store
-                    .get_with_block_hash(&current_header.prev_blockhash)
-                    .expect("previous header should be in the header store");
-                current_height -= 1;
-                current_hash = current_header.prev_blockhash;
-            }
-            pow_limit_bits
-        }
-        Network::Bitcoin | Network::Signet => pow_limit_bits,
-    }
-}
-
-/// This method is only valid when used for testnet and regtest networks.
-/// As per "https://en.bitcoin.it/wiki/Testnet",
-/// "If no block has been found in 20 minutes, the difficulty automatically
-/// resets back to the minimum for a single block, after which it
-/// returns to its previous value." This function is used to compute the
-/// difficulty target in case the block has been found within 20
-/// minutes.
 fn find_next_difficulty_in_chain(
     network: &Network,
     store: &impl HeaderStore,

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -671,35 +671,10 @@ mod test {
         // with non-limit PoW in the first block header and PoW limit
         // in all the other headers.
         // Expect difficulty to be equal to the non-limit PoW.
-        // Expect headers inspected to be equal to the chain length.
 
         // Arrange.
         let network = Network::Regtest;
         let expected_pow = SOME_NON_LIMIT_POW;
-
-        for chain_length in 1..CHAIN_LENGTH_MAX {
-            let (store, last_header) = create_chain(&network, expected_pow, chain_length);
-            assert_eq!(store.height() + 1, chain_length);
-
-            // Act.
-            let difficulty =
-                find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
-
-            // Assert.
-            assert_eq!(difficulty, expected_pow);
-        }
-    }
-
-    #[test]
-    fn test_find_next_difficulty_in_chain_pow_not_found() {
-        // This test checks the chain of headers of different lengths
-        // with Pow limit in all the headers.
-        // Expect difficulty to be equal to the PoW limit.
-        // Expect headers inspected to be equal to the chain length.
-
-        // Arrange.
-        let network = Network::Regtest;
-        let expected_pow = pow_limit_bits(&network);
 
         for chain_length in 1..CHAIN_LENGTH_MAX {
             let (store, last_header) = create_chain(&network, expected_pow, chain_length);

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -593,10 +593,16 @@ mod test {
 
     #[test]
     fn test_is_header_valid_invalid_computed_target() {
-        let header_705600 = deserialize_header(MAINNET_HEADER_705600);
-        let header = deserialize_header(MAINNET_HEADER_705601);
-        let store = SimpleHeaderStore::new(header_705600, 705_600);
-        let result = validate_header(&Network::Regtest, &store, &header, MOCK_CURRENT_TIME);
+        let pow_bitcoin = pow_limit_bits(&Network::Bitcoin);
+        let pow_regtest = pow_limit_bits(&Network::Regtest);
+        let h0 = genesis_header(pow_bitcoin);
+        let h1 = next_block_header(h0, pow_regtest);
+        let h2 = next_block_header(h1, pow_regtest);
+        let h3 = next_block_header(h2, pow_regtest);
+        let mut store = SimpleHeaderStore::new(h0, 0);
+        store.add(h1);
+        store.add(h2);
+        let result = validate_header(&Network::Regtest, &store, &h3, MOCK_CURRENT_TIME);
         assert!(matches!(
             result,
             Err(ValidateHeaderError::InvalidPoWForComputedTarget)

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -654,119 +654,52 @@ mod test {
     }
 
     const SOME_NON_LIMIT_POW: u32 = 7;
+    const CHAIN_LENGTH_MAX: u32 = 10;
 
     #[test]
-    fn test_find_next_difficulty_in_chain_for_initial_header() {
+    fn test_find_next_difficulty_in_chain_pow_found() {
+        // This test checks the chain of headers of different lengths
+        // with non-limit PoW in the first block header and Pow limit
+        // in all the other headers.
+        // Found difficulty should be equal to the non-limit PoW.
+
         // Arrange.
         let network = Network::Regtest;
-        let chain_length = 1;
-        let (store, last_header) = create_chain(&network, SOME_NON_LIMIT_POW, chain_length);
-        assert_eq!(store.height() + 1, chain_length);
+        let expected_pow = SOME_NON_LIMIT_POW;
 
-        // Act.
-        let result =
-            find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
+        for chain_length in 1..CHAIN_LENGTH_MAX {
+            let (store, last_header) = create_chain(&network, expected_pow, chain_length);
+            assert_eq!(store.height() + 1, chain_length);
 
-        // Assert.
-        assert_eq!(result, SOME_NON_LIMIT_POW);
+            // Act.
+            let result =
+                find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
+
+            // Assert.
+            assert_eq!(result, expected_pow);
+        }
     }
 
     #[test]
-    fn test_find_next_difficulty_in_chain_for_2_blocks_pow_not_found() {
+    fn test_find_next_difficulty_in_chain_pow_not_found() {
+        // This test checks the chain of headers of different lengths
+        // with Pow limit in all the headers.
+        // Found difficulty should be equal to the PoW limit.
+
         // Arrange.
         let network = Network::Regtest;
-        let chain_length = 2;
-        let pow_limit = pow_limit_bits(&network);
-        let (store, last_header) = create_chain(&network, pow_limit, chain_length);
-        assert_eq!(store.height() + 1, chain_length);
+        let expected_pow = pow_limit_bits(&network);
 
-        // Act.
-        let result =
-            find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
+        for chain_length in 1..CHAIN_LENGTH_MAX {
+            let (store, last_header) = create_chain(&network, expected_pow, chain_length);
+            assert_eq!(store.height() + 1, chain_length);
 
-        // Assert.
-        assert_eq!(result, pow_limit);
-    }
+            // Act.
+            let result =
+                find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
 
-    #[test]
-    fn test_find_next_difficulty_in_chain_for_2_blocks_pow_found() {
-        // Arrange.
-        let network = Network::Regtest;
-        let chain_length = 2;
-        let (store, last_header) = create_chain(&network, SOME_NON_LIMIT_POW, chain_length);
-        assert_eq!(store.height() + 1, chain_length);
-
-        // Act.
-        let result =
-            find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
-
-        // Assert.
-        assert_eq!(result, SOME_NON_LIMIT_POW);
-    }
-
-    #[test]
-    fn test_find_next_difficulty_in_chain_for_3_blocks_pow_not_found() {
-        // Arrange.
-        let network = Network::Regtest;
-        let chain_length = 3;
-        let pow_limit = pow_limit_bits(&network);
-        let (store, last_header) = create_chain(&network, pow_limit, chain_length);
-        assert_eq!(store.height() + 1, chain_length);
-
-        // Act.
-        let result =
-            find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
-
-        // Assert.
-        assert_eq!(result, pow_limit);
-    }
-
-    #[test]
-    fn test_find_next_difficulty_in_chain_for_3_blocks_pow_found() {
-        // Arrange.
-        let network = Network::Regtest;
-        let chain_length = 3;
-        let (store, last_header) = create_chain(&network, SOME_NON_LIMIT_POW, chain_length);
-        assert_eq!(store.height() + 1, chain_length);
-
-        // Act.
-        let result =
-            find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
-
-        // Assert.
-        assert_eq!(result, SOME_NON_LIMIT_POW);
-    }
-
-    #[test]
-    fn test_find_next_difficulty_in_chain_for_4_blocks_pow_not_found() {
-        // Arrange.
-        let network = Network::Regtest;
-        let chain_length = 4;
-        let pow_limit = pow_limit_bits(&network);
-        let (store, last_header) = create_chain(&network, pow_limit, chain_length);
-        assert_eq!(store.height() + 1, chain_length);
-
-        // Act.
-        let result =
-            find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
-
-        // Assert.
-        assert_eq!(result, pow_limit);
-    }
-
-    #[test]
-    fn test_find_next_difficulty_in_chain_for_4_blocks_pow_found() {
-        // Arrange.
-        let network = Network::Regtest;
-        let chain_length = 4;
-        let (store, last_header) = create_chain(&network, SOME_NON_LIMIT_POW, chain_length);
-        assert_eq!(store.height() + 1, chain_length);
-
-        // Act.
-        let result =
-            find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
-
-        // Assert.
-        assert_eq!(result, SOME_NON_LIMIT_POW);
+            // Assert.
+            assert_eq!(result, expected_pow);
+        }
     }
 }

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -663,7 +663,7 @@ mod test {
     }
 
     #[test]
-    fn test_find_next_difficulty_in_chain_pow_found() {
+    fn test_next_target_regtest() {
         // This test checks the chain of headers of different lengths
         // with non-limit PoW in the first block header and PoW limit
         // in all the other headers.
@@ -672,17 +672,19 @@ mod test {
         // Arrange.
         let network = Network::Regtest;
         let expected_pow = 7; // Some non-limit PoW, the actual value is not important.
-
         for chain_length in 1..10 {
             let (store, last_header) = create_chain(&network, expected_pow, chain_length);
             assert_eq!(store.height() + 1, chain_length);
-
             // Act.
-            let difficulty =
-                find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
-
+            let target = get_next_target(
+                &network,
+                &store,
+                &last_header,
+                chain_length - 1,
+                &next_block_header(last_header, expected_pow),
+            );
             // Assert.
-            assert_eq!(difficulty, expected_pow);
+            assert_eq!(target, BlockHeader::u256_from_compact_target(expected_pow));
         }
     }
 }

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -201,16 +201,16 @@ fn get_next_target(
 fn find_next_difficulty_in_chain(
     network: &Network,
     store: &impl HeaderStore,
-    header: &BlockHeader,
-    height: BlockHeight,
+    prev_header: &BlockHeader,
+    prev_height: BlockHeight,
 ) -> u32 {
     // This is the maximum difficulty target for the network
     let pow_limit_bits = pow_limit_bits(network);
     match network {
         Network::Testnet | Network::Regtest => {
-            let mut current_header = *header;
-            let mut current_height = height;
-            let mut current_hash = header.block_hash();
+            let mut current_header = *prev_header;
+            let mut current_height = prev_height;
+            let mut current_hash = current_header.block_hash();
             let initial_header_hash = store.get_initial_hash();
 
             // Keep traversing the blockchain backwards from the recent block to initial
@@ -232,7 +232,6 @@ fn find_next_difficulty_in_chain(
                     .expect("previous header should be in the header store");
                 current_height -= 1;
             }
-
             pow_limit_bits
         }
         Network::Bitcoin | Network::Signet => pow_limit_bits,

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -228,7 +228,7 @@ fn find_next_difficulty_in_chain(
                     break;
                 }
 
-                // Advance to the previous header.
+                // Traverse to the previous header.
                 current_header = store
                     .get_with_block_hash(&current_header.prev_blockhash)
                     .expect("previous header should be in the header store");

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -607,4 +607,156 @@ mod test {
             Err(ValidateHeaderError::TargetDifficultyAboveMax)
         ));
     }
+
+    fn genesis_header(bits: u32) -> BlockHeader {
+        BlockHeader {
+            version: 1,
+            prev_blockhash: Default::default(),
+            merkle_root: Default::default(),
+            time: 1296688602,
+            bits,
+            nonce: 0,
+        }
+    }
+
+    fn next_block_header(prev: BlockHeader, bits: u32) -> BlockHeader {
+        BlockHeader {
+            prev_blockhash: prev.block_hash(),
+            time: prev.time + TEN_MINUTES,
+            bits,
+            ..prev
+        }
+    }
+
+    #[test]
+    fn test_find_next_difficulty_in_chain_for_initial_header() {
+        // Arrange.
+        let network = Network::Regtest;
+        let pow = 1;
+        let h0 = genesis_header(pow);
+        let store = SimpleHeaderStore::new(h0, 0);
+
+        // Act.
+        let result = find_next_difficulty_in_chain(&network, &store, &h0, 1);
+
+        // Assert.
+        assert_eq!(result, pow_limit_bits(&network));
+    }
+
+    #[test]
+    fn test_find_next_difficulty_in_chain_for_2_blocks_pow_not_found() {
+        // Arrange.
+        let network = Network::Regtest;
+        let pow_limit = pow_limit_bits(&network);
+        let h0 = genesis_header(pow_limit);
+        let h1 = next_block_header(h0, pow_limit);
+        let mut store = SimpleHeaderStore::new(h0, 0);
+        store.add(h1);
+
+        // Act.
+        let result = find_next_difficulty_in_chain(&network, &store, &h1, 1);
+
+        // Assert.
+        assert_eq!(result, pow_limit);
+    }
+
+    #[test]
+    fn test_find_next_difficulty_in_chain_for_2_blocks_pow_found() {
+        // Arrange.
+        let network = Network::Regtest;
+        let pow = 1;
+        let pow_limit = pow_limit_bits(&network);
+        let h0 = genesis_header(pow);
+        let h1 = next_block_header(h0, pow_limit);
+        let mut store = SimpleHeaderStore::new(h0, 0);
+        store.add(h1);
+
+        // Act.
+        let result = find_next_difficulty_in_chain(&network, &store, &h1, 1);
+
+        // Assert.
+        assert_eq!(result, pow);
+    }
+
+    #[test]
+    fn test_find_next_difficulty_in_chain_for_3_blocks_pow_not_found() {
+        // Arrange.
+        let network = Network::Regtest;
+        let pow_limit = pow_limit_bits(&network);
+        let h0 = genesis_header(pow_limit);
+        let h1 = next_block_header(h0, pow_limit);
+        let h2 = next_block_header(h1, pow_limit);
+        let mut store = SimpleHeaderStore::new(h0, 0);
+        store.add(h1);
+        store.add(h2);
+
+        // Act.
+        let result = find_next_difficulty_in_chain(&network, &store, &h2, 2);
+
+        // Assert.
+        assert_eq!(result, pow_limit);
+    }
+
+    #[test]
+    fn test_find_next_difficulty_in_chain_for_3_blocks_pow_found() {
+        // Arrange.
+        let network = Network::Regtest;
+        let pow = 1;
+        let pow_limit = pow_limit_bits(&network);
+        let h0 = genesis_header(pow);
+        let h1 = next_block_header(h0, pow_limit);
+        let h2 = next_block_header(h1, pow_limit);
+        let mut store = SimpleHeaderStore::new(h0, 0);
+        store.add(h1);
+        store.add(h2);
+
+        // Act.
+        let result = find_next_difficulty_in_chain(&network, &store, &h2, 2);
+
+        // Assert.
+        assert_eq!(result, pow);
+    }
+
+    #[test]
+    fn test_find_next_difficulty_in_chain_for_4_blocks_pow_not_found() {
+        // Arrange.
+        let network = Network::Regtest;
+        let pow_limit = pow_limit_bits(&network);
+        let h0 = genesis_header(pow_limit);
+        let h1 = next_block_header(h0, pow_limit);
+        let h2 = next_block_header(h1, pow_limit);
+        let h3 = next_block_header(h2, pow_limit);
+        let mut store = SimpleHeaderStore::new(h0, 0);
+        store.add(h1);
+        store.add(h2);
+        store.add(h3);
+
+        // Act.
+        let result = find_next_difficulty_in_chain(&network, &store, &h3, 3);
+
+        // Assert.
+        assert_eq!(result, pow_limit);
+    }
+
+    #[test]
+    fn test_find_next_difficulty_in_chain_for_4_blocks_pow_found() {
+        // Arrange.
+        let network = Network::Regtest;
+        let pow = 1;
+        let pow_limit = pow_limit_bits(&network);
+        let h0 = genesis_header(pow);
+        let h1 = next_block_header(h0, pow_limit);
+        let h2 = next_block_header(h1, pow_limit);
+        let h3 = next_block_header(h2, pow_limit);
+        let mut store = SimpleHeaderStore::new(h0, 0);
+        store.add(h1);
+        store.add(h2);
+        store.add(h3);
+
+        // Act.
+        let result = find_next_difficulty_in_chain(&network, &store, &h3, 3);
+
+        // Assert.
+        assert_eq!(result, pow);
+    }
 }

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -693,14 +693,14 @@ mod test {
         (store, last_header)
     }
 
-    const FAKE_POW: u32 = 7;
+    const SOME_NON_LIMIT_POW: u32 = 7;
 
     #[test]
     fn test_find_next_difficulty_in_chain_for_initial_header() {
         // Arrange.
         let network = Network::Regtest;
         let chain_length = 1;
-        let pow = FAKE_POW;
+        let pow = SOME_NON_LIMIT_POW;
         let (store, last_header) = create_chain(&network, pow, chain_length);
         assert_eq!(store.height() + 1, chain_length);
 
@@ -709,7 +709,7 @@ mod test {
             find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
 
         // Assert.
-        assert_eq!(result, FAKE_POW);
+        assert_eq!(result, SOME_NON_LIMIT_POW);
     }
 
     #[test]
@@ -734,7 +734,7 @@ mod test {
         // Arrange.
         let network = Network::Regtest;
         let chain_length = 2;
-        let pow = FAKE_POW;
+        let pow = SOME_NON_LIMIT_POW;
         let (store, last_header) = create_chain(&network, pow, chain_length);
         assert_eq!(store.height() + 1, chain_length);
 
@@ -768,7 +768,7 @@ mod test {
         // Arrange.
         let network = Network::Regtest;
         let chain_length = 3;
-        let pow = FAKE_POW;
+        let pow = SOME_NON_LIMIT_POW;
         let (store, last_header) = create_chain(&network, pow, chain_length);
         assert_eq!(store.height() + 1, chain_length);
 
@@ -802,7 +802,7 @@ mod test {
         // Arrange.
         let network = Network::Regtest;
         let chain_length = 4;
-        let pow = FAKE_POW;
+        let pow = SOME_NON_LIMIT_POW;
         let (store, last_header) = create_chain(&network, pow, chain_length);
         assert_eq!(store.height() + 1, chain_length);
 

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -662,9 +662,6 @@ mod test {
         (store, last_header)
     }
 
-    const SOME_NON_LIMIT_POW: u32 = 7;
-    const CHAIN_LENGTH_MAX: u32 = 10;
-
     #[test]
     fn test_find_next_difficulty_in_chain_pow_found() {
         // This test checks the chain of headers of different lengths
@@ -674,9 +671,9 @@ mod test {
 
         // Arrange.
         let network = Network::Regtest;
-        let expected_pow = SOME_NON_LIMIT_POW;
+        let expected_pow = 7; // Some non-limit PoW, the actual value is not important.
 
-        for chain_length in 1..CHAIN_LENGTH_MAX {
+        for chain_length in 1..10 {
             let (store, last_header) = create_chain(&network, expected_pow, chain_length);
             assert_eq!(store.height() + 1, chain_length);
 

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -214,20 +214,25 @@ fn find_next_difficulty_in_chain(
             // Keep traversing the blockchain backwards from the recent block to initial
             // header hash.
             loop {
+                // Count headers inspected for testing purposes.
                 headers_inspected += 1;
+
+                // Check if non-limit PoW found or it's time to adjust difficulty.
                 if current_header.bits != pow_limit_bits
                     || current_height % DIFFICULTY_ADJUSTMENT_INTERVAL == 0
                 {
                     return (current_header.bits, headers_inspected);
                 }
+
+                // Stop if we reach the initial header.
                 if current_hash == initial_header_hash {
                     break;
                 }
 
-                // Update the previous header's hash, so that there's no need to calculate it.
+                // Save the previous header's hash, so that there's no need to calculate it.
                 current_hash = current_header.prev_blockhash;
                 current_height -= 1;
-                // Traverse to the previous header.
+                // Advance to the previous header.
                 current_header = store
                     .get_with_block_hash(&current_header.prev_blockhash)
                     .expect("previous header should be in the header store");

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -234,8 +234,8 @@ fn find_next_difficulty_in_chain(
                     .get_with_block_hash(&current_header.prev_blockhash)
                     .expect("previous header should be in the header store");
                 // Update the current height and hash.
-                current_hash = current_header.block_hash();
                 current_height -= 1;
+                current_hash = current_header.block_hash();
             }
             (pow_limit_bits, headers_inspected)
         }

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -225,12 +225,13 @@ fn find_next_difficulty_in_chain(
                     break;
                 }
 
-                // Traverse to the previous header
+                // Update the previous header's hash, so that there's no need to calculate it.
                 current_hash = current_header.prev_blockhash;
+                current_height -= 1;
+                // Traverse to the previous header.
                 current_header = store
                     .get_with_block_hash(&current_header.prev_blockhash)
                     .expect("previous header should be in the header store");
-                current_height -= 1;
             }
             pow_limit_bits
         }

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -632,6 +632,8 @@ mod test {
         }
     }
 
+    /// Creates a chain of headers with the given length and
+    /// proof of work for the first header.
     fn create_chain(
         network: &Network,
         initial_pow: u32,
@@ -658,8 +660,7 @@ mod test {
         // Arrange.
         let network = Network::Regtest;
         let chain_length = 1;
-        let pow = SOME_NON_LIMIT_POW;
-        let (store, last_header) = create_chain(&network, pow, chain_length);
+        let (store, last_header) = create_chain(&network, SOME_NON_LIMIT_POW, chain_length);
         assert_eq!(store.height() + 1, chain_length);
 
         // Act.
@@ -675,8 +676,8 @@ mod test {
         // Arrange.
         let network = Network::Regtest;
         let chain_length = 2;
-        let pow = pow_limit_bits(&network);
-        let (store, last_header) = create_chain(&network, pow, chain_length);
+        let pow_limit = pow_limit_bits(&network);
+        let (store, last_header) = create_chain(&network, pow_limit, chain_length);
         assert_eq!(store.height() + 1, chain_length);
 
         // Act.
@@ -684,7 +685,7 @@ mod test {
             find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
 
         // Assert.
-        assert_eq!(result, pow);
+        assert_eq!(result, pow_limit);
     }
 
     #[test]
@@ -692,8 +693,7 @@ mod test {
         // Arrange.
         let network = Network::Regtest;
         let chain_length = 2;
-        let pow = SOME_NON_LIMIT_POW;
-        let (store, last_header) = create_chain(&network, pow, chain_length);
+        let (store, last_header) = create_chain(&network, SOME_NON_LIMIT_POW, chain_length);
         assert_eq!(store.height() + 1, chain_length);
 
         // Act.
@@ -701,7 +701,7 @@ mod test {
             find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
 
         // Assert.
-        assert_eq!(result, pow);
+        assert_eq!(result, SOME_NON_LIMIT_POW);
     }
 
     #[test]
@@ -709,8 +709,8 @@ mod test {
         // Arrange.
         let network = Network::Regtest;
         let chain_length = 3;
-        let pow = pow_limit_bits(&network);
-        let (store, last_header) = create_chain(&network, pow, chain_length);
+        let pow_limit = pow_limit_bits(&network);
+        let (store, last_header) = create_chain(&network, pow_limit, chain_length);
         assert_eq!(store.height() + 1, chain_length);
 
         // Act.
@@ -718,7 +718,7 @@ mod test {
             find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
 
         // Assert.
-        assert_eq!(result, pow);
+        assert_eq!(result, pow_limit);
     }
 
     #[test]
@@ -726,8 +726,7 @@ mod test {
         // Arrange.
         let network = Network::Regtest;
         let chain_length = 3;
-        let pow = SOME_NON_LIMIT_POW;
-        let (store, last_header) = create_chain(&network, pow, chain_length);
+        let (store, last_header) = create_chain(&network, SOME_NON_LIMIT_POW, chain_length);
         assert_eq!(store.height() + 1, chain_length);
 
         // Act.
@@ -735,7 +734,7 @@ mod test {
             find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
 
         // Assert.
-        assert_eq!(result, pow);
+        assert_eq!(result, SOME_NON_LIMIT_POW);
     }
 
     #[test]
@@ -743,8 +742,8 @@ mod test {
         // Arrange.
         let network = Network::Regtest;
         let chain_length = 4;
-        let pow = pow_limit_bits(&network);
-        let (store, last_header) = create_chain(&network, pow, chain_length);
+        let pow_limit = pow_limit_bits(&network);
+        let (store, last_header) = create_chain(&network, pow_limit, chain_length);
         assert_eq!(store.height() + 1, chain_length);
 
         // Act.
@@ -752,7 +751,7 @@ mod test {
             find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
 
         // Assert.
-        assert_eq!(result, pow);
+        assert_eq!(result, pow_limit);
     }
 
     #[test]
@@ -760,8 +759,7 @@ mod test {
         // Arrange.
         let network = Network::Regtest;
         let chain_length = 4;
-        let pow = SOME_NON_LIMIT_POW;
-        let (store, last_header) = create_chain(&network, pow, chain_length);
+        let (store, last_header) = create_chain(&network, SOME_NON_LIMIT_POW, chain_length);
         assert_eq!(store.height() + 1, chain_length);
 
         // Act.
@@ -769,6 +767,6 @@ mod test {
             find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
 
         // Assert.
-        assert_eq!(result, pow);
+        assert_eq!(result, SOME_NON_LIMIT_POW);
     }
 }

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -628,16 +628,39 @@ mod test {
         }
     }
 
+    fn create_chain(
+        network: &Network,
+        initial_pow: u32,
+        chain_length: u32,
+    ) -> (SimpleHeaderStore, BlockHeader) {
+        let pow_limit = pow_limit_bits(network);
+        let h0 = genesis_header(initial_pow);
+        let mut store = SimpleHeaderStore::new(h0, 0);
+        let mut last_header = h0;
+
+        for _ in 1..chain_length {
+            let new_header = next_block_header(last_header, pow_limit);
+            store.add(new_header);
+            last_header = new_header;
+        }
+
+        (store, last_header)
+    }
+
+    const FAKE_POW: u32 = 7;
+
     #[test]
     fn test_find_next_difficulty_in_chain_for_initial_header() {
         // Arrange.
         let network = Network::Regtest;
-        let pow = 1;
-        let h0 = genesis_header(pow);
-        let store = SimpleHeaderStore::new(h0, 0);
+        let chain_length = 1;
+        let pow = FAKE_POW;
+        let (store, last_header) = create_chain(&network, pow, chain_length);
+        assert_eq!(store.height() + 1, chain_length);
 
         // Act.
-        let result = find_next_difficulty_in_chain(&network, &store, &h0, 1);
+        let result =
+            find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
 
         // Assert.
         assert_eq!(result, pow_limit_bits(&network));
@@ -647,32 +670,31 @@ mod test {
     fn test_find_next_difficulty_in_chain_for_2_blocks_pow_not_found() {
         // Arrange.
         let network = Network::Regtest;
-        let pow_limit = pow_limit_bits(&network);
-        let h0 = genesis_header(pow_limit);
-        let h1 = next_block_header(h0, pow_limit);
-        let mut store = SimpleHeaderStore::new(h0, 0);
-        store.add(h1);
+        let chain_length = 2;
+        let pow = pow_limit_bits(&network);
+        let (store, last_header) = create_chain(&network, pow, chain_length);
+        assert_eq!(store.height() + 1, chain_length);
 
         // Act.
-        let result = find_next_difficulty_in_chain(&network, &store, &h1, 1);
+        let result =
+            find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
 
         // Assert.
-        assert_eq!(result, pow_limit);
+        assert_eq!(result, pow);
     }
 
     #[test]
     fn test_find_next_difficulty_in_chain_for_2_blocks_pow_found() {
         // Arrange.
         let network = Network::Regtest;
-        let pow = 1;
-        let pow_limit = pow_limit_bits(&network);
-        let h0 = genesis_header(pow);
-        let h1 = next_block_header(h0, pow_limit);
-        let mut store = SimpleHeaderStore::new(h0, 0);
-        store.add(h1);
+        let chain_length = 2;
+        let pow = FAKE_POW;
+        let (store, last_header) = create_chain(&network, pow, chain_length);
+        assert_eq!(store.height() + 1, chain_length);
 
         // Act.
-        let result = find_next_difficulty_in_chain(&network, &store, &h1, 1);
+        let result =
+            find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
 
         // Assert.
         assert_eq!(result, pow);
@@ -682,36 +704,31 @@ mod test {
     fn test_find_next_difficulty_in_chain_for_3_blocks_pow_not_found() {
         // Arrange.
         let network = Network::Regtest;
-        let pow_limit = pow_limit_bits(&network);
-        let h0 = genesis_header(pow_limit);
-        let h1 = next_block_header(h0, pow_limit);
-        let h2 = next_block_header(h1, pow_limit);
-        let mut store = SimpleHeaderStore::new(h0, 0);
-        store.add(h1);
-        store.add(h2);
+        let chain_length = 3;
+        let pow = pow_limit_bits(&network);
+        let (store, last_header) = create_chain(&network, pow, chain_length);
+        assert_eq!(store.height() + 1, chain_length);
 
         // Act.
-        let result = find_next_difficulty_in_chain(&network, &store, &h2, 2);
+        let result =
+            find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
 
         // Assert.
-        assert_eq!(result, pow_limit);
+        assert_eq!(result, pow);
     }
 
     #[test]
     fn test_find_next_difficulty_in_chain_for_3_blocks_pow_found() {
         // Arrange.
         let network = Network::Regtest;
-        let pow = 1;
-        let pow_limit = pow_limit_bits(&network);
-        let h0 = genesis_header(pow);
-        let h1 = next_block_header(h0, pow_limit);
-        let h2 = next_block_header(h1, pow_limit);
-        let mut store = SimpleHeaderStore::new(h0, 0);
-        store.add(h1);
-        store.add(h2);
+        let chain_length = 3;
+        let pow = FAKE_POW;
+        let (store, last_header) = create_chain(&network, pow, chain_length);
+        assert_eq!(store.height() + 1, chain_length);
 
         // Act.
-        let result = find_next_difficulty_in_chain(&network, &store, &h2, 2);
+        let result =
+            find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
 
         // Assert.
         assert_eq!(result, pow);
@@ -721,40 +738,31 @@ mod test {
     fn test_find_next_difficulty_in_chain_for_4_blocks_pow_not_found() {
         // Arrange.
         let network = Network::Regtest;
-        let pow_limit = pow_limit_bits(&network);
-        let h0 = genesis_header(pow_limit);
-        let h1 = next_block_header(h0, pow_limit);
-        let h2 = next_block_header(h1, pow_limit);
-        let h3 = next_block_header(h2, pow_limit);
-        let mut store = SimpleHeaderStore::new(h0, 0);
-        store.add(h1);
-        store.add(h2);
-        store.add(h3);
+        let chain_length = 4;
+        let pow = pow_limit_bits(&network);
+        let (store, last_header) = create_chain(&network, pow, chain_length);
+        assert_eq!(store.height() + 1, chain_length);
 
         // Act.
-        let result = find_next_difficulty_in_chain(&network, &store, &h3, 3);
+        let result =
+            find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
 
         // Assert.
-        assert_eq!(result, pow_limit);
+        assert_eq!(result, pow);
     }
 
     #[test]
     fn test_find_next_difficulty_in_chain_for_4_blocks_pow_found() {
         // Arrange.
         let network = Network::Regtest;
-        let pow = 1;
-        let pow_limit = pow_limit_bits(&network);
-        let h0 = genesis_header(pow);
-        let h1 = next_block_header(h0, pow_limit);
-        let h2 = next_block_header(h1, pow_limit);
-        let h3 = next_block_header(h2, pow_limit);
-        let mut store = SimpleHeaderStore::new(h0, 0);
-        store.add(h1);
-        store.add(h2);
-        store.add(h3);
+        let chain_length = 4;
+        let pow = FAKE_POW;
+        let (store, last_header) = create_chain(&network, pow, chain_length);
+        assert_eq!(store.height() + 1, chain_length);
 
         // Act.
-        let result = find_next_difficulty_in_chain(&network, &store, &h3, 3);
+        let result =
+            find_next_difficulty_in_chain(&network, &store, &last_header, chain_length - 1);
 
         // Assert.
         assert_eq!(result, pow);

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -229,13 +229,13 @@ fn find_next_difficulty_in_chain(
                     break;
                 }
 
-                // Save the previous header's hash, so that there's no need to calculate it.
-                current_hash = current_header.prev_blockhash;
-                current_height -= 1;
                 // Advance to the previous header.
                 current_header = store
                     .get_with_block_hash(&current_header.prev_blockhash)
                     .expect("previous header should be in the header store");
+                // Update the current height and hash.
+                current_hash = current_header.block_hash();
+                current_height -= 1;
             }
             (pow_limit_bits, headers_inspected)
         }


### PR DESCRIPTION
This PR fixes finding the next difficulty in chain for testnets when verifying headers.

Previous implementation was jumping over one block hash because it was advancing the current header and then was saving its previous block hash (which turned to be a prev-prev hash, one-off bug).
Instead it should have saved the previous block hash first (to avoid its calculation on every iteration) and only then advancing the current header. Or another option for readability to recalculate hash after advancing to the previous header.

Previous implementation:
```rust
while current_hash != initial_header_hash {
    // It does not check initial header for PoW.
    if is_pow_found {
        return current_header.bits;
    }

    // Advance current header.
    current_header = store
        .get_with_block_hash(&current_header.prev_blockhash)
        .expect("previous header should be in the header store");
    // Attempt to save the prev hash, but it's now actually prev-prev-hash.
    current_hash = current_header.prev_blockhash;
}
pow_limit_bits
```

New implementation:
```rust
loop {
    // First check if PoW found...
    if is_pow_found {
        return current_header.bits;
    }
    // ...and only then stop when it's the initial header.
    if current_hash == initial_header_hash {
        break;
    }

    // Advance to the previous header.
    current_header = store
        .get_with_block_hash(&current_header.prev_blockhash)
        .expect("previous header should be in the header store");
    // Update current hash.
    current_hash = current_header.block_hash();
}
pow_limit_bits
```
