### PR TITLE
chore: Implement the `From` trait to access the `Txid` bytes

### DIFF
--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -107,9 +107,9 @@ impl AsRef<[u8]> for Txid {
     }
 }
 
-impl Into<[u8; 32]> for Txid {
-    fn into(self) -> [u8; 32] {
-        self.0
+impl From<Txid> for [u8; 32] {
+    fn from(txid: Txid) -> Self {
+        txid.0
     }
 }
 
@@ -565,8 +565,8 @@ mod test {
 
     #[test]
     fn can_extract_bytes_from_txid() {
-        let tx_id = Txid ([1; 32]);
-        let tx : [u8; 32] = tx_id.into();
+        let tx_id = Txid([1; 32]);
+        let tx: [u8; 32] = tx_id.into();
         assert_eq!(tx, [1; 32]);
     }
 }

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -107,6 +107,12 @@ impl AsRef<[u8]> for Txid {
     }
 }
 
+impl Into<[u8; 32]> for Txid {
+    fn into(self) -> [u8; 32] {
+        self.0
+    }
+}
+
 impl serde::Serialize for Txid {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -562,4 +562,11 @@ mod test {
             "Config should be printable using debug formatter {{:?}}."
         );
     }
+
+    #[test]
+    fn can_extract_bytes_from_txid() {
+        let tx_id = Txid ([1; 32]);
+        let tx : [u8; 32] = tx_id.into();
+        assert_eq!(tx, [1; 32]);
+    }
 }


### PR DESCRIPTION
Currently, there is no way to access the 32 bytes of a transaction ID directly (you can only get a `&[u8]` reference).
This PR adds the implementation of the `From` trait to access the transaction ID bytes.