### PR TITLE
chore: upgrade to stable structures 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,9 +1646,9 @@ checksum = "7cb321e571828d64d62319deeaaec4c8e68cdf93144dd6fe248e7a51ab2d3b5d"
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.5.4"
+version = "0.6.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e026318236de13568edafd85534ad29910908bf08cdcf177d4403fd4a5f6c4"
+checksum = "2fc18a65191884de50fc7f25d550aa55f4f608e9e3b17fbaec9bf290483eb2b8"
 
 [[package]]
 name = "ic-verify-bls-signature"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ ic-cdk = "0.10.0"
 ic-cdk-macros = "0.7.0"
 ic-http = { path = "./ic-http" }
 ic-metrics-encoder = "1.0.0"
-ic-stable-structures = "0.5.2"
+ic-stable-structures = "0.6.0-beta.1"
 lazy_static = "1.4.0"
 serde = "1.0.171"
 serde_bytes = "0.11"

--- a/bootstrap/main-state-builder/Cargo.lock
+++ b/bootstrap/main-state-builder/Cargo.lock
@@ -472,9 +472,9 @@ checksum = "7cb321e571828d64d62319deeaaec4c8e68cdf93144dd6fe248e7a51ab2d3b5d"
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.5.2"
+version = "0.6.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d43ba7c5067d1360860e2234d93411d2126c8eac788467966ed1383161f91fc"
+checksum = "2fc18a65191884de50fc7f25d550aa55f4f608e9e3b17fbaec9bf290483eb2b8"
 
 [[package]]
 name = "ic0"

--- a/bootstrap/main-state-builder/Cargo.toml
+++ b/bootstrap/main-state-builder/Cargo.toml
@@ -11,6 +11,6 @@ hex = "0.4.3"
 ic-btc-canister = { path = "../../canister", features = ["file_memory"] }
 ic-btc-interface = { path = "../../interface" }
 ic-btc-types = { path = "../../types" }
-ic-stable-structures = "0.5.2"
+ic-stable-structures = "0.6.0-beta.1"
 
 [workspace]

