### PR TITLE
fix: add a bound on the length of the unstable chain in testnet/regtest

### DIFF
--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -79,12 +79,12 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             "The number of unstable blocks.",
         )?;
         w.encode_gauge(
-            "unstable_blocks_difficulty_based_depth",
+            "unstable_blocks_depth",
             state.unstable_blocks.blocks_depth() as f64,
             "The depth of the unstable blocks.",
         )?;
         w.encode_gauge(
-            "unstable_blocks_max_depth",
+            "unstable_blocks_difficulty_based_depth",
             state.unstable_blocks.blocks_difficulty_based_depth() as f64,
             "The difficulty-based depth of the unstable blocks.",
         )?;

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -35,6 +35,7 @@ pub fn get_metrics() -> HttpResponse {
 
 fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
     with_state(|state| {
+        // General stats
         w.encode_gauge(
             "main_chain_height",
             state::main_chain_height(state) as f64,
@@ -54,6 +55,38 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             "address_utxos_length",
             state.utxos.address_utxos_len() as f64,
             "The number of UTXOs that are owned by supported addresses.",
+        )?;
+
+        // Unstable blocks and stability threshold
+        w.encode_gauge(
+            "anchor_difficulty",
+            state.unstable_blocks.anchor_difficulty() as f64,
+            "The difficulty of the anchor block.",
+        )?;
+        w.encode_gauge(
+            "normalized_stability_threshold",
+            state.unstable_blocks.normalized_stability_threshold() as f64,
+            "The stability threshold normalized by the difficulty of the anchor block.",
+        )?;
+        w.encode_gauge(
+            "unstable_blocks_num_tips",
+            state.unstable_blocks.num_tips() as f64,
+            "The number of tips in the unstable block tree.",
+        )?;
+        w.encode_gauge(
+            "unstable_blocks_total",
+            state::get_unstable_blocks(state).len() as f64,
+            "The number of unstable blocks.",
+        )?;
+        w.encode_gauge(
+            "unstable_blocks_difficulty_based_depth",
+            state.unstable_blocks.blocks_depth() as f64,
+            "The depth of the unstable blocks.",
+        )?;
+        w.encode_gauge(
+            "unstable_blocks_max_depth",
+            state.unstable_blocks.blocks_difficulty_based_depth() as f64,
+            "The difficulty-based depth of the unstable blocks.",
         )?;
 
         // Memory

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -120,6 +120,15 @@ impl BlockTree {
 
         depth
     }
+
+    /// Returns the number of tips in the tree.
+    pub fn num_tips(&self) -> u32 {
+        if self.children.is_empty() {
+            1
+        } else {
+            self.children.iter().map(|c| c.num_tips()).sum()
+        }
+    }
 }
 
 /// Extends the tree with the given block.
@@ -224,6 +233,15 @@ pub fn difficulty_based_depth(tree: &BlockTree, network: Network) -> u128 {
         res = std::cmp::max(res, difficulty_based_depth(child, network));
     }
     res += tree.root.difficulty(network) as u128;
+    res
+}
+
+pub fn depth(tree: &BlockTree) -> u128 {
+    let mut res: u128 = 0;
+    for child in tree.children.iter() {
+        res = std::cmp::max(res, depth(child));
+    }
+    res += 1;
     res
 }
 

--- a/canister/src/test_utils.rs
+++ b/canister/src/test_utils.rs
@@ -240,6 +240,7 @@ impl TransactionBuilder {
 pub struct BlockChainBuilder {
     num_blocks: u32,
     prev_block_header: Option<BlockHeader>,
+    #[allow(clippy::type_complexity)]
     difficulty_ranges: Vec<((Bound<usize>, Bound<usize>), u64)>,
 }
 

--- a/canister/src/test_utils.rs
+++ b/canister/src/test_utils.rs
@@ -13,7 +13,10 @@ use ic_btc_test_utils::{
 use ic_btc_types::{Block, OutPoint, Transaction};
 use ic_stable_structures::{BoundedStorable, Memory, StableBTreeMap};
 use proptest::prelude::RngCore;
-use std::str::FromStr;
+use std::{
+    ops::{Bound, RangeBounds},
+    str::FromStr,
+};
 
 /// Generates a random P2PKH address.
 pub fn random_p2pkh_address(network: Network) -> Address {
@@ -144,29 +147,42 @@ pub fn is_stable_btreemap_equal<
 /// as opposed to `bitcoin::Block`.
 pub struct BlockBuilder {
     builder: ExternalBlockBuilder,
+    mock_difficulty: Option<u64>,
 }
 
 impl BlockBuilder {
     pub fn genesis() -> Self {
         Self {
             builder: ExternalBlockBuilder::genesis(),
+            mock_difficulty: None,
         }
     }
 
     pub fn with_prev_header(prev_header: &BlockHeader) -> Self {
         Self {
             builder: ExternalBlockBuilder::with_prev_header(*prev_header),
+            mock_difficulty: None,
         }
     }
 
     pub fn with_transaction(self, transaction: Transaction) -> Self {
         Self {
             builder: self.builder.with_transaction(transaction.into()),
+            mock_difficulty: None,
+        }
+    }
+
+    pub fn with_difficulty(self, difficulty: u64) -> Self {
+        Self {
+            mock_difficulty: Some(difficulty),
+            ..self
         }
     }
 
     pub fn build(self) -> Block {
-        Block::new(self.builder.build())
+        let mut block = Block::new(self.builder.build());
+        block.mock_difficulty = self.mock_difficulty;
+        block
     }
 
     pub fn build_with_mock_difficulty(self, mock_difficulty: u64) -> Block {
@@ -224,6 +240,7 @@ impl TransactionBuilder {
 pub struct BlockChainBuilder {
     num_blocks: u32,
     prev_block_header: Option<BlockHeader>,
+    difficulty_ranges: Vec<((Bound<usize>, Bound<usize>), u64)>,
 }
 
 impl BlockChainBuilder {
@@ -231,6 +248,7 @@ impl BlockChainBuilder {
         Self {
             num_blocks,
             prev_block_header: None,
+            difficulty_ranges: vec![],
         }
     }
 
@@ -238,28 +256,50 @@ impl BlockChainBuilder {
         Self {
             num_blocks,
             prev_block_header: Some(*prev_block.header()),
+            difficulty_ranges: vec![],
         }
+    }
+
+    /// Sets the difficulty of blocks at the given range of heights.
+    pub fn with_difficulty<R: RangeBounds<usize>>(mut self, difficulty: u64, range: R) -> Self {
+        self.difficulty_ranges.push((
+            (range.start_bound().cloned(), range.end_bound().cloned()),
+            difficulty,
+        ));
+        self
     }
 
     pub fn build(self) -> Vec<Block> {
         let mut blocks = Vec::with_capacity(self.num_blocks as usize);
 
-        match self.prev_block_header {
-            None => {
-                blocks.push(genesis_block(Network::Regtest));
-            }
-            Some(prev_block_header) => {
-                let block = BlockBuilder::with_prev_header(&prev_block_header).build();
-                blocks.push(block);
-            }
+        let mut first_block = match self.prev_block_header {
+            None => genesis_block(Network::Regtest),
+            Some(prev_block_header) => BlockBuilder::with_prev_header(&prev_block_header).build(),
         };
+        if let difficulty @ Some(_) = self.get_difficulty(0) {
+            first_block.mock_difficulty = difficulty;
+        }
+
+        blocks.push(first_block);
 
         for i in 1..self.num_blocks as usize {
-            let block = BlockBuilder::with_prev_header(blocks[i - 1].header()).build();
-            blocks.push(block);
+            let mut block = BlockBuilder::with_prev_header(blocks[i - 1].header());
+            if let Some(difficulty) = self.get_difficulty(i) {
+                block = block.with_difficulty(difficulty);
+            }
+            blocks.push(block.build());
         }
 
         blocks
+    }
+
+    fn get_difficulty(&self, i: usize) -> Option<u64> {
+        for (range, difficulty) in &self.difficulty_ranges {
+            if range.contains(&i) {
+                return Some(*difficulty);
+            }
+        }
+        None
     }
 }
 

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -925,7 +925,7 @@ mod test {
                 < unstable_blocks.normalized_stability_threshold()
         );
 
-        assert_eq!(unstable_blocks.blocks_depth(), chain_len as u128);
+        assert_eq!(unstable_blocks.blocks_depth(), chain_len);
 
         // Even though the chain's difficulty-based depth doesn't exceed the normalized stability
         // threshold, the anchor block can now be popped because the chain's length has exceeded

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -1,6 +1,7 @@
 mod outpoints_cache;
 use crate::{
     blocktree::{self, BlockChain, BlockDoesNotExtendTree, BlockTree},
+    runtime::print,
     types::{Address, TxOut},
     UtxoSet,
 };
@@ -12,6 +13,8 @@ use serde::{Deserialize, Serialize};
 
 mod next_block_headers;
 use self::next_block_headers::NextBlockHeaders;
+
+const TESTNET_MAX_SOLO_CHAIN_LENGTH: u128 = 1000;
 
 /// A data structure for maintaining all unstable blocks.
 ///
@@ -72,6 +75,19 @@ impl UnstableBlocks {
         self.stability_threshold = stability_threshold;
     }
 
+    pub fn anchor_difficulty(&self) -> u64 {
+        self.tree.root.difficulty(self.network)
+    }
+
+    pub fn normalized_stability_threshold(&self) -> u128 {
+        self.anchor_difficulty() as u128 * self.stability_threshold as u128
+    }
+
+    /// Returns the number of tips available in the current block tree.
+    pub fn num_tips(&self) -> u32 {
+        self.tree.num_tips()
+    }
+
     fn get_network(&self) -> Network {
         self.network
     }
@@ -80,6 +96,16 @@ impl UnstableBlocks {
     /// separated by heights.
     pub fn blocks_with_depths_by_heights(&self) -> Vec<Vec<(&Block, u32)>> {
         self.tree.blocks_with_depths_by_heights()
+    }
+
+    /// Returns the depth of the unstable block tree.
+    pub fn blocks_depth(&self) -> u128 {
+        blocktree::depth(&self.tree)
+    }
+
+    /// Returns the difficulty-based depth of the unstable block tree.
+    pub fn blocks_difficulty_based_depth(&self) -> u128 {
+        blocktree::difficulty_based_depth(&self.tree, self.network)
     }
 
     /// Returns depth in BlockTree of Block with given BlockHash.
@@ -278,12 +304,50 @@ fn get_stable_child(blocks: &UnstableBlocks) -> Option<usize> {
     // Sort by depth.
     depths.sort_by_key(|(depth, _child_idx)| *depth);
 
-    let root_difficulty = blocks.tree.root.difficulty(network) as u128;
-
-    let normalized_stability_threshold = root_difficulty * blocks.stability_threshold as u128;
+    let normalized_stability_threshold = blocks.normalized_stability_threshold();
 
     match depths.last() {
         Some((deepest_depth, child_idx)) => {
+            match network {
+                Network::Testnet | Network::Regtest => {
+                    // The difficulty in the Bitcoin testnet/regtest can be reset to the minimum
+                    // in case a block hasn't been found for 20 minutes. This can be problematic.
+                    // Consider the following scenario:
+                    //
+                    // * Assume a `stability_threshold` of 144.
+                    // * The anchor at height `h` has difficulty of 4642.
+                    // * The anchor will be marked as stable if the difficulty-based depth of
+                    //   the successor blocks is `stability_threshold * difficulty(anchor)` = 668,448
+                    // * The difficulty is reset to the minimum of 1.
+                    // * The canister will now need to maintain a chain of length 668,448 just to
+                    //   mark the anchor block as stable!
+                    //
+                    // Very long chains can cause the shadow stacks to overflow, resulting in a
+                    // broken canister.
+                    //
+                    // The pragmatic solution in this case is to bound the length of the chain. If
+                    // there's only one chain and it starts exceeding a certain length, we assume
+                    // that the anchor is stable even if the difficulty requirement hasn't been
+                    // met.
+                    //
+                    // This scenario is only relevant for testnets, so this addition is safe and
+                    // has not impact on the behavior of the mainnet canister.
+                    if depths.len() == 1
+                        && blocktree::depth(&blocks.tree.children[*child_idx])
+                            > TESTNET_MAX_SOLO_CHAIN_LENGTH
+                    {
+                        print(
+                            "Detected a solo chain > {TESTNET_MAX_SOLO_CHAIN_LENGTH}. Assuming the root is stable...",
+                        );
+                        return Some(*child_idx);
+                    }
+                }
+                Network::Mainnet => {
+                    // The difficulty on mainnet is much more stable and is bounded to change by a
+                    // factor of 4, so there is no limit that needs to be imposed.
+                }
+            }
+
             // The deepest child tree must have a depth >= normalized_stability_threshold.
             if *deepest_depth < normalized_stability_threshold {
                 // Need a depth of at least >= normalized_stability_threshold.
@@ -313,7 +377,7 @@ fn get_stable_child(blocks: &UnstableBlocks) -> Option<usize> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test_utils::BlockBuilder;
+    use crate::test_utils::{BlockBuilder, BlockChainBuilder};
     use ic_btc_interface::Network;
 
     #[test]
@@ -807,5 +871,65 @@ mod test {
                 (block_y.header(), block_y.block_hash()),
             ]
         );
+    }
+
+    #[test]
+    fn testnet_chain_longer_than_max_solo_chain() {
+        let stability_threshold = 144;
+        let chain_len = 2000;
+        let anchor_block_difficulty = 4642;
+        let remaining_blocks_difficulty = 1;
+        let network = Network::Regtest;
+        let utxos = UtxoSet::new(network);
+
+        // Assert the chain that will be built exceeds the maximum allowed, so that we can test
+        // that case.
+        assert!(chain_len > TESTNET_MAX_SOLO_CHAIN_LENGTH);
+
+        // Build a long chain where the first block has a substantially higher difficulty than the
+        // remaining blocks.
+        let chain = BlockChainBuilder::new(chain_len as u32)
+            // Set the difficulty of the anchor block to be high.
+            .with_difficulty(anchor_block_difficulty, 0..1)
+            // Set the difficulty of the remaining blocks to be low.
+            .with_difficulty(remaining_blocks_difficulty, 1..)
+            .build();
+
+        let mut unstable_blocks =
+            UnstableBlocks::new(&utxos, stability_threshold, chain[0].clone(), network);
+
+        // Sanity check that the difficulties are set correctly.
+        assert_eq!(chain[0].mock_difficulty, Some(anchor_block_difficulty));
+        assert_eq!(chain[1].mock_difficulty, Some(remaining_blocks_difficulty));
+        assert_eq!(
+            chain[chain_len as usize - 1].mock_difficulty,
+            Some(remaining_blocks_difficulty)
+        );
+
+        // Insert chain into the state.
+        for block in chain.iter().skip(1) {
+            push(&mut unstable_blocks, &utxos, block.clone()).unwrap();
+        }
+
+        // The normalized stability threshold is now very high because of the high difficulty
+        // of the anchor block.
+        assert_eq!(
+            unstable_blocks.normalized_stability_threshold(),
+            anchor_block_difficulty as u128 * stability_threshold as u128
+        );
+
+        // The normalized stability threshold is still not met, which means that, in theory,
+        // there are no stable blocks that can be popped.
+        assert!(
+            unstable_blocks.blocks_difficulty_based_depth()
+                < unstable_blocks.normalized_stability_threshold()
+        );
+
+        assert_eq!(unstable_blocks.blocks_depth(), chain_len as u128);
+
+        // Even though the chain's difficulty-based depth doesn't exceed the normalized stability
+        // threshold, the anchor block can now be popped because the chain's length has exceeded
+        // the maximum allowed.
+        assert_eq!(peek(&unstable_blocks), Some(&chain[0]));
     }
 }


### PR DESCRIPTION
In production, we set a `stability_threshold` of ~144. However, when
we consider the stability of the chain, we consider it weighted by the
blocks' difficulties. This isn't a problem in the normal case, where
block difficulties are very similar.

There are scenarios specific to the Bitcoin testnet, however, that can
make this logic problematic. The difficulty in the Bitcoin testnet can
be reset to the minimum in case a block hasn't been found for 20 minutes.

Consider the following scenario:

* Assume a `stability_threshold` of 144.
* The anchor at height `h` has difficulty of 4642.
* The anchor will be marked as stable if the difficulty-based depth of
  the successor blocks is `stability_threshold * difficulty(anchor)` = 668,448
* The difficulty is reset to the minimum of 1.
* The canister will now need to maintain a chain of length 668,448 just to
  mark the anchor block as stable!

Very long chains can cause the shadow stacks to overflow, resulting in a
broken canister.

The pragmatic solution in this case is to bound the length of the chain. If
there's only one chain and it starts exceeding a certain length, we assume
that the anchor is stable even if the difficulty requirement hasn't been
met.

This scenario is only relevant for testnets, so this addition is safe and
has not impact on the behavior of the mainnet canister.

## Benchmarks
The `get_metrics` endpoint is now slower because of all the additional metrics we've now added,
but it's still acceptable.

```
insert_block_headers    time:   [3201.5 M Instructions 3201.5 M Instructions 3201.5 M Instructions]
                        change: [-0.0039% -0.0039% -0.0039%] (p = 0.00 < 0.05)
                        Change within noise threshold.

insert_block_headers_multiple_times
                        time:   [12.055 B Instructions 12.055 B Instructions 12.055 B Instructions]
                        change: [+0.0016% +0.0016% +0.0016%] (p = 0.00 < 0.05)
                        Change within noise threshold.

insert_300_blocks       time:   [586.23 M Instructions 586.23 M Instructions 586.23 M Instructions]
                        change: [-0.0006% -0.0006% -0.0006%] (p = 0.00 < 0.05)
                        Change within noise threshold.

get_metrics             time:   [90.709 M Instructions 90.709 M Instructions 90.709 M Instructions]
                        change: [+1019.6% +1019.6% +1019.6%] (p = 0.00 < 0.05)
                        Performance has regressed.
```