### PR TITLE
chore: bump up candid to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
  "anyhow",
  "binread",
  "byteorder",
- "candid_derive",
+ "candid_derive 0.5.0",
  "codespan-reporting",
  "crc32fast",
  "data-encoding",
@@ -446,12 +446,39 @@ dependencies = [
  "logos",
  "num-bigint",
  "num-traits",
- "num_enum",
+ "num_enum 0.5.11",
  "paste",
- "pretty",
+ "pretty 0.10.0",
  "serde",
  "serde_bytes",
  "sha2 0.10.6",
+ "thiserror",
+]
+
+[[package]]
+name = "candid"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df671c37a9c6168db0334f2b289dd4e02dea1bbefe1fb22c5d43b12d865aacd"
+dependencies = [
+ "anyhow",
+ "binread",
+ "byteorder",
+ "candid_derive 0.6.2",
+ "codespan-reporting",
+ "crc32fast",
+ "data-encoding",
+ "hex",
+ "leb128",
+ "num-bigint",
+ "num-traits",
+ "num_enum 0.6.1",
+ "paste",
+ "pretty 0.12.1",
+ "serde",
+ "serde_bytes",
+ "sha2 0.10.6",
+ "stacker",
  "thiserror",
 ]
 
@@ -468,10 +495,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "candid_derive"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810b3bd60244f282090652ffc7c30a9d23892e72dfe443e46ee55569044f7dd5"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "canister_backend"
 version = "0.1.0"
 dependencies = [
- "candid",
+ "candid 0.9.1",
  "futures",
  "ic-cdk",
  "ic-cdk-macros",
@@ -796,7 +835,7 @@ name = "disable-api-if-not-fully-synced-flag"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid",
+ "candid 0.9.1",
  "ic-btc-test-utils",
  "ic-cdk",
  "ic-cdk-macros",
@@ -1286,7 +1325,7 @@ dependencies = [
  "base32",
  "base64 0.13.1",
  "byteorder",
- "candid",
+ "candid 0.8.4",
  "futures-util",
  "garcon",
  "hex",
@@ -1320,7 +1359,7 @@ dependencies = [
  "async-std",
  "bitcoin",
  "byteorder",
- "candid",
+ "candid 0.9.1",
  "ciborium 0.2.0",
  "hex",
  "ic-btc-interface",
@@ -1342,7 +1381,7 @@ dependencies = [
 name = "ic-btc-interface"
 version = "0.1.0"
 dependencies = [
- "candid",
+ "candid 0.9.1",
  "ciborium 0.2.1",
  "proptest 1.2.0",
  "serde",
@@ -1372,7 +1411,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9beb0bf1dcd0639c313630e34aa547a2b19450ddf1969c176e13225ef3b29048"
 dependencies = [
- "candid",
+ "candid 0.8.4",
  "ic-cdk-macros",
  "ic0",
  "serde",
@@ -1385,7 +1424,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebf50458685a0fc6b0e414cdba487610aeb199ac94db52d9fd76270565debee7"
 dependencies = [
- "candid",
+ "candid 0.8.4",
  "proc-macro2",
  "quote",
  "serde",
@@ -1411,7 +1450,7 @@ dependencies = [
 name = "ic-http"
 version = "0.1.0"
 dependencies = [
- "candid",
+ "candid 0.9.1",
  "futures",
  "ic-cdk",
  "ic-cdk-macros",
@@ -1744,7 +1783,16 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive 0.6.1",
 ]
 
 [[package]]
@@ -1757,6 +1805,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1925,6 +1985,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563c9d701c3a31dfffaaf9ce23507ba09cbe0b9125ba176d15e629b0235e9acc"
+dependencies = [
+ "arrayvec",
+ "typed-arena",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,6 +2052,15 @@ dependencies = [
  "rusty-fork 0.3.0",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2436,7 +2516,7 @@ name = "scenario-1"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid",
+ "candid 0.9.1",
  "ic-btc-test-utils",
  "ic-cdk",
  "ic-cdk-macros",
@@ -2448,7 +2528,7 @@ name = "scenario-2"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid",
+ "candid 0.9.1",
  "ic-btc-test-utils",
  "ic-cdk",
  "ic-cdk-macros",
@@ -2460,7 +2540,7 @@ name = "scenario-3"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid",
+ "candid 0.9.1",
  "ic-btc-test-utils",
  "ic-cdk",
  "ic-cdk-macros",
@@ -2747,6 +2827,19 @@ checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
 ]
 
 [[package]]
@@ -3074,6 +3167,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3096,7 +3195,7 @@ name = "uploader"
 version = "0.1.0"
 dependencies = [
  "async-std",
- "candid",
+ "candid 0.9.1",
  "clap",
  "garcon",
  "ic-agent",
@@ -3257,7 +3356,7 @@ version = "0.1.0"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "candid",
+ "candid 0.9.1",
  "futures",
  "hex",
  "ic-btc-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ members = [
 ]
 
 [workspace.dependencies]
-candid = "0.8.1"
+candid = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ members = [
     "ic-http",
     "ic-http/example_canister/src/canister_backend",
 ]
+
+[workspace.dependencies]
+candid = "0.8.1"

--- a/bootstrap/uploader/Cargo.toml
+++ b/bootstrap/uploader/Cargo.toml
@@ -19,7 +19,7 @@ name = "compute_hashes"
 path = "src/compute_hashes.rs"
 
 [dependencies]
-candid = "0.8.1"
+candid = { workspace = true }
 ic-cdk = "0.7.4"
 ic-cdk-macros = "0.6.10"
 sha256 = "1.1.1"

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 bitcoin = {version = "0.28.1", features = ["use-serde"]}
-candid = "0.8.1"
+candid = { workspace = true }
 # NOTE: A specific commit of ciborium is used that includes efficient serializion/deserialization of
 #       blobs. At the time of this writing, a new version including this commit hasn't yet been released.
 ciborium = { git = "https://github.com/enarx/ciborium", rev = "e719537c99b564c3674a56defe53713c702c6f46" }

--- a/e2e-tests/disable-api-if-not-fully-synced-flag/Cargo.toml
+++ b/e2e-tests/disable-api-if-not-fully-synced-flag/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 bitcoin = "0.28.1"
-candid = "0.8.1"
+candid = { workspace = true }
 ic-btc-test-utils = { path = "../../test-utils" }
 ic-cdk = "0.7.4"
 ic-cdk-macros = "0.6.10"

--- a/e2e-tests/scenario-1/Cargo.toml
+++ b/e2e-tests/scenario-1/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 bitcoin = "0.28.1"
-candid = "0.8.1"
+candid = { workspace = true }
 ic-btc-test-utils = { path = "../../test-utils" }
 ic-cdk = "0.7.4"
 ic-cdk-macros = "0.6.10"

--- a/e2e-tests/scenario-2/Cargo.toml
+++ b/e2e-tests/scenario-2/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 bitcoin = "0.28.1"
-candid = "0.8.1"
+candid = { workspace = true }
 ic-btc-test-utils = { path = "../../test-utils" }
 ic-cdk = "0.7.4"
 ic-cdk-macros = "0.6.10"

--- a/e2e-tests/scenario-3/Cargo.toml
+++ b/e2e-tests/scenario-3/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 bitcoin = "0.28.1"
-candid = "0.8.1"
+candid = { workspace = true }
 ic-btc-test-utils = { path = "../../test-utils" }
 ic-cdk = "0.7.4"
 ic-cdk-macros = "0.6.10"

--- a/ic-http/Cargo.toml
+++ b/ic-http/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-candid = "0.8.1"
+candid = { workspace = true }
 ic-cdk = "0.7.4"
 ic-cdk-macros = "0.6.10"
 

--- a/ic-http/example_canister/src/canister_backend/Cargo.toml
+++ b/ic-http/example_canister/src/canister_backend/Cargo.toml
@@ -10,7 +10,7 @@ name = "canister_backend"
 path = "src/main.rs"
 
 [dependencies]
-candid = "0.8.1"
+candid = { workspace = true }
 ic-cdk = "0.7.4"
 ic-cdk-macros = "0.6.10"
 ic-http = {path = "../../../"}

--- a/ic-http/src/response.rs
+++ b/ic-http/src/response.rs
@@ -1,4 +1,5 @@
 use ic_cdk::api::management_canister::http_request::{HttpHeader, HttpResponse};
+use ic_cdk::export::candid::Nat;
 
 /// Creates a new `HttpResponseBuilder` to construct an HTTP response.
 pub fn create_response() -> HttpResponseBuilder {
@@ -8,7 +9,7 @@ pub fn create_response() -> HttpResponseBuilder {
 /// Represents a builder for an HTTP response.
 pub struct HttpResponseBuilder {
     /// The response status (e.g., 200, 404).
-    pub status: ic_cdk::export::candid::Nat,
+    pub status: Nat,
     /// List of HTTP response headers and their corresponding values.
     pub headers: Vec<HttpHeader>,
     /// The response’s body.
@@ -18,14 +19,14 @@ pub struct HttpResponseBuilder {
 impl HttpResponseBuilder {
     pub fn new() -> Self {
         Self {
-            status: ic_cdk::export::candid::Nat::from(200),
+            status: Nat::from(200),
             headers: Vec::new(),
             body: Vec::new(),
         }
     }
 
     pub fn status(mut self, status: u64) -> Self {
-        self.status = ic_cdk::export::candid::Nat::from(status);
+        self.status = Nat::from(status);
         self
     }
 

--- a/ic-http/src/response.rs
+++ b/ic-http/src/response.rs
@@ -8,7 +8,7 @@ pub fn create_response() -> HttpResponseBuilder {
 /// Represents a builder for an HTTP response.
 pub struct HttpResponseBuilder {
     /// The response status (e.g., 200, 404).
-    pub status: candid::Nat,
+    pub status: ic_cdk::export::candid::Nat,
     /// List of HTTP response headers and their corresponding values.
     pub headers: Vec<HttpHeader>,
     /// The response’s body.
@@ -18,14 +18,14 @@ pub struct HttpResponseBuilder {
 impl HttpResponseBuilder {
     pub fn new() -> Self {
         Self {
-            status: candid::Nat::from(200),
+            status: ic_cdk::export::candid::Nat::from(200),
             headers: Vec::new(),
             body: Vec::new(),
         }
     }
 
     pub fn status(mut self, status: u64) -> Self {
-        self.status = candid::Nat::from(status);
+        self.status = ic_cdk::export::candid::Nat::from(status);
         self
     }
 

--- a/ic-http/src/transform.rs
+++ b/ic-http/src/transform.rs
@@ -3,7 +3,11 @@ use ic_cdk::api::management_canister::http_request::{
 };
 
 #[cfg(not(target_arch = "wasm32"))]
-use {candid::Principal, ic_cdk::api::management_canister::http_request::TransformFunc};
+use ic_cdk::api::management_canister::http_request::TransformFunc;
+#[cfg(not(target_arch = "wasm32"))]
+use ic_cdk::export::candid::Func;
+#[cfg(not(target_arch = "wasm32"))]
+use ic_cdk::export::Principal;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub type TransformFn = dyn Fn(TransformArgs) -> HttpResponse + 'static;
@@ -19,7 +23,7 @@ where
     crate::storage::transform_function_insert(function_name.clone(), Box::new(func));
 
     TransformContext {
-        function: TransformFunc(candid::Func {
+        function: TransformFunc(Func {
             principal: Principal::management_canister(),
             method: function_name,
         }),

--- a/ic-http/tests/api.rs
+++ b/ic-http/tests/api.rs
@@ -1,5 +1,6 @@
 use ic_cdk::api::call::RejectionCode;
 use ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs};
+use ic_cdk::export::candid::Nat;
 use std::time::{Duration, Instant};
 
 const STATUS_CODE_OK: u64 = 200;
@@ -20,7 +21,7 @@ async fn test_http_request_no_transform() {
     let (response,) = ic_http::http_request(request.clone()).await.unwrap();
 
     // Assert
-    assert_eq!(response.status, candid::Nat::from(STATUS_CODE_OK));
+    assert_eq!(response.status, Nat::from(STATUS_CODE_OK));
     assert_eq!(response.body, body.to_string().as_bytes().to_vec());
     assert_eq!(ic_http::mock::times_called(request), 1);
 }
@@ -40,7 +41,7 @@ async fn test_http_request_called_several_times() {
     // Act
     for _ in 0..calls {
         let (response,) = ic_http::http_request(request.clone()).await.unwrap();
-        assert_eq!(response.status, candid::Nat::from(STATUS_CODE_OK));
+        assert_eq!(response.status, Nat::from(STATUS_CODE_OK));
         assert_eq!(response.body, body.to_string().as_bytes().to_vec());
     }
 
@@ -70,8 +71,8 @@ async fn test_http_request_transform_status() {
     let (response,) = ic_http::http_request(request.clone()).await.unwrap();
 
     // Assert
-    assert_ne!(response.status, candid::Nat::from(STATUS_CODE_OK));
-    assert_eq!(response.status, candid::Nat::from(STATUS_CODE_NOT_FOUND));
+    assert_ne!(response.status, Nat::from(STATUS_CODE_OK));
+    assert_eq!(response.status, Nat::from(STATUS_CODE_NOT_FOUND));
     assert_eq!(ic_http::mock::times_called(request), 1);
 }
 
@@ -110,7 +111,7 @@ async fn test_http_request_transform_both_status_and_body() {
 
     fn transform_status(arg: TransformArgs) -> HttpResponse {
         let mut response = arg.response;
-        response.status = candid::Nat::from(STATUS_CODE_NOT_FOUND);
+        response.status = Nat::from(STATUS_CODE_NOT_FOUND);
         response
     }
 
@@ -158,12 +159,9 @@ async fn test_http_request_transform_both_status_and_body() {
         vec!["transform_body", "transform_status"]
     );
     assert_eq!(responses.len(), 2);
-    assert_eq!(
-        responses[0].status,
-        candid::Nat::from(STATUS_CODE_NOT_FOUND)
-    );
+    assert_eq!(responses[0].status, Nat::from(STATUS_CODE_NOT_FOUND));
     assert_eq!(responses[0].body, ORIGINAL_BODY.as_bytes().to_vec());
-    assert_eq!(responses[1].status, candid::Nat::from(STATUS_CODE_OK));
+    assert_eq!(responses[1].status, Nat::from(STATUS_CODE_OK));
     assert_eq!(responses[1].body, TRANSFORMED_BODY.as_bytes().to_vec());
     assert_eq!(ic_http::mock::times_called(request_1), 1);
     assert_eq!(ic_http::mock::times_called(request_2), 1);

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-candid = "0.8.1"
+candid = { workspace = true }
 serde = "1.0.132"
 serde_bytes = "0.11"
 

--- a/watchdog/Cargo.toml
+++ b/watchdog/Cargo.toml
@@ -10,7 +10,7 @@ name = "watchdog-canister"
 path = "src/main.rs"
 
 [dependencies]
-candid = "0.8.1"
+candid = { workspace = true }
 ic-cdk = "0.7.4"
 ic-cdk-macros = "0.6.10"
 ic-cdk-timers = "0.1"


### PR DESCRIPTION
UPD: closed in favour of #231 

NOTE: on hold until Rust CDK updates candid to 0.9.1.