### PR TITLE
chore: add additional logs to the canister heartbeat

### DIFF
--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -2,7 +2,7 @@ use crate::{
     address_utxoset::AddressUtxoSet,
     block_header_store::BlockHeaderStore,
     metrics::Metrics,
-    runtime::{performance_counter, time},
+    runtime::{performance_counter, time, print},
     types::{
         into_bitcoin_network, Address, Block, BlockHash, GetSuccessorsCompleteResponse,
         GetSuccessorsPartialResponse, Slicing,
@@ -148,6 +148,7 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
     };
 
     // Finish ingesting the stable block that's partially ingested, if that exists.
+    print("Running ingest_block_continue...");
     match state.utxos.ingest_block_continue() {
         None => {}
         Some(Slicing::Paused(())) => return has_state_changed(state),
@@ -158,7 +159,13 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
     }
 
     // Check if there are any stable blocks and ingest those into the UTXO set.
+    print("Looking for new stable blocks to ingest...");
     while let Some(new_stable_block) = unstable_blocks::peek(&state.unstable_blocks) {
+        print(&format!(
+            "Ingesting new stable block {:?}...",
+            new_stable_block.block_hash()
+        ));
+
         // Store the block's header.
         state
             .stable_block_headers

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -2,7 +2,7 @@ use crate::{
     address_utxoset::AddressUtxoSet,
     block_header_store::BlockHeaderStore,
     metrics::Metrics,
-    runtime::{performance_counter, time, print},
+    runtime::{performance_counter, print, time},
     types::{
         into_bitcoin_network, Address, Block, BlockHash, GetSuccessorsCompleteResponse,
         GetSuccessorsPartialResponse, Slicing,

--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -519,9 +519,7 @@ impl From<Vec<u8>> for BlockHeaderBlob {
 }
 
 // A blob representing a block hash.
-#[derive(
-    CandidType, PartialEq, Clone, Debug, Ord, PartialOrd, Eq, Serialize, Deserialize, Hash,
-)]
+#[derive(CandidType, PartialEq, Clone, Ord, PartialOrd, Eq, Serialize, Deserialize, Hash)]
 pub struct BlockHash(Vec<u8>);
 
 impl StableStructuresStorable for BlockHash {
@@ -586,6 +584,12 @@ impl ToString for BlockHash {
 impl Default for BlockHash {
     fn default() -> Self {
         Self(vec![0; 32])
+    }
+}
+
+impl std::fmt::Debug for BlockHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "BlockHash({})", self.to_string())
     }
 }
 
@@ -670,11 +674,25 @@ pub enum GetSuccessorsRequest {
     FollowUp(PageNumber),
 }
 
-#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(CandidType, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GetSuccessorsRequestInitial {
     pub network: Network,
     pub anchor: BlockHash,
     pub processed_block_hashes: Vec<BlockHash>,
+}
+
+impl std::fmt::Debug for GetSuccessorsRequestInitial {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GetSuccessorsRequestInitial")
+            .field("network", &self.network)
+            .field("anchor", &self.anchor)
+            .field(
+                "processed_block_hashes_len",
+                &self.processed_block_hashes.len(),
+            )
+            .field("processed_block_hashes", &self.processed_block_hashes)
+            .finish()
+    }
 }
 
 /// A response containing new successor blocks from the Bitcoin network.


### PR DESCRIPTION
We've run into a situation where the Bitcoin testnet canister stopped syncing, but there are no logs or information for us to understand what exactly is happening.

This commit adds additional logs to give us this additional visibility in order to triage issues.