### PR TITLE
fix: deserialize `BlockTree` iteratively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,6 +1514,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "tempfile",
+ "test-strategy",
 ]
 
 [[package]]
@@ -3166,6 +3167,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "structmeta"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.25",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.25",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3225,6 +3249,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-strategy"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8361c808554228ad09bfed70f5c823caf8a3450b6881cc3a38eb57e8c08c1d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta",
+ "syn 2.0.25",
 ]
 
 [[package]]

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -34,6 +34,7 @@ ic-btc-types = { workspace = true, features = ["mock_difficulty"] }
 maplit = "1.0.2"
 proptest = "0.9.4"
 tempfile = "3.2.0"
+test-strategy = "0.3.1"
 
 [features]
 file_memory = []

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -536,4 +536,19 @@ mod test {
         assert_eq!(height_2_block.block_hash(), fork[1].block_hash());
         assert_eq!(height_2_depth, 1);
     }
+
+    #[test]
+    fn deserialize_very_deep_block_tree() {
+        let chain = BlockChainBuilder::new(5_000).build();
+        let mut tree = BlockTree::new(chain[0].clone());
+
+        for block in chain.into_iter().skip(1) {
+            extend(&mut tree, block).unwrap();
+        }
+
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(&tree, &mut bytes).unwrap();
+        let new_tree: BlockTree = ciborium::de::from_reader(&bytes[..]).unwrap();
+        assert_eq!(tree, new_tree);
+    }
 }

--- a/canister/src/blocktree/serde.rs
+++ b/canister/src/blocktree/serde.rs
@@ -71,7 +71,7 @@ impl<'de> Visitor<'de> for BlockTreeDeserializer {
                     Some(parent) => parent.0.children.push(tree),
                     None => {
                         // There's no parent to this tree. Deserialization is complete.
-                        // Assert that there's no more data to serialize.
+                        // Assert that there's no more data to deserialize.
                         assert_eq!(next(&mut seq), None);
                         return Ok(tree);
                     }
@@ -87,6 +87,6 @@ impl<'de> Visitor<'de> for BlockTreeDeserializer {
             }
         }
 
-        unreachable!();
+        unreachable!("expected more while deserializing BlockTree");
     }
 }


### PR DESCRIPTION
# Problem
We're now running into a situation where the Bitcoin testnet has ~125k unstable blocks due to a difficulty reset.
Recursively deserializing these blocks, which we do in `post_upgrade`, causes a stack overflow.

# Solution
Rewrite the `BlockTree` deserialization to be iterative rather than recursive. Running a test with the current production state confirms that it fixes that stack overflow issue.