### PR TITLE
fix: Add watchdog_upgradability to check_pass on GitHub CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -508,6 +508,7 @@ jobs:
       - watchdog_health_status
       - watchdog_get_config
       - watchdog_metrics
+      - watchdog_upgradability
       - canister-build-reproducibility
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
Problem: The passing of watchdog_upgradability is not checked in check_pass on GitHub CI

