### PR TITLE
fix: make api_access metric an enum

### DIFF
--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -119,15 +119,16 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             "Is the canister synced with the network?",
         )?;
 
-        w.encode_gauge(
+        let (enabled, disabled) = match state.api_access {
+            Flag::Enabled => (1.0, 0.0),
+            Flag::Disabled => (0.0, 1.0),
+        };
+        w.gauge_vec(
             "api_access",
-            if state.api_access == Flag::Enabled {
-                1.0
-            } else {
-                0.0
-            },
             "Flag to control access to the APIs provided by the canister.",
-        )?;
+        )?
+        .value(&[("flag", "enabled")], enabled)?
+        .value(&[("flag", "disabled")], disabled)?;
 
         Ok(())
     })

--- a/watchdog/src/metrics.rs
+++ b/watchdog/src/metrics.rs
@@ -36,15 +36,6 @@ pub fn get_metrics() -> CandidHttpResponse {
     }
 }
 
-/// Converts a flag to a gauge value.
-fn flag_to_gauge(flag: Option<Flag>) -> f64 {
-    match flag {
-        None => NO_VALUE,
-        Some(Flag::Enabled) => 1.0,
-        Some(Flag::Disabled) => 0.0,
-    }
-}
-
 /// Encodes the metrics in the Prometheus format.
 fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
     let config = crate::storage::get_config();


### PR DESCRIPTION
This PR changes the `api_access` metric to an enum with clear `enabled` and `disabled` states for both Bitcoin and watchdog canisters.

Previously, we used `0/1` to represent `disabled/enabled`, but Grafana views no value as zero, causing confusion on charts.

Now, with enums, dashboards will clearly show `enabled` or `disabled`, and won't assume a state if there's no value. 

This is a "nice to have" improvement.