### PR TITLE
test: add proptests for computing next header target.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+validation/tests/data/block_headers_testnet.csv filter=lfs diff=lfs merge=lfs -text
+validation/tests/data/block_headers_mainnet.csv filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -62,7 +62,7 @@ jobs:
           lfs: true
 
       - name: Checkout LFS objects
-        run: git lfs checkout
+        run: git lfs fetch
 
       - name: Install Rust
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -59,6 +59,10 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+          lfs: true
+
+      - name: Checkout LFS objects
+        run: git lfs checkout
 
       - name: Install Rust
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -52,6 +52,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          lfs: true
       - uses: actions/cache@v3
         with:
           path: |
@@ -59,10 +61,6 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
-          lfs: true
-
-      - name: Checkout LFS objects
-        run: git lfs fetch
 
       - name: Install Rust
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,6 +1401,8 @@ version = "0.1.0"
 dependencies = [
  "bitcoin",
  "csv",
+ "hex",
+ "proptest 0.9.6",
 ]
 
 [[package]]

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -10,3 +10,5 @@ bitcoin = "0.28.1"
 
 [dev-dependencies]
 csv = "1.1"
+hex = "0.4.3"
+proptest = "0.9.4"

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -80,7 +80,7 @@ pub fn validate_header(
         return Err(ValidateHeaderError::InvalidPoWForHeaderTarget);
     }
 
-    let target = get_next_target(network, store, &prev_header, prev_height, header);
+    let target = get_next_target(network, store, &prev_header, prev_height, header.time);
     if let Err(err) = header.validate_pow(&target) {
         match err {
             bitcoin::Error::BlockBadProofOfWork => println!("bad proof of work"),
@@ -141,18 +141,14 @@ fn is_timestamp_valid(
     Ok(())
 }
 
-/// Gets the next target by doing the following:
-/// * If the network allows blocks to have the max target (testnet & regtest),
-///   the next difficulty is searched for unless the header's timestamp is
-///   greater than 20 minutes from the previous header's timestamp.
-/// * If the network does not allow blocks with the max target, the next
-///   difficulty is computed and then cast into the next target.
+// Returns the next required target at the given timestamp.
+// The target is the number that a block hash must be below for it to be accepted.
 fn get_next_target(
     network: &Network,
     store: &impl HeaderStore,
     prev_header: &BlockHeader,
     prev_height: BlockHeight,
-    header: &BlockHeader,
+    timestamp: u32,
 ) -> Uint256 {
     match network {
         Network::Testnet | Network::Regtest => {
@@ -162,7 +158,7 @@ fn get_next_target(
                 // "If no block has been found in 20 minutes, the difficulty automatically
                 // resets back to the minimum for a single block, after which it
                 // returns to its previous value."
-                if header.time > prev_header.time + TEN_MINUTES * 2 {
+                if timestamp > prev_header.time + TEN_MINUTES * 2 {
                     //If no block has been found in 20 minutes, then use the maximum difficulty
                     // target
                     max_target(network)
@@ -304,6 +300,7 @@ mod test {
 
     use bitcoin::{consensus::deserialize, hashes::hex::FromHex, TxMerkleNode};
     use csv::Reader;
+    use proptest::prelude::*;
 
     use super::*;
     use crate::constants::test::{
@@ -392,8 +389,6 @@ mod test {
     }
 
     /// This function reads `num_headers` headers from `tests/data/headers.csv`
-    /// and returns them.
-    /// This function reads `num_headers` headers from `blockchain_headers.csv`
     /// and returns them.
     fn get_bitcoin_headers() -> Vec<BlockHeader> {
         let rdr = Reader::from_path(
@@ -606,5 +601,62 @@ mod test {
             result,
             Err(ValidateHeaderError::TargetDifficultyAboveMax)
         ));
+    }
+
+    fn test_next_targets(network: Network, headers_path: &str, up_to_height: usize) {
+        use bitcoin::consensus::Decodable;
+        use std::io::BufRead;
+        let file = std::fs::File::open(
+            PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap()).join(headers_path),
+        )
+        .unwrap();
+
+        let rdr = std::io::BufReader::new(file);
+
+        println!("Loading headers...");
+        let mut headers = vec![];
+        for line in rdr.lines() {
+            let header = line.unwrap();
+            let header = hex::decode(header.trim()).unwrap();
+            let header = BlockHeader::consensus_decode(header.as_slice()).unwrap();
+            headers.push(header);
+        }
+
+        println!("Creating header store...");
+        let mut store = SimpleHeaderStore::new(headers[0].clone(), 0);
+        for header in headers[1..].iter() {
+            store.add(header.clone());
+        }
+
+        println!("Verifying next targets...");
+        proptest!(|(i in 0..up_to_height)| {
+            // Compute what the target of the next header should be.
+            let expected_next_target =
+                get_next_target(&network, &store, &headers[i], i as u32, headers[i + 1].time);
+
+            // Assert that the expected next target matches the next header's target.
+            assert_eq!(
+                expected_next_target,
+                BlockHeader::u256_from_compact_target(headers[i + 1].bits)
+            );
+        });
+    }
+
+    #[test]
+    fn mainnet_next_targets() {
+        test_next_targets(
+            Network::Bitcoin,
+            "tests/data/block_headers_mainnet.csv",
+            700_000,
+        );
+    }
+
+    #[test]
+    fn testnet_next_targets() {
+        test_next_targets(
+            Network::Testnet,
+            "tests/data/block_headers_testnet.csv",
+            2_400_000,
+        );
     }
 }

--- a/validation/tests/data/block_headers_mainnet.csv
+++ b/validation/tests/data/block_headers_mainnet.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60c3b3cf86363a9f3a71571a5643625541fce0584a794fbf9efcd4cd24693b22
+size 125947563

--- a/validation/tests/data/block_headers_testnet.csv
+++ b/validation/tests/data/block_headers_testnet.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80b384e910bff64e4ecb97b96b6f8656d63e9942ed7ea480b5d333375f423011
+size 390503729


### PR DESCRIPTION
The `get_next_target` doesn't have good test coverage, yet it's important and a bug in it can bring the bitcoin integration to a halt or, in a worse case, provide a window for an attacker to feed bad blocks into the system.

This PR adds proptests to add more test coverage to this code.