### PR TITLE
perf: Add inspect_message endpoint to Bitcoin canister

### DIFF
--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -108,10 +108,10 @@ pub fn http_request(request: HttpRequest) -> HttpResponse {
 
 #[inspect_message]
 fn inspect_message() {
-  // Reject calls to the query endpoints as they are not supported in replicated mode.
-    let inspected_maethod_name = ic_cdk::api::call::method_name();
-    if inspected_maethod_name.as_str() != "bitcoin_get_balance_query"
-        && inspected_maethod_name.as_str() != "bitcoin_get_utxos_query"
+    // Reject calls to the query endpoints as they are not supported in replicated mode.
+    let inspected_method_name = ic_cdk::api::call::method_name();
+    if inspected_method_name.as_str() != "bitcoin_get_balance_query"
+        && inspected_method_name.as_str() != "bitcoin_get_utxos_query"
     {
         ic_cdk::api::call::accept_message();
     }

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -47,7 +47,7 @@ pub fn bitcoin_get_balance(request: GetBalanceRequest) {
 #[query(manual_reply = true)]
 pub fn bitcoin_get_balance_query(request: GetBalanceRequest) {
     if ic_cdk::api::data_certificate().is_none() {
-        reject("bitcoin_get_balance_query cannot be called in replicated mode");
+        reject("get_balance_query cannot be called in replicated mode");
         return;
     }
     match ic_btc_canister::get_balance_query(request) {
@@ -67,7 +67,7 @@ pub fn bitcoin_get_utxos(request: GetUtxosRequest) {
 #[query(manual_reply = true)]
 pub fn bitcoin_get_utxos_query(request: GetUtxosRequest) {
     if ic_cdk::api::data_certificate().is_none() {
-        reject("bitcoin_get_utxos_query cannot be called in replicated mode");
+        reject("get_utxos_query cannot be called in replicated mode");
         return;
     }
     match ic_btc_canister::get_utxos_query(request) {

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -108,6 +108,7 @@ pub fn http_request(request: HttpRequest) -> HttpResponse {
 
 #[inspect_message]
 fn inspect_message() {
+  // Reject calls to the query endpoints as they are not supported in replicated mode.
     let inspected_maethod_name = ic_cdk::api::call::method_name();
     if inspected_maethod_name.as_str() != "bitcoin_get_balance_query"
         && inspected_maethod_name.as_str() != "bitcoin_get_utxos_query"

--- a/e2e-tests/scenario-1.sh
+++ b/e2e-tests/scenario-1.sh
@@ -130,7 +130,7 @@ GET_UTXOS_QUERY_REPLICATED_CALL=$(dfx canister call --update bitcoin bitcoin_get
 })' 2>&1)
 set -e
 
-if [[ $GET_UTXOS_QUERY_REPLICATED_CALL != *"get_utxos_query cannot be called in replicated mode"* ]]; then
+if [[ $GET_UTXOS_QUERY_REPLICATED_CALL != *"rejected the message, error code Some(\"IC0516\")"* ]]; then
   echo "FAIL"
   exit 1
 fi
@@ -153,7 +153,7 @@ GET_BALANCE_QUERY_REPLICATED_CALL=$(dfx canister call --update bitcoin bitcoin_g
 })' 2>&1)
 set -e
 
-if [[ $GET_BALANCE_QUERY_REPLICATED_CALL != *"get_balance_query cannot be called in replicated mode"* ]]; then
+if [[ $GET_BALANCE_QUERY_REPLICATED_CALL != *"rejected the message, error code Some(\"IC0516\")"* ]]; then
   echo "FAIL"
   exit 1
 fi


### PR DESCRIPTION
Problem:
Replicated calls to query methods first go through consensus and then are rejected by the Bitcoin canister, hence wasting resources.

 

Solution:

Add inspect_message endpoint, which will reject all calls to the query endpoints.