### PR TITLE
chore: add metadata to publish the ic-btc-interface crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "ic-btc-interface"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "candid 0.9.1",
  "ciborium",

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -2,6 +2,13 @@
 name = "ic-btc-interface"
 version = "0.1.0"
 edition = "2021"
+description = "Rust types for the Internet Computer's Bitcoin API."
+homepage = "https://docs.rs/ic-btc-interface"
+documentation = "https://docs.rs/ic-btc-interface"
+license = "Apache-2.0"
+include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
+repository = "https://github.com/dfinity/bitcoin-canister"
+readme= "README.md"
 
 [dependencies]
 candid = { workspace = true }

--- a/interface/README.md
+++ b/interface/README.md
@@ -1,0 +1,3 @@
+# ic-btc-interface
+
+This crates contains Rust types needed to interact with the Bitcoin API on the Internet Computer.


### PR DESCRIPTION
There is more than one consumer of `ic-btc-interface`. Having it versioned and published on crates.io would make it more convenient to pull this dependency.