### PR TITLE
chore: downgrade candid from 0.9.0-beta.3 to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,8 +286,8 @@ dependencies = [
  "hex",
  "ic-btc-canister",
  "ic-btc-interface",
- "ic-cdk 0.8.0-beta.0",
- "ic-cdk-macros 0.8.0-beta.0",
+ "ic-cdk",
+ "ic-cdk-macros",
 ]
 
 [[package]]
@@ -435,7 +435,7 @@ dependencies = [
  "anyhow",
  "binread",
  "byteorder",
- "candid_derive 0.5.0",
+ "candid_derive",
  "codespan-reporting",
  "crc32fast",
  "data-encoding",
@@ -456,33 +456,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "candid"
-version = "0.9.0-beta.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3005be607a05b449b5a5a144839c5731699af5c309ce20eb5c812f889683601e"
-dependencies = [
- "anyhow",
- "binread",
- "byteorder",
- "candid_derive 0.6.1",
- "codespan-reporting",
- "crc32fast",
- "data-encoding",
- "hex",
- "leb128",
- "num-bigint",
- "num-traits",
- "num_enum",
- "paste",
- "pretty",
- "serde",
- "serde_bytes",
- "sha2 0.10.6",
- "stacker",
- "thiserror",
-]
-
-[[package]]
 name = "candid_derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,25 +468,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "candid_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "041ce1020740a400035899b2909a6f4f275b79c8db502cbd59ace9b2cc88af58"
-dependencies = [
- "lazy_static",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "canister_backend"
 version = "0.1.0"
 dependencies = [
- "candid 0.9.0-beta.4",
+ "candid",
  "futures",
- "ic-cdk 0.8.0-beta.0",
- "ic-cdk-macros 0.8.0-beta.0",
+ "ic-cdk",
+ "ic-cdk-macros",
  "ic-http",
  "serde",
  "serde_json",
@@ -835,10 +796,10 @@ name = "disable-api-if-not-fully-synced-flag"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid 0.9.0-beta.4",
+ "candid",
  "ic-btc-test-utils",
- "ic-cdk 0.8.0-beta.0",
- "ic-cdk-macros 0.8.0-beta.0",
+ "ic-cdk",
+ "ic-cdk-macros",
  "serde",
 ]
 
@@ -1325,7 +1286,7 @@ dependencies = [
  "base32",
  "base64 0.13.1",
  "byteorder",
- "candid 0.8.4",
+ "candid",
  "futures-util",
  "garcon",
  "hex",
@@ -1359,14 +1320,14 @@ dependencies = [
  "async-std",
  "bitcoin",
  "byteorder",
- "candid 0.9.0-beta.4",
+ "candid",
  "ciborium 0.2.0",
  "hex",
  "ic-btc-interface",
  "ic-btc-test-utils",
  "ic-btc-validation",
- "ic-cdk 0.8.0-beta.0",
- "ic-cdk-macros 0.8.0-beta.0",
+ "ic-cdk",
+ "ic-cdk-macros",
  "ic-metrics-encoder",
  "ic-stable-structures",
  "lazy_static",
@@ -1381,7 +1342,7 @@ dependencies = [
 name = "ic-btc-interface"
 version = "0.1.0"
 dependencies = [
- "candid 0.9.0-beta.4",
+ "candid",
  "ciborium 0.2.1",
  "proptest 1.2.0",
  "serde",
@@ -1409,21 +1370,8 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9beb0bf1dcd0639c313630e34aa547a2b19450ddf1969c176e13225ef3b29048"
 dependencies = [
- "candid 0.8.4",
- "ic-cdk-macros 0.6.10",
- "ic0",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "ic-cdk"
-version = "0.8.0-beta.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a2796b731794363b45ab7b3a8ae28dc4220256997709e52746887425c5135"
-dependencies = [
- "candid 0.9.0-beta.4",
- "ic-cdk-macros 0.8.0-beta.0",
+ "candid",
+ "ic-cdk-macros",
  "ic0",
  "serde",
  "serde_bytes",
@@ -1435,21 +1383,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebf50458685a0fc6b0e414cdba487610aeb199ac94db52d9fd76270565debee7"
 dependencies = [
- "candid 0.8.4",
- "proc-macro2",
- "quote",
- "serde",
- "serde_tokenstream",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ic-cdk-macros"
-version = "0.8.0-beta.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8ed566a9a45e97f8dd7eed3db58c95875272dbf053f0d94a965319cbffdb9e0"
-dependencies = [
- "candid 0.9.0-beta.4",
+ "candid",
  "proc-macro2",
  "quote",
  "serde",
@@ -1464,7 +1398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c739e7c592cb66df4f15c6b6c4859b1195782f63923e2fb1b29553d9c0819bd4"
 dependencies = [
  "futures",
- "ic-cdk 0.7.4",
+ "ic-cdk",
  "ic0",
  "serde",
  "serde_bytes",
@@ -1475,10 +1409,10 @@ dependencies = [
 name = "ic-http"
 version = "0.1.0"
 dependencies = [
- "candid 0.9.0-beta.4",
+ "candid",
  "futures",
- "ic-cdk 0.8.0-beta.0",
- "ic-cdk-macros 0.8.0-beta.0",
+ "ic-cdk",
+ "ic-cdk-macros",
  "serde_json",
  "tokio",
 ]
@@ -2048,15 +1982,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psm"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2509,10 +2434,10 @@ name = "scenario-1"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid 0.9.0-beta.4",
+ "candid",
  "ic-btc-test-utils",
- "ic-cdk 0.8.0-beta.0",
- "ic-cdk-macros 0.8.0-beta.0",
+ "ic-cdk",
+ "ic-cdk-macros",
  "serde",
 ]
 
@@ -2521,10 +2446,10 @@ name = "scenario-2"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid 0.9.0-beta.4",
+ "candid",
  "ic-btc-test-utils",
- "ic-cdk 0.8.0-beta.0",
- "ic-cdk-macros 0.8.0-beta.0",
+ "ic-cdk",
+ "ic-cdk-macros",
  "serde",
 ]
 
@@ -2533,10 +2458,10 @@ name = "scenario-3"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid 0.9.0-beta.4",
+ "candid",
  "ic-btc-test-utils",
- "ic-cdk 0.8.0-beta.0",
- "ic-cdk-macros 0.8.0-beta.0",
+ "ic-cdk",
+ "ic-cdk-macros",
  "serde",
 ]
 
@@ -2820,19 +2745,6 @@ checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der",
-]
-
-[[package]]
-name = "stacker"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "winapi",
 ]
 
 [[package]]
@@ -3182,12 +3094,12 @@ name = "uploader"
 version = "0.1.0"
 dependencies = [
  "async-std",
- "candid 0.9.0-beta.4",
+ "candid",
  "clap",
  "garcon",
  "ic-agent",
- "ic-cdk 0.8.0-beta.0",
- "ic-cdk-macros 0.8.0-beta.0",
+ "ic-cdk",
+ "ic-cdk-macros",
  "serde",
  "sha256",
  "url",
@@ -3343,12 +3255,12 @@ version = "0.1.0"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "candid 0.9.0-beta.4",
+ "candid",
  "futures",
  "hex",
  "ic-btc-interface",
- "ic-cdk 0.8.0-beta.0",
- "ic-cdk-macros 0.8.0-beta.0",
+ "ic-cdk",
+ "ic-cdk-macros",
  "ic-cdk-timers",
  "ic-http",
  "ic-metrics-encoder",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [dependencies]
 bitcoin = {version = "0.28.1", features = ["use-serde"]}
 hex = "0.4.3"
-ic-cdk = "=0.8.0-beta.0"
-ic-cdk-macros = "0.8.0-beta.0"
+ic-cdk = "0.7.4"
+ic-cdk-macros = "0.6.10"
 ic-btc-canister = { path = "../canister" }
 ic-btc-interface = { path = "../interface" }

--- a/bootstrap/uploader/Cargo.toml
+++ b/bootstrap/uploader/Cargo.toml
@@ -19,9 +19,9 @@ name = "compute_hashes"
 path = "src/compute_hashes.rs"
 
 [dependencies]
-candid = "0.9.0-beta.3"
-ic-cdk = "=0.8.0-beta.0"
-ic-cdk-macros = "0.8.0-beta.0"
+candid = "0.8.1"
+ic-cdk = "0.7.4"
+ic-cdk-macros = "0.6.10"
 sha256 = "1.1.1"
 serde = "1.0.132"
 

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -7,15 +7,15 @@ edition = "2018"
 
 [dependencies]
 bitcoin = {version = "0.28.1", features = ["use-serde"]}
-candid = "0.9.0-beta.3"
+candid = "0.8.1"
 # NOTE: A specific commit of ciborium is used that includes efficient serializion/deserialization of
 #       blobs. At the time of this writing, a new version including this commit hasn't yet been released.
 ciborium = { git = "https://github.com/enarx/ciborium", rev = "e719537c99b564c3674a56defe53713c702c6f46" }
 hex = "0.4.3"
 ic-btc-interface = { path = "../interface" }
 ic-btc-validation = { path = "../validation" }
-ic-cdk = "=0.8.0-beta.0"
-ic-cdk-macros = "0.8.0-beta.0"
+ic-cdk = "0.7.4"
+ic-cdk-macros = "0.6.10"
 ic-metrics-encoder = "1.0.0"
 ic-stable-structures = "0.5.2"
 lazy_static = "1.4.0"

--- a/e2e-tests/disable-api-if-not-fully-synced-flag/Cargo.toml
+++ b/e2e-tests/disable-api-if-not-fully-synced-flag/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 bitcoin = "0.28.1"
-candid = "0.9.0-beta.3"
+candid = "0.8.1"
 ic-btc-test-utils = { path = "../../test-utils" }
-ic-cdk = "=0.8.0-beta.0"
-ic-cdk-macros = "0.8.0-beta.0"
+ic-cdk = "0.7.4"
+ic-cdk-macros = "0.6.10"
 serde = "1.0.132"

--- a/e2e-tests/scenario-1/Cargo.toml
+++ b/e2e-tests/scenario-1/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 bitcoin = "0.28.1"
-candid = "0.9.0-beta.3"
+candid = "0.8.1"
 ic-btc-test-utils = { path = "../../test-utils" }
-ic-cdk = "=0.8.0-beta.0"
-ic-cdk-macros = "0.8.0-beta.0"
+ic-cdk = "0.7.4"
+ic-cdk-macros = "0.6.10"
 serde = "1.0.132"

--- a/e2e-tests/scenario-2/Cargo.toml
+++ b/e2e-tests/scenario-2/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 bitcoin = "0.28.1"
-candid = "0.9.0-beta.3"
+candid = "0.8.1"
 ic-btc-test-utils = { path = "../../test-utils" }
-ic-cdk = "=0.8.0-beta.0"
-ic-cdk-macros = "0.8.0-beta.0"
+ic-cdk = "0.7.4"
+ic-cdk-macros = "0.6.10"
 serde = "1.0.132"

--- a/e2e-tests/scenario-3/Cargo.toml
+++ b/e2e-tests/scenario-3/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 bitcoin = "0.28.1"
-candid = "0.9.0-beta.3"
+candid = "0.8.1"
 ic-btc-test-utils = { path = "../../test-utils" }
-ic-cdk = "=0.8.0-beta.0"
-ic-cdk-macros = "0.8.0-beta.0"
+ic-cdk = "0.7.4"
+ic-cdk-macros = "0.6.10"
 serde = "1.0.132"

--- a/ic-http/Cargo.toml
+++ b/ic-http/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-candid = "0.9.0-beta.3"
-ic-cdk = "=0.8.0-beta.0"
-ic-cdk-macros = "0.8.0-beta.0"
+candid = "0.8.1"
+ic-cdk = "0.7.4"
+ic-cdk-macros = "0.6.10"
 
 # Added to use non-blocking sleep to mock delayed responses.
 # Currently wasm32 does not support tokio, so we need to disable it for wasm32.

--- a/ic-http/example_canister/src/canister_backend/Cargo.toml
+++ b/ic-http/example_canister/src/canister_backend/Cargo.toml
@@ -10,9 +10,9 @@ name = "canister_backend"
 path = "src/main.rs"
 
 [dependencies]
-candid = "0.9.0-beta.3"
-ic-cdk = "=0.8.0-beta.0"
-ic-cdk-macros = "0.8.0-beta.0"
+candid = "0.8.1"
+ic-cdk = "0.7.4"
+ic-cdk-macros = "0.6.10"
 ic-http = {path = "../../../"}
 serde = { version = "1.0.158", features = [ "derive" ] }
 serde_json = "1.0.94"

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-candid = "0.9.0-beta.3"
+candid = "0.8.1"
 serde = "1.0.132"
 serde_bytes = "0.11"
 

--- a/watchdog/Cargo.toml
+++ b/watchdog/Cargo.toml
@@ -10,9 +10,9 @@ name = "watchdog-canister"
 path = "src/main.rs"
 
 [dependencies]
-candid = "0.9.0-beta.3"
-ic-cdk = "=0.8.0-beta.0"
-ic-cdk-macros = "0.8.0-beta.0"
+candid = "0.8.1"
+ic-cdk = "0.7.4"
+ic-cdk-macros = "0.6.10"
 ic-cdk-timers = "0.1"
 serde = { version = "1.0.158", features = [ "derive" ] }
 serde_json = "1.0.94"


### PR DESCRIPTION
This PR downgrades versions for `candid`, `ic-cdk` and `ic-cdk-macros` revering #213.

The reason is that `candid = "0.9.0-beta.3"` blocks using updated crates `ic-btc-interface`, `ic-btc-validate` in the IC repo due to some candid incompatibility.