### PR TITLE
chore: bump up candid to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,8 +316,8 @@ dependencies = [
  "hex",
  "ic-btc-canister",
  "ic-btc-interface",
- "ic-cdk",
- "ic-cdk-macros",
+ "ic-cdk 0.10.0",
+ "ic-cdk-macros 0.7.0",
 ]
 
 [[package]]
@@ -465,7 +465,7 @@ dependencies = [
  "anyhow",
  "binread",
  "byteorder",
- "candid_derive",
+ "candid_derive 0.5.0",
  "codespan-reporting",
  "crc32fast",
  "data-encoding",
@@ -476,12 +476,39 @@ dependencies = [
  "logos",
  "num-bigint",
  "num-traits",
- "num_enum",
+ "num_enum 0.5.11",
  "paste",
- "pretty",
+ "pretty 0.10.0",
  "serde",
  "serde_bytes",
  "sha2 0.10.6",
+ "thiserror",
+]
+
+[[package]]
+name = "candid"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df671c37a9c6168db0334f2b289dd4e02dea1bbefe1fb22c5d43b12d865aacd"
+dependencies = [
+ "anyhow",
+ "binread",
+ "byteorder",
+ "candid_derive 0.6.2",
+ "codespan-reporting",
+ "crc32fast",
+ "data-encoding",
+ "hex",
+ "leb128",
+ "num-bigint",
+ "num-traits",
+ "num_enum 0.6.1",
+ "paste",
+ "pretty 0.12.1",
+ "serde",
+ "serde_bytes",
+ "sha2 0.10.6",
+ "stacker",
  "thiserror",
 ]
 
@@ -498,13 +525,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "candid_derive"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810b3bd60244f282090652ffc7c30a9d23892e72dfe443e46ee55569044f7dd5"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.25",
+]
+
+[[package]]
 name = "canister_backend"
 version = "0.1.0"
 dependencies = [
- "candid",
+ "candid 0.8.4",
  "futures",
- "ic-cdk",
- "ic-cdk-macros",
+ "ic-cdk 0.7.4",
+ "ic-cdk-macros 0.6.10",
  "ic-http",
  "serde",
  "serde_json",
@@ -802,10 +841,10 @@ name = "disable-api-if-not-fully-synced-flag"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid",
+ "candid 0.9.1",
  "ic-btc-test-utils",
- "ic-cdk",
- "ic-cdk-macros",
+ "ic-cdk 0.10.0",
+ "ic-cdk-macros 0.7.0",
  "serde",
 ]
 
