### PR TITLE
perf: skip next block headers if they are already inserted.

### DIFF
--- a/benchmarks/benches.rs
+++ b/benchmarks/benches.rs
@@ -146,6 +146,7 @@ fn bench_function(c: &mut Criterion<Instructions>, method: &str) {
 
 pub fn criterion_benchmark(c: &mut Criterion<Instructions>) {
     bench_function(c, "insert_block_headers");
+    bench_function(c, "insert_block_headers_multiple_times");
     bench_function(c, "insert_300_blocks");
     bench_function(c, "get_metrics");
 }

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -198,6 +198,11 @@ pub fn insert_next_block_headers(state: &mut State, next_block_headers: &[BlockH
             }
         };
 
+        if state.unstable_blocks.has_next_block_header(&block_header) {
+            // Already processed this block header. Skip...
+            continue;
+        }
+
         let validation_result =
             match ValidationContext::new_with_next_block_headers(state, &block_header)
                 .map_err(|_| InsertBlockError::PrevHeaderNotFound)

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -112,6 +112,13 @@ impl UnstableBlocks {
         Ok(())
     }
 
+    /// Returns true if the given block header is already stored as one of the next block headers.
+    pub fn has_next_block_header(&self, block_header: &BlockHeader) -> bool {
+        self.next_block_headers
+            .get_header(&BlockHash::from(block_header.block_hash()))
+            .is_some()
+    }
+
     // Public only for testing purpose.
     pub(crate) fn next_block_headers_max_height(&self) -> Option<Height> {
         self.next_block_headers.get_max_height()


### PR DESCRIPTION
As the Bitcoin canister is syncing, it can encounter the following scenario frequently if it's falling far behind:

```
// Initial state
unstable_state = {
  blocks: {A, B, C};
  next_block_headers: {D, E, F}
}

// Calls get_successors, and gets the following response:
get_successors_response {
  blocks: {D},
  next_block_headers: {E, F}
}
```

In this scenario, the canister processes block headers `E` and `F` are processed twice, and that is relatively expensive.

This commit adds logic to check if a block header has already been added to the unstable state and, if yes, skips it. A benchmark has been added to prevent this from regressing.

Before the optimization:

```
insert_block_headers_multiple_times
                        time:   [118.21 B Instructions 118.21 B Instructions 118.21 B Instructions]
```

After the optimization:

```
insert_block_headers_multiple_times
                        time:   [12.055 B Instructions 12.055 B Instructions 12.055 B Instructions]
                        change: [-89.802% -89.802% -89.802%] (p = 0.00 < 0.05)
                        Performance has improved.
```