### PR TITLE
fix: Use vbyte for the computation of a transaction fee

### DIFF
--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -550,7 +550,6 @@ mod test {
         assert_ne!(tx.vsize(), tx.size());
         assert_eq!(tx_without_witness.vsize(), tx_without_witness.size());
 
-
         let blocks = vec![
             BlockBuilder::with_prev_header(genesis_block(Network::Regtest).header())
                 .with_transaction(coinbase_tx)

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -521,7 +521,7 @@ mod test {
     }
 
     #[test]
-    fn transaction_vsize() {
+    fn measures_fees_in_vbytes() {
         let balance = 1000;
         let fee = 1;
         let fee_in_millisatoshi = 1000;

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -113,9 +113,9 @@ fn get_tx_fee_per_byte(
         satoshi -= tx_out.value;
     }
 
-    if tx.size() > 0 {
+    if tx.vsize() > 0 {
         // Don't use floating point division to avoid non-determinism.
-        Some(((1000 * satoshi) / tx.size() as u64) as MillisatoshiPerByte)
+        Some(((1000 * satoshi) / tx.vsize() as u64) as MillisatoshiPerByte)
     } else {
         // Calculating fee is not possible for a zero-size invalid transaction.
         None
@@ -358,7 +358,7 @@ mod test {
             // so the percentiles should be the fee / byte of the second transaction.
             assert_eq!(
                 get_current_fee_percentiles_internal(s, 1),
-                vec![fee_in_millisatoshi / tx_2.size() as u64; PERCENTILE_BUCKETS]
+                vec![fee_in_millisatoshi / tx_2.vsize() as u64; PERCENTILE_BUCKETS]
             );
         });
     }

--- a/canister/src/test_utils.rs
+++ b/canister/src/test_utils.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use bitcoin::{
     hashes::Hash, secp256k1::rand::rngs::OsRng, secp256k1::Secp256k1, Address as BitcoinAddress,
-    BlockHeader, PublicKey, Script, WScriptHash,
+    BlockHeader, PublicKey, Script, WScriptHash, Witness,
 };
 use ic_btc_interface::Network;
 use ic_btc_test_utils::{
@@ -213,7 +213,15 @@ impl TransactionBuilder {
 
     pub fn with_input(self, previous_output: OutPoint) -> Self {
         Self {
-            builder: self.builder.with_input(previous_output.into()),
+            builder: self.builder.with_input(previous_output.into(), None),
+        }
+    }
+
+    pub fn with_input_and_witness(self, previous_output: OutPoint, witness: Witness) -> Self {
+        Self {
+            builder: self
+                .builder
+                .with_input(previous_output.into(), Some(witness)),
         }
     }
 

--- a/e2e-tests/scenario-1/src/main.rs
+++ b/e2e-tests/scenario-1/src/main.rs
@@ -95,10 +95,13 @@ fn init() {
     for i in 0..10_000 {
         block_2_txs.push(
             TransactionBuilder::new()
-                .with_input(OutPoint {
-                    txid: tx_1_id,
-                    vout: i,
-                })
+                .with_input(
+                    OutPoint {
+                        txid: tx_1_id,
+                        vout: i,
+                    },
+                    None,
+                )
                 .with_output(&Address::from_str(ADDRESS_2).unwrap(), 500_000)
                 .build(),
         )
@@ -136,10 +139,13 @@ fn init() {
     for block_2_tx in block_2_txs {
         block_5_txs.push(
             TransactionBuilder::new()
-                .with_input(OutPoint {
-                    txid: block_2_tx.txid(),
-                    vout: 0,
-                })
+                .with_input(
+                    OutPoint {
+                        txid: block_2_tx.txid(),
+                        vout: 0,
+                    },
+                    None,
+                )
                 .with_output(&Address::from_str(ADDRESS_5).unwrap(), 500_000)
                 .build(),
         )

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -21,7 +21,7 @@ pub fn random_p2tr_address(network: Network) -> Address {
     Address::p2tr(&secp, xonly, None, network)
 }
 
-pub fn coinbase_input() -> TxIn {
+fn coinbase_input() -> TxIn {
     TxIn {
         previous_output: OutPoint::null(),
         script_sig: Script::new(),

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -21,6 +21,15 @@ pub fn random_p2tr_address(network: Network) -> Address {
     Address::p2tr(&secp, xonly, None, network)
 }
 
+pub fn coinbase_input() -> TxIn {
+    TxIn {
+        previous_output: OutPoint::null(),
+        script_sig: Script::new(),
+        sequence: 0xffffffff,
+        witness: Witness::new(),
+    }
+}
+
 pub struct BlockBuilder {
     prev_header: Option<BlockHeader>,
     transactions: Vec<Transaction>,
@@ -91,7 +100,7 @@ fn genesis(merkle_root: TxMerkleNode) -> BlockHeader {
 }
 
 pub struct TransactionBuilder {
-    previous_output: Vec<OutPoint>,
+    input: Vec<TxIn>,
     output: Vec<TxOut>,
     lock_time: u32,
 }
@@ -99,7 +108,7 @@ pub struct TransactionBuilder {
 impl TransactionBuilder {
     pub fn new() -> Self {
         Self {
-            previous_output: vec![],
+            input: vec![],
             output: vec![],
             lock_time: 0,
         }
@@ -107,17 +116,25 @@ impl TransactionBuilder {
 
     pub fn coinbase() -> Self {
         Self {
-            previous_output: vec![OutPoint::null()],
+            input: vec![coinbase_input()],
             output: vec![],
             lock_time: 0,
         }
     }
 
-    pub fn with_input(mut self, previous_output: OutPoint) -> Self {
-        if self.previous_output == vec![OutPoint::null()] {
+    pub fn with_input(mut self, previous_output: OutPoint, witness: Option<Witness>) -> Self {
+        if self.input == vec![coinbase_input()] {
             panic!("A call `with_input` should not be possible if `coinbase` was called");
         }
-        self.previous_output.push(previous_output);
+
+        let witness = witness.map_or(Witness::new(), |w| w);
+        let input = TxIn {
+            previous_output,
+            script_sig: Script::new(),
+            sequence: 0xffffffff,
+            witness,
+        };
+        self.input.push(input);
         self
     }
 
@@ -135,21 +152,12 @@ impl TransactionBuilder {
     }
 
     pub fn build(self) -> Transaction {
-        let prev_outputs = if self.previous_output.is_empty() {
+        let input = if self.input.is_empty() {
             // Default to coinbase if no inputs provided.
-            vec![OutPoint::null()]
+            vec![coinbase_input()]
         } else {
-            self.previous_output
+            self.input
         };
-        let input = prev_outputs
-            .iter()
-            .map(|output| TxIn {
-                previous_output: *output,
-                script_sig: Script::new(),
-                sequence: 0xffffffff,
-                witness: Witness::new(),
-            })
-            .collect();
         let output = if self.output.is_empty() {
             // Use default of 50 BTC.
             vec![TxOut {
@@ -236,7 +244,7 @@ mod test {
                 .build();
 
             TransactionBuilder::coinbase()
-                .with_input(bitcoin::OutPoint::new(coinbase_tx.txid(), 0));
+                .with_input(bitcoin::OutPoint::new(coinbase_tx.txid(), 0), None);
         }
 
         #[test]
@@ -281,7 +289,7 @@ mod test {
                 .build();
 
             let tx = TransactionBuilder::new()
-                .with_input(bitcoin::OutPoint::new(coinbase_tx.txid(), 0))
+                .with_input(bitcoin::OutPoint::new(coinbase_tx.txid(), 0), None)
                 .build();
             assert!(!tx.is_coin_base());
             assert_eq!(tx.input.len(), 1);
@@ -304,8 +312,8 @@ mod test {
                 .build();
 
             let tx = TransactionBuilder::new()
-                .with_input(bitcoin::OutPoint::new(coinbase_tx_0.txid(), 0))
-                .with_input(bitcoin::OutPoint::new(coinbase_tx_1.txid(), 0))
+                .with_input(bitcoin::OutPoint::new(coinbase_tx_0.txid(), 0), None)
+                .with_input(bitcoin::OutPoint::new(coinbase_tx_1.txid(), 0), None)
                 .build();
             assert!(!tx.is_coin_base());
             assert_eq!(tx.input.len(), 2);

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -106,6 +106,10 @@ impl Transaction {
         &self.tx.output
     }
 
+    pub fn vsize(&self) -> usize {
+        self.tx.vsize()
+    }
+
     pub fn size(&self) -> usize {
         self.tx.size()
     }


### PR DESCRIPTION
The specification mentions that the fee percentiles are measured in [millisatoshi/vbyte](https://github.com/dfinity/interface-spec/blob/master/spec/index.md#ic-method-bitcoin_get_current_fee_percentiles-ic-bitcoin_get_current_fee_percentiles). 
This PR updates the code in accordance with the specification.