### PR TITLE
chore: update some crate revisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,7 @@ dependencies = [
  "ic-stable-structures",
  "lazy_static",
  "maplit",
- "proptest",
+ "proptest 0.9.6",
  "serde",
  "serde_bytes",
  "tempfile",
@@ -1356,7 +1356,7 @@ version = "0.1.0"
 dependencies = [
  "candid",
  "ciborium",
- "proptest",
+ "proptest 1.2.0",
  "serde",
  "serde_bytes",
 ]
@@ -1375,7 +1375,7 @@ dependencies = [
  "bitcoin",
  "csv",
  "hex",
- "proptest",
+ "proptest 1.2.0",
 ]
 
 [[package]]
@@ -1975,6 +1975,26 @@ dependencies = [
 
 [[package]]
 name = "proptest"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c477819b845fe023d33583ebf10c9f62518c8d79a0960ba5c36d6ac8a55a5b"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error",
+ "rand 0.6.5",
+ "rand_chacha 0.1.1",
+ "rand_xorshift 0.1.1",
+ "regex-syntax 0.6.29",
+ "rusty-fork 0.2.2",
+ "tempfile",
+]
+
+[[package]]
+name = "proptest"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
@@ -1988,7 +2008,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_xorshift 0.3.0",
  "regex-syntax 0.6.29",
- "rusty-fork",
+ "rusty-fork 0.3.0",
  "tempfile",
  "unarray",
 ]
@@ -2402,6 +2422,18 @@ name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
+name = "rusty-fork"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dd93264e10c577503e926bd1430193eeb5d21b059148910082245309b424fae"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rusty-fork"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,29 +495,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "ciborium"
-version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium?rev=e719537c99b564c3674a56defe53713c702c6f46#e719537c99b564c3674a56defe53713c702c6f46"
-dependencies = [
- "ciborium-io 0.2.0",
- "ciborium-ll 0.2.0",
- "serde",
-]
-
-[[package]]
-name = "ciborium"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
- "ciborium-io 0.2.1",
- "ciborium-ll 0.2.1",
+ "ciborium-io",
+ "ciborium-ll",
  "serde",
 ]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium?rev=e719537c99b564c3674a56defe53713c702c6f46#e719537c99b564c3674a56defe53713c702c6f46"
 
 [[package]]
 name = "ciborium-io"
@@ -527,20 +512,11 @@ checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium?rev=e719537c99b564c3674a56defe53713c702c6f46#e719537c99b564c3674a56defe53713c702c6f46"
-dependencies = [
- "ciborium-io 0.2.0",
- "half",
-]
-
-[[package]]
-name = "ciborium-ll"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
- "ciborium-io 0.2.1",
+ "ciborium-io",
  "half",
 ]
 
