### PR TITLE
perf: calculate the main chain height more efficiently

### DIFF
--- a/bootstrap/2_compute_unstable_blocks.sh
+++ b/bootstrap/2_compute_unstable_blocks.sh
@@ -39,25 +39,13 @@ echo "Preparing the unstable blocks..."
 # Run bitcoind in the background with no network access.
 $BITCOIN_D -conf="$CONF_FILE" -datadir="$(pwd)/data" > /dev/null &
 
+echo "sleeping"
 # Wait for bitcoind to load.
 sleep 30
 
-STABLE_HEIGHT=$((HEIGHT-12))
+for ((i = 0 ; i <= 4000 ; i++)); do
+  BLOCK_HASH=$($BITCOIN_CLI -conf="$CONF_FILE" -datadir="$(pwd)/data" getblockhash $i)
+  BLOCK=$($BITCOIN_CLI -conf="$CONF_FILE" -datadir="$(pwd)/data" getblock $BLOCK_HASH 0)
+  echo "$BLOCK"
+done
 
-echo "Getting block hash at height $((STABLE_HEIGHT+1))"
-BLOCK_HASH_1=$($BITCOIN_CLI -conf="$CONF_FILE" -datadir="$(pwd)/data" getblockhash $((STABLE_HEIGHT+1)))
-echo "Hash: $BLOCK_HASH_1"
-
-echo "Getting block hash at height $((STABLE_HEIGHT+2))"
-BLOCK_HASH_2=$($BITCOIN_CLI -conf="$CONF_FILE" -datadir="$(pwd)/data" getblockhash $((STABLE_HEIGHT+2)))
-echo "Hash: $BLOCK_HASH_2"
-
-$BITCOIN_CLI -conf="$CONF_FILE" getblock "$BLOCK_HASH_1" 0 > unstable_blocks
-$BITCOIN_CLI -conf="$CONF_FILE" getblock "$BLOCK_HASH_2" 0 >> unstable_blocks
-
-echo "Invalidating unstable blocks..."
-$BITCOIN_CLI -conf="$CONF_FILE" invalidateblock "$BLOCK_HASH_1"
-
-echo "Computing checksum of unstable blocks..."
-sha256sum unstable_blocks
-echo "Done."

--- a/bootstrap/2_compute_unstable_blocks.sh
+++ b/bootstrap/2_compute_unstable_blocks.sh
@@ -39,13 +39,25 @@ echo "Preparing the unstable blocks..."
 # Run bitcoind in the background with no network access.
 $BITCOIN_D -conf="$CONF_FILE" -datadir="$(pwd)/data" > /dev/null &
 
-echo "sleeping"
 # Wait for bitcoind to load.
 sleep 30
 
-for ((i = 0 ; i <= 4000 ; i++)); do
-  BLOCK_HASH=$($BITCOIN_CLI -conf="$CONF_FILE" -datadir="$(pwd)/data" getblockhash $i)
-  BLOCK=$($BITCOIN_CLI -conf="$CONF_FILE" -datadir="$(pwd)/data" getblock $BLOCK_HASH 0)
-  echo "$BLOCK"
-done
+STABLE_HEIGHT=$((HEIGHT-12))
 
+echo "Getting block hash at height $((STABLE_HEIGHT+1))"
+BLOCK_HASH_1=$($BITCOIN_CLI -conf="$CONF_FILE" -datadir="$(pwd)/data" getblockhash $((STABLE_HEIGHT+1)))
+echo "Hash: $BLOCK_HASH_1"
+
+echo "Getting block hash at height $((STABLE_HEIGHT+2))"
+BLOCK_HASH_2=$($BITCOIN_CLI -conf="$CONF_FILE" -datadir="$(pwd)/data" getblockhash $((STABLE_HEIGHT+2)))
+echo "Hash: $BLOCK_HASH_2"
+
+$BITCOIN_CLI -conf="$CONF_FILE" getblock "$BLOCK_HASH_1" 0 > unstable_blocks
+$BITCOIN_CLI -conf="$CONF_FILE" getblock "$BLOCK_HASH_2" 0 >> unstable_blocks
+
+echo "Invalidating unstable blocks..."
+$BITCOIN_CLI -conf="$CONF_FILE" invalidateblock "$BLOCK_HASH_1"
+
+echo "Computing checksum of unstable blocks..."
+sha256sum unstable_blocks
+echo "Done."

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -177,8 +177,7 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
 }
 
 pub fn main_chain_height(state: &State) -> Height {
-    unstable_blocks::get_main_chain(&state.unstable_blocks).len() as u32 + state.utxos.next_height()
-        - 1
+    unstable_blocks::get_main_chain_length(&state.unstable_blocks) as u32 + state.utxos.next_height() - 1
 }
 
 pub fn get_unstable_blocks(state: &State) -> Vec<&Block> {

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -228,6 +228,22 @@ pub fn get_main_chain(blocks: &UnstableBlocks) -> BlockChain {
     main_chain
 }
 
+/// Returns the length of the "main chain".
+/// See `get_main_chain` for what defines a main chain.
+pub fn get_main_chain_length(blocks: &UnstableBlocks) -> usize {
+    let blocks_by_height = blocks.blocks_with_depths_by_heights();
+
+    // Traverse the heights in reverse order. The highest height with a single block corresponds to
+    // the tip of the main chain.
+    for height in (0..blocks_by_height.len()).rev() {
+        if blocks_by_height[height].len() == 1 {
+            return height + 1;
+        }
+    }
+
+    unreachable!("There must be at least one height with exactly one block.");
+}
+
 pub fn get_blocks(blocks: &UnstableBlocks) -> Vec<&Block> {
     blocktree::blockchains(&blocks.tree)
         .into_iter()


### PR DESCRIPTION
The Bitcoin testnet's metrics endpoint ran out of cycles because it had a large number of unstable blocks, and computing the main chain height under those conditions was very expensive.

This commit makes that computation more efficient. Prior to this change, the `get_metrics` benchmark took `163_059_419` cycles. Now it takes `8_102_095`.