### PR TITLE
fix: failing scenario 1 test

### DIFF
--- a/e2e-tests/scenario-1.sh
+++ b/e2e-tests/scenario-1.sh
@@ -130,7 +130,7 @@ GET_UTXOS_QUERY_REPLICATED_CALL=$(dfx canister call --update bitcoin bitcoin_get
 })' 2>&1)
 set -e
 
-if [[ $GET_UTXOS_QUERY_REPLICATED_CALL != *"rejected the message, error code Some(\"IC0516\")"* ]]; then
+if [[ $GET_UTXOS_QUERY_REPLICATED_CALL != *"Http Error: status 403 Forbidden"* ]]; then
   echo "FAIL"
   exit 1
 fi
@@ -153,7 +153,7 @@ GET_BALANCE_QUERY_REPLICATED_CALL=$(dfx canister call --update bitcoin bitcoin_g
 })' 2>&1)
 set -e
 
-if [[ $GET_BALANCE_QUERY_REPLICATED_CALL != *"rejected the message, error code Some(\"IC0516\")"* ]]; then
+if [[ $GET_BALANCE_QUERY_REPLICATED_CALL != *"Http Error: status 403 Forbidden"* ]]; then
   echo "FAIL"
   exit 1
 fi


### PR DESCRIPTION
The e2e scenario 1 test started failing lately. It appears that the behavior of dfx has changed and the error messages being returned, which we use in the test, have changed. I don't quite understand how the behavior of one particular version of dfx has changed, unless that version has been modified. I'm following up with the SDK team to understand that. In any case, this fixes the failures we're seeing.