@@ -1298,7 +1337,7 @@ dependencies = [
  "base32",
  "base64 0.13.1",
  "byteorder",
- "candid",
+ "candid 0.8.4",
  "futures-util",
  "garcon",
  "hex",
@@ -1332,14 +1371,14 @@ dependencies = [
  "async-std",
  "bitcoin",
  "byteorder",
- "candid",
+ "candid 0.9.1",
  "ciborium",
  "hex",
  "ic-btc-interface",
  "ic-btc-test-utils",
  "ic-btc-validation",
- "ic-cdk",
- "ic-cdk-macros",
+ "ic-cdk 0.10.0",
+ "ic-cdk-macros 0.7.0",
  "ic-metrics-encoder",
  "ic-stable-structures",
  "lazy_static",
@@ -1354,7 +1393,7 @@ dependencies = [
 name = "ic-btc-interface"
 version = "0.1.0"
 dependencies = [
- "candid",
+ "candid 0.9.1",
  "ciborium",
  "proptest 1.2.0",
  "serde",
@@ -1384,8 +1423,21 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9beb0bf1dcd0639c313630e34aa547a2b19450ddf1969c176e13225ef3b29048"
 dependencies = [
- "candid",
- "ic-cdk-macros",
+ "candid 0.8.4",
+ "ic-cdk-macros 0.6.10",
+ "ic0",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "ic-cdk"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d4c0b932bf454d5d60e61e13c3c944972fcfd74dc82b9ed5c8b0a75979cf50"
+dependencies = [
+ "candid 0.9.1",
+ "ic-cdk-macros 0.7.0",
  "ic0",
  "serde",
  "serde_bytes",
@@ -1397,7 +1449,21 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebf50458685a0fc6b0e414cdba487610aeb199ac94db52d9fd76270565debee7"
 dependencies = [
- "candid",
+ "candid 0.8.4",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ic-cdk-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4587624e64b8db56224033ee74e5c246d39be15375d03d3df7c117d49d18487"
+dependencies = [
+ "candid 0.9.1",
  "proc-macro2",
  "quote",
  "serde",
@@ -1412,7 +1478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c739e7c592cb66df4f15c6b6c4859b1195782f63923e2fb1b29553d9c0819bd4"
 dependencies = [
  "futures",
- "ic-cdk",
+ "ic-cdk 0.7.4",
  "ic0",
  "serde",
  "serde_bytes",
@@ -1423,10 +1489,10 @@ dependencies = [
 name = "ic-http"
 version = "0.1.0"
 dependencies = [
- "candid",
+ "candid 0.9.1",
  "futures",
- "ic-cdk",
- "ic-cdk-macros",
+ "ic-cdk 0.10.0",
+ "ic-cdk-macros 0.7.0",
  "serde_json",
  "tokio",
 ]
@@ -1457,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "ic0"
-version = "0.18.10"
+version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187fa0cecf46628330b7a390a1a65fb0637ea00d3a1121aa847ecbebc0f3ff79"
+checksum = "576c539151d4769fb4d1a0c25c4108dd18facd04c5695b02cf2d226ab4e43aa5"
 
 [[package]]
 name = "idna"
@@ -1765,7 +1831,16 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive 0.6.1",
 ]
 
 [[package]]
@@ -1778,6 +1853,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1955,6 +2042,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563c9d701c3a31dfffaaf9ce23507ba09cbe0b9125ba176d15e629b0235e9acc"
+dependencies = [
+ "arrayvec",
+ "typed-arena",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,6 +2109,15 @@ dependencies = [
  "rusty-fork 0.3.0",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2472,10 +2579,10 @@ name = "scenario-1"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid",
+ "candid 0.9.1",
  "ic-btc-test-utils",
- "ic-cdk",
- "ic-cdk-macros",
+ "ic-cdk 0.10.0",
+ "ic-cdk-macros 0.7.0",
  "serde",
 ]
 
@@ -2484,10 +2591,10 @@ name = "scenario-2"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid",
+ "candid 0.9.1",
  "ic-btc-test-utils",
- "ic-cdk",
- "ic-cdk-macros",
+ "ic-cdk 0.10.0",
+ "ic-cdk-macros 0.7.0",
  "serde",
 ]
 
@@ -2496,10 +2603,10 @@ name = "scenario-3"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid",
+ "candid 0.9.1",
  "ic-btc-test-utils",
- "ic-cdk",
- "ic-cdk-macros",
+ "ic-cdk 0.10.0",
+ "ic-cdk-macros 0.7.0",
  "serde",
 ]
 
@@ -2783,6 +2890,19 @@ checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
 ]
 
 [[package]]
@@ -3111,6 +3231,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3133,12 +3259,12 @@ name = "uploader"
 version = "0.1.0"
 dependencies = [
  "async-std",
- "candid",
+ "candid 0.9.1",
  "clap",
  "garcon",
  "ic-agent",
- "ic-cdk",
- "ic-cdk-macros",
+ "ic-cdk 0.10.0",
+ "ic-cdk-macros 0.7.0",
  "serde",
  "sha256",
  "url",
@@ -3294,12 +3420,12 @@ version = "0.1.0"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "candid",
+ "candid 0.9.1",
  "futures",
  "hex",
  "ic-btc-interface",
- "ic-cdk",
- "ic-cdk-macros",
+ "ic-cdk 0.10.0",
+ "ic-cdk-macros 0.7.0",
  "ic-cdk-timers",
  "ic-http",
  "ic-metrics-encoder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,10 +540,10 @@ dependencies = [
 name = "canister_backend"
 version = "0.1.0"
 dependencies = [
- "candid 0.8.4",
+ "candid 0.9.1",
  "futures",
- "ic-cdk 0.7.4",
- "ic-cdk-macros 0.6.10",
+ "ic-cdk 0.10.0",
+ "ic-cdk-macros 0.7.0",
  "ic-http",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 [workspace.dependencies]
 bitcoin = "0.28.1"
 byteorder = "1.4.3"
-candid = "0.8.1"
+candid = "0.9.1"
 ciborium = "0.2.1"
 clap = { version = "4.0.11", features = ["derive"] }
 futures = "0.3.28"
@@ -34,8 +34,8 @@ ic-btc-canister = { path = "./canister" }
 ic-btc-interface = { path = "./interface" }
 ic-btc-test-utils = { path = "./test-utils" }
 ic-btc-validation = { path = "./validation" }
-ic-cdk = "0.7.4"
-ic-cdk-macros = "0.6.10"
+ic-cdk = "0.10.0"
+ic-cdk-macros = "0.7.0"
 ic-http = { path = "./ic-http" }
 ic-metrics-encoder = "1.0.0"
 ic-stable-structures = "0.5.2"

--- a/ic-http/example_canister/src/canister_backend/Cargo.toml
+++ b/ic-http/example_canister/src/canister_backend/Cargo.toml
@@ -10,9 +10,9 @@ name = "canister_backend"
 path = "src/main.rs"
 
 [dependencies]
-candid = "0.8.1"
-ic-cdk = "0.7.4"
-ic-cdk-macros = "0.6.10"
+candid = "0.9.1"
+ic-cdk = "0.10.0"
+ic-cdk-macros = "0.7.0"
 ic-http = {path = "../../../"}
 serde = { workspace = true, features = [ "derive" ] }
 serde_json = "1.0.94"

--- a/ic-http/example_canister/src/canister_backend/src/main.rs
+++ b/ic-http/example_canister/src/canister_backend/src/main.rs
@@ -2,6 +2,8 @@ use ic_cdk::api::management_canister::http_request::{
     CanisterHttpRequestArgument, HttpHeader, HttpResponse, TransformArgs,
 };
 
+const ZERO_CYCLES: u128 = 0;
+
 /// Print a message to the console.
 pub fn print(msg: &str) {
     #[cfg(target_arch = "wasm32")]
@@ -53,7 +55,7 @@ fn build_quote_request(url: &str) -> CanisterHttpRequestArgument {
 
 /// Fetch data by making an HTTP request.
 async fn fetch(request: CanisterHttpRequestArgument) -> String {
-    let result = ic_http::http_request(request, 0).await;
+    let result = ic_http::http_request(request, ZERO_CYCLES).await;
 
     match result {
         Ok((response,)) => {
@@ -97,7 +99,9 @@ mod test {
         ic_http::mock::mock(request.clone(), mock_response);
 
         // Act.
-        let (response,) = ic_http::http_request(request.clone(), 0).await.unwrap();
+        let (response,) = ic_http::http_request(request.clone(), ZERO_CYCLES)
+            .await
+            .unwrap();
 
         // Assert.
         assert_eq!(
@@ -115,7 +119,9 @@ mod test {
         ic_http::mock::mock(request.clone(), mock_response);
 
         // Act.
-        let (response,) = ic_http::http_request(request.clone(), 0).await.unwrap();
+        let (response,) = ic_http::http_request(request.clone(), ZERO_CYCLES)
+            .await
+            .unwrap();
 
         // Assert.
         assert_eq!(response.status, 404);
@@ -130,7 +136,7 @@ mod test {
         ic_http::mock::mock_error(request.clone(), mock_error);
 
         // Act.
-        let result = ic_http::http_request(request.clone(), 0).await;
+        let result = ic_http::http_request(request.clone(), ZERO_CYCLES).await;
 
         // Assert.
         assert_eq!(

--- a/ic-http/example_canister/src/canister_backend/src/main.rs
+++ b/ic-http/example_canister/src/canister_backend/src/main.rs
@@ -47,7 +47,7 @@ fn build_quote_request(url: &str) -> CanisterHttpRequestArgument {
             name: "User-Agent".to_string(),
             value: "ic-http-example-canister".to_string(),
         })
-        .transform_func(transform_quote, vec![])
+        .transform_func("transform_quote", transform_quote, vec![])
         .build()
 }
 

--- a/ic-http/example_canister/src/canister_backend/src/main.rs
+++ b/ic-http/example_canister/src/canister_backend/src/main.rs
@@ -53,7 +53,7 @@ fn build_quote_request(url: &str) -> CanisterHttpRequestArgument {
 
 /// Fetch data by making an HTTP request.
 async fn fetch(request: CanisterHttpRequestArgument) -> String {
-    let result = ic_http::http_request(request).await;
+    let result = ic_http::http_request(request, 0).await;
 
     match result {
         Ok((response,)) => {
@@ -97,7 +97,7 @@ mod test {
         ic_http::mock::mock(request.clone(), mock_response);
 
         // Act.
-        let (response,) = ic_http::http_request(request.clone()).await.unwrap();
+        let (response,) = ic_http::http_request(request.clone(), 0).await.unwrap();
 
         // Assert.
         assert_eq!(
@@ -115,7 +115,7 @@ mod test {
         ic_http::mock::mock(request.clone(), mock_response);
 
         // Act.
-        let (response,) = ic_http::http_request(request.clone()).await.unwrap();
+        let (response,) = ic_http::http_request(request.clone(), 0).await.unwrap();
 
         // Assert.
         assert_eq!(response.status, 404);
@@ -130,7 +130,7 @@ mod test {
         ic_http::mock::mock_error(request.clone(), mock_error);
 
         // Act.
-        let result = ic_http::http_request(request.clone()).await;
+        let result = ic_http::http_request(request.clone(), 0).await;
 
         // Assert.
         assert_eq!(

--- a/ic-http/src/http_request.rs
+++ b/ic-http/src/http_request.rs
@@ -9,11 +9,12 @@ pub type CallResult<R> = Result<R, (RejectionCode, String)>;
 /// Make a HTTP request to a given URL and return HTTP response, possibly after a transformation.
 pub async fn http_request(
     arg: CanisterHttpRequestArgument,
-    _cycles: u128,
+    cycles: u128,
 ) -> CallResult<(HttpResponse,)> {
     #[cfg(not(target_arch = "wasm32"))]
     {
         // Mocking cycles is not implemented at the moment.
+        let _ = cycles;
         crate::mock::http_request(arg).await
     }
 

--- a/ic-http/src/http_request.rs
+++ b/ic-http/src/http_request.rs
@@ -6,18 +6,6 @@ use ic_cdk::api::management_canister::http_request::{CanisterHttpRequestArgument
 /// Errors on the IC have two components; a Code and a message associated with it.
 pub type CallResult<R> = Result<R, (RejectionCode, String)>;
 
-// /// Make a HTTP request to a given URL and return HTTP response, possibly after a transformation.
-// #[cfg(not(target_arch = "wasm32"))]
-// pub async fn http_request(arg: CanisterHttpRequestArgument) -> CallResult<(HttpResponse,)> {
-//     crate::mock::http_request(arg).await
-// }
-
-// /// Make an HTTP request to a given URL and return the HTTP response, possibly after a transformation.
-// #[cfg(target_arch = "wasm32")]
-// pub async fn http_request(arg: CanisterHttpRequestArgument) -> CallResult<(HttpResponse,)> {
-//     ic_cdk::api::management_canister::http_request::http_request(arg).await
-// }
-
 /// Make a HTTP request to a given URL and return HTTP response, possibly after a transformation.
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn http_request(

--- a/ic-http/src/http_request.rs
+++ b/ic-http/src/http_request.rs
@@ -6,21 +6,21 @@ use ic_cdk::api::management_canister::http_request::{CanisterHttpRequestArgument
 /// Errors on the IC have two components; a Code and a message associated with it.
 pub type CallResult<R> = Result<R, (RejectionCode, String)>;
 
+// /// Make a HTTP request to a given URL and return HTTP response, possibly after a transformation.
+// #[cfg(not(target_arch = "wasm32"))]
+// pub async fn http_request(arg: CanisterHttpRequestArgument) -> CallResult<(HttpResponse,)> {
+//     crate::mock::http_request(arg).await
+// }
+
+// /// Make an HTTP request to a given URL and return the HTTP response, possibly after a transformation.
+// #[cfg(target_arch = "wasm32")]
+// pub async fn http_request(arg: CanisterHttpRequestArgument) -> CallResult<(HttpResponse,)> {
+//     ic_cdk::api::management_canister::http_request::http_request(arg).await
+// }
+
 /// Make a HTTP request to a given URL and return HTTP response, possibly after a transformation.
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn http_request(arg: CanisterHttpRequestArgument) -> CallResult<(HttpResponse,)> {
-    crate::mock::http_request(arg).await
-}
-
-/// Make an HTTP request to a given URL and return the HTTP response, possibly after a transformation.
-#[cfg(target_arch = "wasm32")]
-pub async fn http_request(arg: CanisterHttpRequestArgument) -> CallResult<(HttpResponse,)> {
-    ic_cdk::api::management_canister::http_request::http_request(arg).await
-}
-
-/// Make a HTTP request to a given URL and return HTTP response, possibly after a transformation.
-#[cfg(not(target_arch = "wasm32"))]
-pub async fn http_request_with_cycles(
+pub async fn http_request(
     arg: CanisterHttpRequestArgument,
     _cycles: u128,
 ) -> CallResult<(HttpResponse,)> {
@@ -30,7 +30,7 @@ pub async fn http_request_with_cycles(
 
 /// Make an HTTP request to a given URL and return the HTTP response, possibly after a transformation.
 #[cfg(target_arch = "wasm32")]
-pub async fn http_request_with_cycles(
+pub async fn http_request(
     arg: CanisterHttpRequestArgument,
     cycles: u128,
 ) -> CallResult<(HttpResponse,)> {

--- a/ic-http/src/http_request.rs
+++ b/ic-http/src/http_request.rs
@@ -7,26 +7,24 @@ use ic_cdk::api::management_canister::http_request::{CanisterHttpRequestArgument
 pub type CallResult<R> = Result<R, (RejectionCode, String)>;
 
 /// Make a HTTP request to a given URL and return HTTP response, possibly after a transformation.
-#[cfg(not(target_arch = "wasm32"))]
 pub async fn http_request(
     arg: CanisterHttpRequestArgument,
     _cycles: u128,
 ) -> CallResult<(HttpResponse,)> {
-    // Mocking cycles is not implemented at the moment.
-    crate::mock::http_request(arg).await
-}
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        // Mocking cycles is not implemented at the moment.
+        crate::mock::http_request(arg).await
+    }
 
-/// Make an HTTP request to a given URL and return the HTTP response, possibly after a transformation.
-#[cfg(target_arch = "wasm32")]
-pub async fn http_request(
-    arg: CanisterHttpRequestArgument,
-    cycles: u128,
-) -> CallResult<(HttpResponse,)> {
-    ic_cdk::api::call::call_with_payment128(
-        candid::Principal::management_canister(),
-        "http_request",
-        (arg,),
-        cycles,
-    )
-    .await
+    #[cfg(target_arch = "wasm32")]
+    {
+        ic_cdk::api::call::call_with_payment128(
+            candid::Principal::management_canister(),
+            "http_request",
+            (arg,),
+            cycles,
+        )
+        .await
+    }
 }

--- a/ic-http/src/lib.rs
+++ b/ic-http/src/lib.rs
@@ -66,7 +66,7 @@
 //! #[ic_cdk_macros::update]
 //! async fn fetch() -> String {
 //!     let request = build_request();
-//!     let result = ic_http::http_request(request).await;
+//!     let result = ic_http::http_request(request, 0).await;
 //!
 //!     match result {
 //!         Ok((response,)) => {
@@ -100,7 +100,7 @@
 //!     ic_http::mock::mock(request.clone(), mock_response);
 //!
 //!     // Act
-//!     let (response,) = ic_http::http_request(request.clone()).await.unwrap();
+//!     let (response,) = ic_http::http_request(request.clone(), 0).await.unwrap();
 //!
 //!     // Assert
 //!     assert_eq!(
@@ -126,6 +126,5 @@ pub mod mock;
 
 // Re-export.
 pub use crate::http_request::http_request;
-pub use crate::http_request::http_request_with_cycles;
 pub use crate::request::create_request;
 pub use crate::response::create_response;

--- a/ic-http/src/lib.rs
+++ b/ic-http/src/lib.rs
@@ -66,7 +66,8 @@
 //! #[ic_cdk_macros::update]
 //! async fn fetch() -> String {
 //!     let request = build_request();
-//!     let result = ic_http::http_request(request, 0).await;
+//!     let cycles = 0;
+//!     let result = ic_http::http_request(request, cycles).await;
 //!
 //!     match result {
 //!         Ok((response,)) => {
@@ -100,7 +101,8 @@
 //!     ic_http::mock::mock(request.clone(), mock_response);
 //!
 //!     // Act
-//!     let (response,) = ic_http::http_request(request.clone(), 0).await.unwrap();
+//!     let cycles = 0;
+//!     let (response,) = ic_http::http_request(request.clone(), cycles).await.unwrap();
 //!
 //!     // Assert
 //!     assert_eq!(

--- a/ic-http/src/lib.rs
+++ b/ic-http/src/lib.rs
@@ -58,7 +58,7 @@
 //!             name: "User-Agent".to_string(),
 //!             value: "ic-http-example-canister".to_string(),
 //!         })
-//!         .transform_func(transform, vec![])
+//!         .transform_func("transform", transform, vec![])
 //!         .build()
 //! }
 //!

--- a/ic-http/src/request.rs
+++ b/ic-http/src/request.rs
@@ -73,11 +73,20 @@ impl HttpRequestBuilder {
         self
     }
 
-    pub fn transform_func<T>(mut self, func: T, context: Vec<u8>) -> Self
+    pub fn transform_func<T>(
+        mut self,
+        candid_function_name: &str,
+        func: T,
+        context: Vec<u8>,
+    ) -> Self
     where
         T: Fn(TransformArgs) -> HttpResponse + 'static,
     {
-        self.transform = Some(create_transform_context(func, context));
+        self.transform = Some(create_transform_context(
+            candid_function_name,
+            func,
+            context,
+        ));
         self
     }
 

--- a/ic-http/tests/api.rs
+++ b/ic-http/tests/api.rs
@@ -17,7 +17,7 @@ async fn test_http_request_no_transform() {
     ic_http::mock::mock(request.clone(), mock_response);
 
     // Act
-    let (response,) = ic_http::http_request(request.clone()).await.unwrap();
+    let (response,) = ic_http::http_request(request.clone(), 0).await.unwrap();
 
     // Assert
     assert_eq!(response.status, candid::Nat::from(STATUS_CODE_OK));
@@ -39,7 +39,7 @@ async fn test_http_request_called_several_times() {
 
     // Act
     for _ in 0..calls {
-        let (response,) = ic_http::http_request(request.clone()).await.unwrap();
+        let (response,) = ic_http::http_request(request.clone(), 0).await.unwrap();
         assert_eq!(response.status, candid::Nat::from(STATUS_CODE_OK));
         assert_eq!(response.body, body.to_string().as_bytes().to_vec());
     }
@@ -67,7 +67,7 @@ async fn test_http_request_transform_status() {
     ic_http::mock::mock(request.clone(), mock_response);
 
     // Act
-    let (response,) = ic_http::http_request(request.clone()).await.unwrap();
+    let (response,) = ic_http::http_request(request.clone(), 0).await.unwrap();
 
     // Assert
     assert_ne!(response.status, candid::Nat::from(STATUS_CODE_OK));
@@ -94,7 +94,7 @@ async fn test_http_request_transform_body() {
     ic_http::mock::mock(request.clone(), mock_response);
 
     // Act
-    let (response,) = ic_http::http_request(request.clone()).await.unwrap();
+    let (response,) = ic_http::http_request(request.clone(), 0).await.unwrap();
 
     // Assert
     assert_ne!(response.body, ORIGINAL_BODY.as_bytes().to_vec());
@@ -142,8 +142,8 @@ async fn test_http_request_transform_both_status_and_body() {
 
     // Act
     let futures = vec![
-        ic_http::http_request(request_1.clone()),
-        ic_http::http_request(request_2.clone()),
+        ic_http::http_request(request_1.clone(), 0),
+        ic_http::http_request(request_2.clone(), 0),
     ];
     let results = futures::future::join_all(futures).await;
     let responses: Vec<_> = results
@@ -185,7 +185,7 @@ async fn test_http_request_max_response_bytes_ok() {
     ic_http::mock::mock(request.clone(), mock_response);
 
     // Act
-    let result = ic_http::http_request(request.clone()).await;
+    let result = ic_http::http_request(request.clone(), 0).await;
 
     // Assert
     assert!(result.is_ok());
@@ -208,7 +208,7 @@ async fn test_http_request_max_response_bytes_error() {
     ic_http::mock::mock(request.clone(), mock_response);
 
     // Act
-    let result = ic_http::http_request(request.clone()).await;
+    let result = ic_http::http_request(request.clone(), 0).await;
 
     // Assert
     assert!(result.is_err());
@@ -236,9 +236,9 @@ async fn test_http_request_sequentially() {
 
     // Act
     let start = Instant::now();
-    let _ = ic_http::http_request(request_a.clone()).await;
-    let _ = ic_http::http_request(request_b.clone()).await;
-    let _ = ic_http::http_request(request_c.clone()).await;
+    let _ = ic_http::http_request(request_a.clone(), 0).await;
+    let _ = ic_http::http_request(request_b.clone(), 0).await;
+    let _ = ic_http::http_request(request_c.clone(), 0).await;
     println!("All finished after {} s", start.elapsed().as_secs_f32());
 
     // Assert
@@ -270,9 +270,9 @@ async fn test_http_request_concurrently() {
     // Act
     let start = Instant::now();
     let futures = vec![
-        ic_http::http_request(request_a.clone()),
-        ic_http::http_request(request_b.clone()),
-        ic_http::http_request(request_c.clone()),
+        ic_http::http_request(request_a.clone(), 0),
+        ic_http::http_request(request_b.clone(), 0),
+        ic_http::http_request(request_c.clone(), 0),
     ];
     futures::future::join_all(futures).await;
     println!("All finished after {} s", start.elapsed().as_secs_f32());
@@ -292,7 +292,7 @@ async fn test_http_request_error() {
     ic_http::mock::mock_error(request.clone(), mock_error);
 
     // Act
-    let result = ic_http::http_request(request.clone()).await;
+    let result = ic_http::http_request(request.clone(), 0).await;
 
     // Assert
     assert_eq!(
@@ -311,7 +311,7 @@ async fn test_http_request_error_with_delay() {
 
     // Act
     let start = Instant::now();
-    let result = ic_http::http_request(request.clone()).await;
+    let result = ic_http::http_request(request.clone(), 0).await;
 
     // Assert
     assert!(start.elapsed() > Duration::from_millis(100));

--- a/ic-http/tests/api.rs
+++ b/ic-http/tests/api.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, Instant};
 
 const STATUS_CODE_OK: u64 = 200;
 const STATUS_CODE_NOT_FOUND: u64 = 404;
+const ZERO_CYCLES: u128 = 0;
 
 #[tokio::test]
 async fn test_http_request_no_transform() {
@@ -17,7 +18,9 @@ async fn test_http_request_no_transform() {
     ic_http::mock::mock(request.clone(), mock_response);
 
     // Act
-    let (response,) = ic_http::http_request(request.clone(), 0).await.unwrap();
+    let (response,) = ic_http::http_request(request.clone(), ZERO_CYCLES)
+        .await
+        .unwrap();
 
     // Assert
     assert_eq!(response.status, candid::Nat::from(STATUS_CODE_OK));
@@ -39,7 +42,9 @@ async fn test_http_request_called_several_times() {
 
     // Act
     for _ in 0..calls {
-        let (response,) = ic_http::http_request(request.clone(), 0).await.unwrap();
+        let (response,) = ic_http::http_request(request.clone(), ZERO_CYCLES)
+            .await
+            .unwrap();
         assert_eq!(response.status, candid::Nat::from(STATUS_CODE_OK));
         assert_eq!(response.body, body.to_string().as_bytes().to_vec());
     }
@@ -67,7 +72,9 @@ async fn test_http_request_transform_status() {
     ic_http::mock::mock(request.clone(), mock_response);
 
     // Act
-    let (response,) = ic_http::http_request(request.clone(), 0).await.unwrap();
+    let (response,) = ic_http::http_request(request.clone(), ZERO_CYCLES)
+        .await
+        .unwrap();
 
     // Assert
     assert_ne!(response.status, candid::Nat::from(STATUS_CODE_OK));
@@ -94,7 +101,9 @@ async fn test_http_request_transform_body() {
     ic_http::mock::mock(request.clone(), mock_response);
 
     // Act
-    let (response,) = ic_http::http_request(request.clone(), 0).await.unwrap();
+    let (response,) = ic_http::http_request(request.clone(), ZERO_CYCLES)
+        .await
+        .unwrap();
 
     // Assert
     assert_ne!(response.body, ORIGINAL_BODY.as_bytes().to_vec());
@@ -142,8 +151,8 @@ async fn test_http_request_transform_both_status_and_body() {
 
     // Act
     let futures = vec![
-        ic_http::http_request(request_1.clone(), 0),
-        ic_http::http_request(request_2.clone(), 0),
+        ic_http::http_request(request_1.clone(), ZERO_CYCLES),
+        ic_http::http_request(request_2.clone(), ZERO_CYCLES),
     ];
     let results = futures::future::join_all(futures).await;
     let responses: Vec<_> = results
@@ -185,7 +194,7 @@ async fn test_http_request_max_response_bytes_ok() {
     ic_http::mock::mock(request.clone(), mock_response);
 
     // Act
-    let result = ic_http::http_request(request.clone(), 0).await;
+    let result = ic_http::http_request(request.clone(), ZERO_CYCLES).await;
 
     // Assert
     assert!(result.is_ok());
@@ -208,7 +217,7 @@ async fn test_http_request_max_response_bytes_error() {
     ic_http::mock::mock(request.clone(), mock_response);
 
     // Act
-    let result = ic_http::http_request(request.clone(), 0).await;
+    let result = ic_http::http_request(request.clone(), ZERO_CYCLES).await;
 
     // Assert
     assert!(result.is_err());
@@ -236,9 +245,9 @@ async fn test_http_request_sequentially() {
 
     // Act
     let start = Instant::now();
-    let _ = ic_http::http_request(request_a.clone(), 0).await;
-    let _ = ic_http::http_request(request_b.clone(), 0).await;
-    let _ = ic_http::http_request(request_c.clone(), 0).await;
+    let _ = ic_http::http_request(request_a.clone(), ZERO_CYCLES).await;
+    let _ = ic_http::http_request(request_b.clone(), ZERO_CYCLES).await;
+    let _ = ic_http::http_request(request_c.clone(), ZERO_CYCLES).await;
     println!("All finished after {} s", start.elapsed().as_secs_f32());
 
     // Assert
@@ -270,9 +279,9 @@ async fn test_http_request_concurrently() {
     // Act
     let start = Instant::now();
     let futures = vec![
-        ic_http::http_request(request_a.clone(), 0),
-        ic_http::http_request(request_b.clone(), 0),
-        ic_http::http_request(request_c.clone(), 0),
+        ic_http::http_request(request_a.clone(), ZERO_CYCLES),
+        ic_http::http_request(request_b.clone(), ZERO_CYCLES),
+        ic_http::http_request(request_c.clone(), ZERO_CYCLES),
     ];
     futures::future::join_all(futures).await;
     println!("All finished after {} s", start.elapsed().as_secs_f32());
@@ -292,7 +301,7 @@ async fn test_http_request_error() {
     ic_http::mock::mock_error(request.clone(), mock_error);
 
     // Act
-    let result = ic_http::http_request(request.clone(), 0).await;
+    let result = ic_http::http_request(request.clone(), ZERO_CYCLES).await;
 
     // Assert
     assert_eq!(
@@ -311,7 +320,7 @@ async fn test_http_request_error_with_delay() {
 
     // Act
     let start = Instant::now();
-    let result = ic_http::http_request(request.clone(), 0).await;
+    let result = ic_http::http_request(request.clone(), ZERO_CYCLES).await;
 
     // Assert
     assert!(start.elapsed() > Duration::from_millis(100));

--- a/ic-http/tests/api.rs
+++ b/ic-http/tests/api.rs
@@ -58,7 +58,7 @@ async fn test_http_request_transform_status() {
     }
     let request = ic_http::create_request()
         .get("https://example.com")
-        .transform_func(transform, vec![])
+        .transform_func("transform", transform, vec![])
         .build();
     let mock_response = ic_http::create_response()
         .status(STATUS_CODE_OK)
@@ -85,7 +85,7 @@ async fn test_http_request_transform_body() {
     }
     let request = ic_http::create_request()
         .get("https://dummyjson.com/todos/1")
-        .transform_func(transform, vec![])
+        .transform_func("transform", transform, vec![])
         .build();
     let mock_response = ic_http::create_response()
         .status(STATUS_CODE_OK)
@@ -122,7 +122,7 @@ async fn test_http_request_transform_both_status_and_body() {
 
     let request_1 = ic_http::create_request()
         .get("https://dummyjson.com/todos/1")
-        .transform_func(transform_status, vec![])
+        .transform_func("transform_status", transform_status, vec![])
         .build();
     let mock_response_1 = ic_http::create_response()
         .status(STATUS_CODE_NOT_FOUND)
@@ -132,7 +132,7 @@ async fn test_http_request_transform_both_status_and_body() {
 
     let request_2 = ic_http::create_request()
         .get("https://dummyjson.com/todos/2")
-        .transform_func(transform_body, vec![])
+        .transform_func("transform_body", transform_body, vec![])
         .build();
     let mock_response_2 = ic_http::create_response()
         .status(STATUS_CODE_OK)

--- a/watchdog/src/bitcoin_block_apis.rs
+++ b/watchdog/src/bitcoin_block_apis.rs
@@ -206,7 +206,7 @@ async fn http_request(config: crate::http::HttpRequestConfig) -> serde_json::Val
     // Send zero cycles with the request to avoid the canister
     // to run out of cycles when deployed on a system subnet.
     let cycles = 0;
-    let result = ic_http::http_request_with_cycles(config.request(), cycles).await;
+    let result = ic_http::http_request(config.request(), cycles).await;
 
     match result {
         Ok((response,)) if response.status == 200 => parse_response(response),

--- a/watchdog/src/endpoints.rs
+++ b/watchdog/src/endpoints.rs
@@ -342,6 +342,8 @@ mod test {
     use assert_json_diff::assert_json_eq;
     use serde_json::json;
 
+    const ZERO_CYCLES: u128 = 0;
+
     fn parse_json(body: Vec<u8>) -> serde_json::Value {
         let json_str = String::from_utf8(body).expect("Raw response is not UTF-8 encoded.");
         serde_json::from_str(&json_str).expect("Failed to parse JSON from string")
@@ -360,7 +362,7 @@ mod test {
             .build();
         ic_http::mock::mock(request.clone(), mock_response);
 
-        let (response,) = ic_http::http_request(request.clone(), 0)
+        let (response,) = ic_http::http_request(request.clone(), ZERO_CYCLES)
             .await
             .expect("HTTP request failed");
 
@@ -601,7 +603,7 @@ mod test {
             ic_http::mock::mock(request.clone(), mock_response);
 
             // Act
-            let (response,) = ic_http::http_request(request, 0).await.unwrap();
+            let (response,) = ic_http::http_request(request, ZERO_CYCLES).await.unwrap();
 
             // Assert
             assert_eq!(response.status, expected_status, "url: {:?}", config.url());

--- a/watchdog/src/endpoints.rs
+++ b/watchdog/src/endpoints.rs
@@ -1,5 +1,5 @@
 use crate::config::BitcoinNetwork;
-use crate::http::HttpRequestConfig;
+use crate::http::{HttpRequestConfig, TransformFnWrapper};
 use crate::print;
 use crate::{
     transform_api_bitaps_com_block, transform_api_blockchair_com_block,
@@ -28,15 +28,22 @@ fn endpoint_api_bitaps_com_block(bitcoin_network: BitcoinNetwork) -> HttpRequest
         BitcoinNetwork::Mainnet => "https://api.bitaps.com/btc/v1/blockchain/block/last",
         BitcoinNetwork::Testnet => "https://api.bitaps.com/btc/testnet/v1/blockchain/block/last",
     };
-    HttpRequestConfig::new(url, Some(transform_api_bitaps_com_block), |raw| {
-        apply_to_body_json(raw, |json| {
-            let data = json["data"].clone();
-            json!({
-                "height": data["height"].as_u64(),
-                "hash": data["hash"].as_str(),
+    HttpRequestConfig::new(
+        url,
+        Some(TransformFnWrapper {
+            name: "transform_api_bitaps_com_block",
+            func: transform_api_bitaps_com_block,
+        }),
+        |raw| {
+            apply_to_body_json(raw, |json| {
+                let data = json["data"].clone();
+                json!({
+                    "height": data["height"].as_u64(),
+                    "hash": data["hash"].as_str(),
+                })
             })
-        })
-    })
+        },
+    )
 }
 
 /// Creates a config for fetching mainnet block data from api.blockchair.com.
@@ -55,15 +62,22 @@ fn endpoint_api_blockchair_com_block(bitcoin_network: BitcoinNetwork) -> HttpReq
         BitcoinNetwork::Mainnet => "https://api.blockchair.com/bitcoin/stats",
         BitcoinNetwork::Testnet => "https://api.blockchair.com/bitcoin/testnet/stats",
     };
-    HttpRequestConfig::new(url, Some(transform_api_blockchair_com_block), |raw| {
-        apply_to_body_json(raw, |json| {
-            let data = json["data"].clone();
-            json!({
-                "height": data["best_block_height"].as_u64(),
-                "hash": data["best_block_hash"].as_str(),
+    HttpRequestConfig::new(
+        url,
+        Some(TransformFnWrapper {
+            name: "transform_api_blockchair_com_block",
+            func: transform_api_blockchair_com_block,
+        }),
+        |raw| {
+            apply_to_body_json(raw, |json| {
+                let data = json["data"].clone();
+                json!({
+                    "height": data["best_block_height"].as_u64(),
+                    "hash": data["best_block_hash"].as_str(),
+                })
             })
-        })
-    })
+        },
+    )
 }
 
 /// Creates a config for fetching mainnet block data from api.blockcypher.com.
@@ -82,15 +96,22 @@ fn endpoint_api_blockcypher_com_block(bitcoin_network: BitcoinNetwork) -> HttpRe
         BitcoinNetwork::Mainnet => "https://api.blockcypher.com/v1/btc/main",
         BitcoinNetwork::Testnet => "https://api.blockcypher.com/v1/btc/test3",
     };
-    HttpRequestConfig::new(url, Some(transform_api_blockcypher_com_block), |raw| {
-        apply_to_body_json(raw, |json| {
-            json!({
-                "height": json["height"].as_u64(),
-                "hash": json["hash"].as_str(),
-                "previous_hash": json["previous_hash"].as_str(),
+    HttpRequestConfig::new(
+        url,
+        Some(TransformFnWrapper {
+            name: "transform_api_blockcypher_com_block",
+            func: transform_api_blockcypher_com_block,
+        }),
+        |raw| {
+            apply_to_body_json(raw, |json| {
+                json!({
+                    "height": json["height"].as_u64(),
+                    "hash": json["hash"].as_str(),
+                    "previous_hash": json["previous_hash"].as_str(),
+                })
             })
-        })
-    })
+        },
+    )
 }
 
 /// Applies regex rule to parse bitcoin_canister block height.
@@ -121,7 +142,10 @@ fn parse_bitcoin_canister_height(text: String) -> Result<u64, String> {
 pub fn endpoint_bitcoin_canister() -> HttpRequestConfig {
     HttpRequestConfig::new(
         &crate::storage::get_config().get_bitcoin_canister_endpoint(),
-        Some(transform_bitcoin_canister),
+        Some(TransformFnWrapper {
+            name: "transform_bitcoin_canister",
+            func: transform_bitcoin_canister,
+        }),
         |raw| {
             apply_to_body(raw, |text| {
                 parse_bitcoin_canister_height(text)
@@ -141,7 +165,10 @@ pub fn endpoint_bitcoin_canister() -> HttpRequestConfig {
 pub fn endpoint_blockchain_info_hash_mainnet() -> HttpRequestConfig {
     HttpRequestConfig::new(
         "https://blockchain.info/q/latesthash",
-        Some(transform_blockchain_info_hash),
+        Some(TransformFnWrapper {
+            name: "transform_blockchain_info_hash",
+            func: transform_blockchain_info_hash,
+        }),
         |raw| {
             apply_to_body(raw, |text| {
                 json!({
@@ -157,7 +184,10 @@ pub fn endpoint_blockchain_info_hash_mainnet() -> HttpRequestConfig {
 pub fn endpoint_blockchain_info_height_mainnet() -> HttpRequestConfig {
     HttpRequestConfig::new(
         "https://blockchain.info/q/getblockcount",
-        Some(transform_blockchain_info_height),
+        Some(TransformFnWrapper {
+            name: "transform_blockchain_info_height",
+            func: transform_blockchain_info_height,
+        }),
         |raw| {
             apply_to_body(raw, |text| {
                 text.parse::<u64>()
@@ -189,14 +219,21 @@ fn endpoint_blockstream_info_hash(bitcoin_network: BitcoinNetwork) -> HttpReques
         BitcoinNetwork::Mainnet => "https://blockstream.info/api/blocks/tip/hash",
         BitcoinNetwork::Testnet => "https://blockstream.info/testnet/api/blocks/tip/hash",
     };
-    HttpRequestConfig::new(url, Some(transform_blockstream_info_hash), |raw| {
-        apply_to_body(raw, |text| {
-            json!({
-                "hash": text,
+    HttpRequestConfig::new(
+        url,
+        Some(TransformFnWrapper {
+            name: "transform_blockstream_info_hash",
+            func: transform_blockstream_info_hash,
+        }),
+        |raw| {
+            apply_to_body(raw, |text| {
+                json!({
+                    "hash": text,
+                })
+                .to_string()
             })
-            .to_string()
-        })
-    })
+        },
+    )
 }
 
 /// Creates a config for fetching mainnet height data from blockstream.info.
@@ -215,25 +252,35 @@ fn endpoint_blockstream_info_height(bitcoin_network: BitcoinNetwork) -> HttpRequ
         BitcoinNetwork::Mainnet => "https://blockstream.info/api/blocks/tip/height",
         BitcoinNetwork::Testnet => "https://blockstream.info/testnet/api/blocks/tip/height",
     };
-    HttpRequestConfig::new(url, Some(transform_blockstream_info_height), |raw| {
-        apply_to_body(raw, |text| {
-            text.parse::<u64>()
-                .map(|height| {
-                    json!({
-                        "height": height,
+    HttpRequestConfig::new(
+        url,
+        Some(TransformFnWrapper {
+            name: "transform_blockstream_info_height",
+            func: transform_blockstream_info_height,
+        }),
+        |raw| {
+            apply_to_body(raw, |text| {
+                text.parse::<u64>()
+                    .map(|height| {
+                        json!({
+                            "height": height,
+                        })
+                        .to_string()
                     })
-                    .to_string()
-                })
-                .unwrap_or_default()
-        })
-    })
+                    .unwrap_or_default()
+            })
+        },
+    )
 }
 
 /// Creates a config for fetching mainnet block data from chain.api.btc.com.
 pub fn endpoint_chain_api_btc_com_block_mainnet() -> HttpRequestConfig {
     HttpRequestConfig::new(
         "https://chain.api.btc.com/v3/block/latest",
-        Some(transform_chain_api_btc_com_block),
+        Some(TransformFnWrapper {
+            name: "transform_chain_api_btc_com_block",
+            func: transform_chain_api_btc_com_block,
+        }),
         |raw| {
             apply_to_body_json(raw, |json| {
                 let data = json["data"].clone();

--- a/watchdog/src/endpoints.rs
+++ b/watchdog/src/endpoints.rs
@@ -313,7 +313,7 @@ mod test {
             .build();
         ic_http::mock::mock(request.clone(), mock_response);
 
-        let (response,) = ic_http::http_request(request.clone())
+        let (response,) = ic_http::http_request(request.clone(), 0)
             .await
             .expect("HTTP request failed");
 
@@ -554,7 +554,7 @@ mod test {
             ic_http::mock::mock(request.clone(), mock_response);
 
             // Act
-            let (response,) = ic_http::http_request(request).await.unwrap();
+            let (response,) = ic_http::http_request(request, 0).await.unwrap();
 
             // Assert
             assert_eq!(response.status, expected_status, "url: {:?}", config.url());

--- a/watchdog/src/http.rs
+++ b/watchdog/src/http.rs
@@ -13,10 +13,15 @@ pub struct HttpRequestConfig {
     transform_implementation: TransformFn,
 }
 
+pub struct TransformFnWrapper<T> {
+    pub name: &'static str,
+    pub func: T,
+}
+
 impl HttpRequestConfig {
     pub fn new<T>(
         url: &str,
-        transform_endpoint: Option<T>,
+        transform_endpoint: Option<TransformFnWrapper<T>>,
         transform_implementation: TransformFn,
     ) -> Self
     where
@@ -45,7 +50,10 @@ impl HttpRequestConfig {
     }
 }
 
-fn create_request<T>(url: &str, transform_func: Option<T>) -> CanisterHttpRequestArgument
+fn create_request<T>(
+    url: &str,
+    transform_func: Option<TransformFnWrapper<T>>,
+) -> CanisterHttpRequestArgument
 where
     T: Fn(TransformArgs) -> HttpResponse + 'static,
 {
@@ -54,7 +62,7 @@ where
         value: "bitcoin_watchdog_canister".to_string(),
     });
     let builder = if let Some(func) = transform_func {
-        builder.transform_func(func, vec![])
+        builder.transform_func(func.name, func.func, vec![])
     } else {
         builder
     };


### PR DESCRIPTION
This PR bumps up `candid` version to `0.9.1`.

Additionally it updates `ic-cdk` to `0.10.0` and `ic-cdk-macros` to `0.7.0`.

Changes:
- removed unsupported `http_request_with_cycles`
- `http_request` now accepts cycles, which should be zero for watchdog canister
- registering transform function does not rely on `std::any::type_name::<F>()` for figuring out function name any more, so it has to be provided manually