@@ -1321,7 +1297,7 @@ dependencies = [
  "bitcoin",
  "byteorder",
  "candid",
- "ciborium 0.2.0",
+ "ciborium",
  "hex",
  "ic-btc-interface",
  "ic-btc-test-utils",
@@ -1343,7 +1319,7 @@ name = "ic-btc-interface"
 version = "0.1.0"
 dependencies = [
  "candid",
- "ciborium 0.2.1",
+ "ciborium",
  "proptest 1.2.0",
  "serde",
  "serde_bytes",
@@ -2756,7 +2732,7 @@ dependencies = [
  "async-std",
  "bitcoin",
  "byteorder",
- "ciborium 0.2.0",
+ "ciborium",
  "clap",
  "hex",
  "ic-btc-canister",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -583,7 +583,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1031,7 +1031,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1966,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -2555,9 +2555,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
@@ -2583,13 +2583,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2810,9 +2810,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2870,7 +2870,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2952,7 +2952,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3198,7 +3198,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
  "wasm-bindgen-shared",
 ]
 
@@ -3232,7 +3232,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.25",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +250,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base16ct"
@@ -1076,6 +1106,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,7 +1344,7 @@ dependencies = [
  "ic-stable-structures",
  "lazy_static",
  "maplit",
- "proptest 0.9.6",
+ "proptest",
  "serde",
  "serde_bytes",
  "tempfile",
@@ -1320,7 +1356,7 @@ version = "0.1.0"
 dependencies = [
  "candid",
  "ciborium",
- "proptest 1.2.0",
+ "proptest",
  "serde",
  "serde_bytes",
 ]
@@ -1339,7 +1375,7 @@ dependencies = [
  "bitcoin",
  "csv",
  "hex",
- "proptest 0.9.6",
+ "proptest",
 ]
 
 [[package]]
@@ -1656,6 +1692,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,6 +1778,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1921,26 +1975,6 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c477819b845fe023d33583ebf10c9f62518c8d79a0960ba5c36d6ac8a55a5b"
-dependencies = [
- "bit-set",
- "bitflags",
- "byteorder",
- "lazy_static",
- "num-traits",
- "quick-error",
- "rand 0.6.5",
- "rand_chacha 0.1.1",
- "rand_xorshift 0.1.1",
- "regex-syntax 0.6.29",
- "rusty-fork 0.2.2",
- "tempfile",
-]
-
-[[package]]
-name = "proptest"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
@@ -1954,7 +1988,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_xorshift 0.3.0",
  "regex-syntax 0.6.29",
- "rusty-fork 0.3.0",
+ "rusty-fork",
  "tempfile",
  "unarray",
 ]
@@ -2289,6 +2323,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustix"
 version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,18 +2402,6 @@ name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
-
-[[package]]
-name = "rusty-fork"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd93264e10c577503e926bd1430193eeb5d21b059148910082245309b424fae"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "rusty-fork"
@@ -2898,11 +2926,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg 1.1.0",
+ "backtrace",
  "bytes",
  "libc",
  "mio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,7 @@ dependencies = [
  "bitcoin",
  "csv",
  "hex",
- "proptest 1.2.0",
+ "proptest 0.9.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ ic-http = { path = "./ic-http" }
 ic-metrics-encoder = "1.0.0"
 ic-stable-structures = "0.5.2"
 proptest = "1.2"
-serde = "1.0.158"
+serde = "1.0.171"
 serde_bytes = "0.11"
 serde_json = "1.0.94"
 tokio = { version = "1.29.1", features = [ "full" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
 bitcoin = "0.28.1"
 byteorder = "1.4.3"
 candid = "0.8.1"
+ciborium = "0.2.1"
 clap = { version = "4.0.11", features = ["derive"] }
 hex = "0.4.3"
 ic-btc-canister = { path = "./canister" }
@@ -37,6 +38,6 @@ ic-cdk-macros = "0.6.10"
 ic-http = { path = "./ic-http" }
 ic-metrics-encoder = "1.0.0"
 ic-stable-structures = "0.5.2"
-serde = "1.0.132"
+serde = "1.0.158"
 serde_bytes = "0.11"
 serde_json = "1.0.94"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ ic-cdk-macros = "0.6.10"
 ic-http = { path = "./ic-http" }
 ic-metrics-encoder = "1.0.0"
 ic-stable-structures = "0.5.2"
-proptest = "1.2"
 serde = "1.0.171"
 serde_bytes = "0.11"
 serde_json = "1.0.94"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ byteorder = "1.4.3"
 candid = "0.8.1"
 ciborium = "0.2.1"
 clap = { version = "4.0.11", features = ["derive"] }
+futures = "0.3.28"
 hex = "0.4.3"
 ic-btc-canister = { path = "./canister" }
 ic-btc-interface = { path = "./interface" }
@@ -38,6 +39,8 @@ ic-cdk-macros = "0.6.10"
 ic-http = { path = "./ic-http" }
 ic-metrics-encoder = "1.0.0"
 ic-stable-structures = "0.5.2"
+proptest = "1.2"
 serde = "1.0.158"
 serde_bytes = "0.11"
 serde_json = "1.0.94"
+tokio = { version = "1.29.1", features = [ "full" ] }

--- a/bootstrap/main-state-builder/Cargo.toml
+++ b/bootstrap/main-state-builder/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 bitcoin = "0.28.1"
 clap = { version = "4.0.11", features = ["derive"] }
-ciborium = { git = "https://github.com/enarx/ciborium", rev = "e719537c99b564c3674a56defe53713c702c6f46" }
+ciborium = { workspace = true }
 hex = "0.4.3"
 ic-btc-canister = { path = "../../canister", features = ["file_memory"] }
 ic-btc-interface = { path = "../../interface" }

--- a/bootstrap/main-state-builder/Cargo.toml
+++ b/bootstrap/main-state-builder/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 bitcoin = "0.28.1"
 clap = { version = "4.0.11", features = ["derive"] }
-ciborium = { workspace = true }
+ciborium = "0.2.1"
 hex = "0.4.3"
 ic-btc-canister = { path = "../../canister", features = ["file_memory"] }
 ic-btc-interface = { path = "../../interface" }

--- a/bootstrap/state-builder/Cargo.toml
+++ b/bootstrap/state-builder/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/combine_state.rs"
 async-std = { version = "1.12.0", features = ["attributes"] }
 bitcoin = { workspace = true }
 byteorder = { workspace = true }
-ciborium = { git = "https://github.com/enarx/ciborium", rev = "e719537c99b564c3674a56defe53713c702c6f46" }
+ciborium = { workspace = true }
 clap = { workspace = true }
 hex = { workspace = true }
 ic-btc-canister = { workspace = true }

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -30,7 +30,7 @@ bitcoin = { workspace = true, features = ["rand"] } # needed for generating secp
 byteorder = { workspace = true }
 ic-btc-test-utils = { workspace = true }
 maplit = "1.0.2"
-proptest = "0.9.4"
+proptest = { workspace = true }
 tempfile = "3.2.0"
 
 [features]

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -8,9 +8,7 @@ edition = "2018"
 [dependencies]
 bitcoin = { workspace = true, features = ["use-serde"] }
 candid = { workspace = true }
-# NOTE: A specific commit of ciborium is used that includes efficient serializion/deserialization of
-#       blobs. At the time of this writing, a new version including this commit hasn't yet been released.
-ciborium = { git = "https://github.com/enarx/ciborium", rev = "e719537c99b564c3674a56defe53713c702c6f46" }
+ciborium = { workspace = true }
 hex = { workspace = true }
 ic-btc-interface = { workspace = true }
 ic-btc-validation = { workspace = true }

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -30,7 +30,7 @@ bitcoin = { workspace = true, features = ["rand"] } # needed for generating secp
 byteorder = { workspace = true }
 ic-btc-test-utils = { workspace = true }
 maplit = "1.0.2"
-proptest = { workspace = true }
+proptest = "0.9.4"
 tempfile = "3.2.0"
 
 [features]

--- a/ic-http/Cargo.toml
+++ b/ic-http/Cargo.toml
@@ -14,8 +14,8 @@ ic-cdk-macros = { workspace = true }
 # Added to use non-blocking sleep to mock delayed responses.
 # Currently wasm32 does not support tokio, so we need to disable it for wasm32.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.15.0", features = [ "full" ] }
+tokio = { workspace = true }
 
 [dev-dependencies]
-futures = "0.3.27"
+futures = { workspace = true }
 serde_json = { workspace = true }

--- a/ic-http/example_canister/src/canister_backend/Cargo.toml
+++ b/ic-http/example_canister/src/canister_backend/Cargo.toml
@@ -18,5 +18,5 @@ serde = { workspace = true, features = [ "derive" ] }
 serde_json = "1.0.94"
 
 [dev-dependencies]
-tokio = { version = "1.15.0", features = [ "full" ] }
-futures = "0.3.27"
+tokio = { workspace = true }
+futures = { workspace = true }

--- a/ic-http/example_canister/src/canister_backend/Cargo.toml
+++ b/ic-http/example_canister/src/canister_backend/Cargo.toml
@@ -14,7 +14,7 @@ candid = "0.8.1"
 ic-cdk = "0.7.4"
 ic-cdk-macros = "0.6.10"
 ic-http = {path = "../../../"}
-serde = { version = "1.0.158", features = [ "derive" ] }
+serde = { workspace = true, features = [ "derive" ] }
 serde_json = "1.0.94"
 
 [dev-dependencies]

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -9,5 +9,5 @@ serde = { workspace = true }
 serde_bytes = { workspace = true }
 
 [dev-dependencies]
-ciborium = "0.2.1"
+ciborium = { workspace = true }
 proptest = "1.0"

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -10,4 +10,4 @@ serde_bytes = { workspace = true }
 
 [dev-dependencies]
 ciborium = { workspace = true }
-proptest = { workspace = true }
+proptest = "1.0"

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -10,4 +10,4 @@ serde_bytes = { workspace = true }
 
 [dev-dependencies]
 ciborium = { workspace = true }
-proptest = "1.0"
+proptest = { workspace = true }

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -11,4 +11,4 @@ bitcoin = { workspace = true }
 [dev-dependencies]
 csv = "1.1"
 hex = { workspace = true }
-proptest = { workspace = true }
+proptest = "0.9.4"

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -11,4 +11,4 @@ bitcoin = { workspace = true }
 [dev-dependencies]
 csv = "1.1"
 hex = { workspace = true }
-proptest = "0.9.4"
+proptest = { workspace = true }

--- a/watchdog/Cargo.toml
+++ b/watchdog/Cargo.toml
@@ -20,11 +20,11 @@ serde_json = { workspace = true }
 hex = { workspace = true }
 async-trait = "0.1.67"
 regex = "1.7.0"
-futures = "0.3.27"
+futures = { workspace = true }
 ic-http = { workspace = true }
 serde_bytes = { workspace = true }
 ic-btc-interface = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1.15.0", features = [ "full" ] }
+tokio = { workspace = true }
 assert-json-diff = "2.0.2"

--- a/watchdog/Cargo.toml
+++ b/watchdog/Cargo.toml
@@ -15,7 +15,7 @@ ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-metrics-encoder = { workspace = true }
 ic-cdk-timers = "0.1"
-serde = { version = "1.0.158", features = [ "derive" ] }
+serde = { workspace = true, features = [ "derive" ] }
 serde_json = { workspace = true }
 hex = { workspace = true }
 async-trait = "0.1.67"


### PR DESCRIPTION
This PR moves crate revisions on workspace level and updates them:
- `ciborium` from rev `e719537` from [23 Feb 2023](https://github.com/enarx/ciborium/commit/e719537c99b564c3674a56defe53713c702c6f46) to version `0.2.1` from [7 May 2023](https://github.com/enarx/ciborium/commit/7d8f6e499db51fe52f5d3c2ce1d0e0be61c7eaa2)
- `futures` from `0.3.27` to `0.3.28`
- `serde` from `1.0.132` to `1.0.171`
- `tokio` from `1.15.0` to `1.29.1`