--- a/bootstrap/state-builder/src/build_address_utxos.rs
+++ b/bootstrap/state-builder/src/build_address_utxos.rs
@@ -12,7 +12,8 @@ use ic_btc_canister::types::{into_bitcoin_network, Address, AddressUtxo};
 use ic_btc_interface::Network;
 use ic_btc_types::{OutPoint, Txid};
 use ic_stable_structures::{
-    storable::Blob, BoundedStorable, DefaultMemoryImpl, StableBTreeMap, Storable,
+    storable::{max_size, Blob},
+    DefaultMemoryImpl, StableBTreeMap, Storable,
 };
 use std::{
     fs::File,
@@ -44,7 +45,7 @@ fn main() {
     let reader = BufReader::new(utxos_file);
 
     let memory = DefaultMemoryImpl::default();
-    let mut address_utxos: StableBTreeMap<Blob<{ AddressUtxo::MAX_SIZE as usize }>, (), _> =
+    let mut address_utxos: StableBTreeMap<Blob<{ max_size::<AddressUtxo>() as usize }>, (), _> =
         StableBTreeMap::init(memory.clone());
 
     for (i, line) in reader.lines().enumerate() {

--- a/canister/src/test_utils.rs
+++ b/canister/src/test_utils.rs
@@ -11,7 +11,7 @@ use ic_btc_test_utils::{
     BlockBuilder as ExternalBlockBuilder, TransactionBuilder as ExternalTransactionBuilder,
 };
 use ic_btc_types::{Block, OutPoint, Transaction};
-use ic_stable_structures::{BoundedStorable, Memory, StableBTreeMap};
+use ic_stable_structures::{storable::Storable, Memory, StableBTreeMap};
 use proptest::prelude::RngCore;
 use std::{
     ops::{Bound, RangeBounds},
@@ -122,11 +122,7 @@ fn build_chain_with_genesis_block(
 }
 
 /// Returns true if the instances of `StableBTreeMap` provided are equal.
-pub fn is_stable_btreemap_equal<
-    M: Memory,
-    K: BoundedStorable + Ord + Eq + Clone,
-    V: BoundedStorable + Eq,
->(
+pub fn is_stable_btreemap_equal<M: Memory, K: Storable + Ord + Eq + Clone, V: Storable + Eq>(
     a: &StableBTreeMap<K, V, M>,
     b: &StableBTreeMap<K, V, M>,
 ) -> bool {

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -7,7 +7,10 @@ use crate::{
 use bitcoin::{Script, TxOut as BitcoinTxOut};
 use ic_btc_interface::{Height, Network, Satoshi};
 use ic_btc_types::{Block, BlockHash, OutPoint, Transaction, Txid};
-use ic_stable_structures::{storable::Blob, BoundedStorable, StableBTreeMap, Storable as _};
+use ic_stable_structures::{
+    storable::{max_size, Blob},
+    StableBTreeMap, Storable as _,
+};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, iter::Iterator, str::FromStr};
 mod utxos;
@@ -32,7 +35,7 @@ pub struct UtxoSet {
     // An index for fast retrievals of an address's UTXOs.
     // NOTE: Stable structures don't need to be serialized.
     #[serde(skip, default = "init_address_utxos")]
-    address_utxos: StableBTreeMap<Blob<{ AddressUtxo::MAX_SIZE as usize }>, (), Memory>,
+    address_utxos: StableBTreeMap<Blob<{ max_size::<AddressUtxo>() as usize }>, (), Memory>,
 
     // A map of an address and its current balance.
     // NOTE: Stable structures don't need to be serialized.
@@ -446,7 +449,8 @@ impl UtxoSet {
     }
 }
 
-fn init_address_utxos() -> StableBTreeMap<Blob<{ AddressUtxo::MAX_SIZE as usize }>, (), Memory> {
+fn init_address_utxos() -> StableBTreeMap<Blob<{ max_size::<AddressUtxo>() as usize }>, (), Memory>
+{
     StableBTreeMap::init(crate::memory::get_address_utxos_memory())
 }
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -7,7 +7,10 @@ use bitcoin::{
 };
 use candid::CandidType;
 use ic_btc_interface::{Network, Txid as PublicTxid};
-use ic_stable_structures::{BoundedStorable, Storable};
+use ic_stable_structures::{
+    storable::{max_size, Bound},
+    Storable,
+};
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, cell::RefCell, str::FromStr};
 
@@ -215,11 +218,11 @@ impl Storable for BlockHash {
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         Self::from(bytes.to_vec())
     }
-}
 
-impl BoundedStorable for BlockHash {
-    const MAX_SIZE: u32 = 32;
-    const IS_FIXED_SIZE: bool = true;
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 32,
+        is_fixed_size: true,
+    };
 }
 
 impl BlockHash {
@@ -232,9 +235,9 @@ impl From<Vec<u8>> for BlockHash {
     fn from(bytes: Vec<u8>) -> Self {
         assert_eq!(
             bytes.len() as u32,
-            Self::MAX_SIZE,
+            max_size::<Self>(),
             "BlockHash must {} bytes",
-            Self::MAX_SIZE
+            max_size::<Self>(),
         );
         Self(bytes)
     }
@@ -348,11 +351,11 @@ impl Storable for OutPoint {
             vout: u32::from_le_bytes(bytes[32..36].try_into().unwrap()),
         }
     }
-}
 
-impl BoundedStorable for OutPoint {
-    const MAX_SIZE: u32 = OutPoint::size();
-    const IS_FIXED_SIZE: bool = true;
+    const BOUND: Bound = Bound::Bounded {
+        max_size: OutPoint::size(),
+        is_fixed_size: true,
+    };
 }
 
 #[test]


### PR DESCRIPTION
Upgrades to the beta release of 0.6.0. We'll run this on a testnet for a while until 0.6.0 is production-ready.