### PR TITLE
perf: add benchmark for inserting block headers

### DIFF
--- a/benchmarks/drun.txt
+++ b/benchmarks/drun.txt
@@ -2,3 +2,4 @@ create
 install rwlgt-iiaaa-aaaaa-aaaaa-cai ../target/wasm32-unknown-unknown/release/benchmarks.wasm.gz ""
 query rwlgt-iiaaa-aaaaa-aaaaa-cai insert_300_blocks "DIDL\x00\x00"
 query rwlgt-iiaaa-aaaaa-aaaaa-cai get_metrics "DIDL\x00\x00"
+query rwlgt-iiaaa-aaaaa-aaaaa-cai insert_block_headers "DIDL\x00\x00"

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -75,16 +75,20 @@ fn get_metrics() -> u64 {
     })
 }
 
+// Benchmarks inserting 100 block headers into a tree containing 1000 blocks
 #[query]
 fn insert_block_headers() -> u64 {
+    let blocks_to_insert = 1000;
+    let block_headers_to_insert = 100;
+
     ic_btc_canister::init(Config {
         network: Network::Testnet,
-        stability_threshold: 600,
         ..Config::default()
     });
 
+    // Insert the blocks.
     with_state_mut(|s| {
-        for i in 0..600 {
+        for i in 0..blocks_to_insert {
             ic_btc_canister::state::insert_block(
                 s,
                 TESTNET_BLOCKS.with(|b| b.borrow()[i as usize].clone()),
@@ -93,24 +97,23 @@ fn insert_block_headers() -> u64 {
         }
     });
 
+    // Compute the next block headers.
     let next_block_headers = TESTNET_BLOCKS.with(|b| {
         let blocks = b.borrow();
         let mut next_block_headers = vec![];
-
-        for i in 600..700 {
+        for i in blocks_to_insert..blocks_to_insert + block_headers_to_insert {
             let mut block_header_blob = vec![];
             BlockHeader::consensus_encode(blocks[i as usize].header(), &mut block_header_blob)
                 .unwrap();
-
             next_block_headers.push(BlockHeaderBlob::try_from(block_header_blob).unwrap());
         }
 
         next_block_headers
     });
-    
+
+    // Benchmark inserting the block headers.
     count_instructions(|| {
         with_state_mut(|s| {
-            // Insert 100 next block headers.
             ic_btc_canister::state::insert_next_block_headers(s, next_block_headers.as_slice());
         });
     })

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -7,8 +7,8 @@ use crate::{
     },
 };
 use crate::{with_state, with_state_mut};
+use bitcoin::consensus::Decodable;
 use bitcoin::Block as BitcoinBlock;
-use bitcoin::{consensus::Decodable};
 use ic_btc_interface::Flag;
 
 /// The heartbeat of the Bitcoin canister.


### PR DESCRIPTION
Inserting block headers can be deceivingly expensive, as it involves validating the block header, and that can involve the expensive computation of many block hashes.

This commit adds a benchmark to ensure we don't introduce new regressions to this code path.