### PR TITLE
feat: improve benchmarking reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,17 +237,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,7 +313,9 @@ name = "benchmarks"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "criterion",
+ "candid 0.9.1",
+ "clap",
+ "colored",
  "hex",
  "ic-btc-canister",
  "ic-btc-interface",
@@ -338,6 +323,9 @@ dependencies = [
  "ic-cdk 0.10.0",
  "ic-cdk-macros 0.7.0",
  "lazy_static",
+ "maplit",
+ "serde",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -571,12 +559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,18 +599,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "bitflags",
- "clap_lex 0.2.4",
- "indexmap",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed"
@@ -647,7 +617,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "bitflags",
- "clap_lex 0.5.0",
+ "clap_lex",
  "strsim",
 ]
 
@@ -661,15 +631,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.25",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -702,6 +663,17 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "colored"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
+dependencies = [
+ "is-terminal",
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -759,76 +731,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "criterion"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
-dependencies = [
- "anes",
- "atty",
- "cast",
- "ciborium",
- "clap 3.2.25",
- "criterion-plot",
- "itertools",
- "lazy_static",
- "num-traits",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
-dependencies = [
- "autocfg 1.1.0",
- "cfg-if",
- "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
@@ -1021,6 +923,12 @@ checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -1302,7 +1210,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1322,19 +1230,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1686,7 +1591,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg 1.1.0",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.1",
 ]
 
 [[package]]
@@ -1894,15 +1809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg 1.1.0",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2034,12 +1940,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "oorandom"
-version = "11.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2050,12 +1950,6 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "pairing"
@@ -2132,7 +2026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -2164,34 +2058,6 @@ checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
  "spki",
-]
-
-[[package]]
-name = "plotters"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
-dependencies = [
- "plotters-backend",
 ]
 
 [[package]]
@@ -2513,28 +2379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "num_cpus",
-]
-
-[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2788,15 +2632,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "scenario-1"
 version = "0.1.0"
 dependencies = [
@@ -2988,6 +2823,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
+dependencies = [
+ "indexmap 2.0.2",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3135,7 +2983,7 @@ dependencies = [
  "bitcoin",
  "byteorder",
  "ciborium",
- "clap 4.3.4",
+ "clap",
  "hex",
  "ic-btc-canister",
  "ic-btc-interface",
@@ -3264,12 +3112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "thiserror"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3323,16 +3165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
-]
-
-[[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -3428,7 +3260,7 @@ version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "toml_datetime",
  "winnow",
 ]
@@ -3523,6 +3355,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3534,7 +3372,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "candid 0.9.1",
- "clap 4.3.4",
+ "clap",
  "garcon",
  "ic-agent",
  "ic-cdk 0.10.0",
@@ -3587,16 +3425,6 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
-
-[[package]]
-name = "walkdir"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
-dependencies = [
- "same-file",
- "winapi-util",
-]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ byteorder = "1.4.3"
 candid = "0.9.1"
 ciborium = "0.2.1"
 clap = { version = "4.0.11", features = ["derive"] }
-criterion = "0.4.0"
 futures = "0.3.28"
 hex = "0.4.3"
 ic-btc-canister = { path = "./canister" }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -6,19 +6,25 @@ edition = "2021"
 [[bin]]
 name = "benchmarks"
 path = "src/main.rs"
+bench = false
 
 [dependencies]
 bitcoin = { workspace = true, features = ["use-serde"]}
+candid = { workspace = true }
 hex = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-btc-canister = { workspace = true }
 ic-btc-interface = { workspace = true }
 ic-btc-types = { workspace = true }
+maplit = "1.0.2"
+serde = "1.0"
 
 [dev-dependencies]
-criterion = { workspace = true }
+clap = { workspace = true }
+colored = "2.0.4"
 lazy_static = { workspace = true }
+serde_yaml = "0.9"
 
 [[bench]]
 name = "benches"

--- a/benchmarks/results.yml
+++ b/benchmarks/results.yml
@@ -1,0 +1,16 @@
+get_metrics:
+  measurements:
+    instructions: 90708530
+    stable_memory_size: 769
+insert_300_blocks:
+  measurements:
+    instructions: 586134355
+    stable_memory_size: 769
+insert_block_headers:
+  measurements:
+    instructions: 3201195751
+    stable_memory_size: 769
+insert_block_headers_multiple_times:
+  measurements:
+    instructions: 12047830062
+    stable_memory_size: 769

--- a/benchmarks/run-benchmark.sh
+++ b/benchmarks/run-benchmark.sh
@@ -11,13 +11,13 @@ if ! type "drun" > /dev/null; then
   exit 1
 fi
 
-cat > $FILE << EOF
+cat > "$FILE" << EOF
 create
 install rwlgt-iiaaa-aaaaa-aaaaa-cai ../target/wasm32-unknown-unknown/release/benchmarks.wasm.gz ""
 query rwlgt-iiaaa-aaaaa-aaaaa-cai ${BENCH_NAME} "DIDL\x00\x00"
 EOF
 
 # Run the benchmarks, decode the output.
-drun $FILE --instruction-limit 99999999999999 \
+drun "$FILE" --instruction-limit 99999999999999 \
     | awk '{ print $3 }' \
     | grep "44.*" -o

--- a/benchmarks/run-benchmark.sh
+++ b/benchmarks/run-benchmark.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 BENCH_NAME=$1
-FILE=mktemp
+FILE=$(mktemp)
 
 if ! type "drun" > /dev/null; then
   echo "drun is not installed. Please add drun to your path from commit d35535c96184be039aaa31f68b48bbe45909494e."
@@ -20,5 +20,4 @@ EOF
 # Run the benchmarks, decode the output.
 drun $FILE --instruction-limit 99999999999999 \
     | awk '{ print $3 }' \
-    | grep "44.*" -o \
-    | xargs didc decode
+    | grep "44.*" -o

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1,10 +1,13 @@
 use bitcoin::consensus::Decodable;
 use bitcoin::{consensus::Encodable, Block as BitcoinBlock, BlockHeader};
+use candid::CandidType;
 use ic_btc_canister::{types::BlockHeaderBlob, with_state_mut};
 use ic_btc_interface::{Config, Network};
 use ic_btc_types::Block;
 use ic_cdk_macros::{init, query};
-use std::cell::RefCell;
+use maplit::btreemap;
+use serde::Deserialize;
+use std::{cell::RefCell, collections::BTreeMap};
 
 thread_local! {
     static TESTNET_BLOCKS: RefCell<Vec<Block>> =  RefCell::new(vec![]);
@@ -29,14 +32,14 @@ fn init() {
 
 // Benchmarks inserting the first 300 blocks of the Bitcoin testnet.
 #[query]
-fn insert_300_blocks() -> u64 {
+fn insert_300_blocks() -> BenchResult {
     ic_btc_canister::init(Config {
         network: Network::Testnet,
         stability_threshold: 144,
         ..Config::default()
     });
 
-    count_instructions(|| {
+    benchmark(|| {
         with_state_mut(|s| {
             for i in 0..300 {
                 ic_btc_canister::state::insert_block(
@@ -51,7 +54,7 @@ fn insert_300_blocks() -> u64 {
 
 // Benchmarks gettings the metrics when there are many unstable blocks..
 #[query]
-fn get_metrics() -> u64 {
+fn get_metrics() -> BenchResult {
     ic_btc_canister::init(Config {
         network: Network::Testnet,
         stability_threshold: 3000,
@@ -68,14 +71,14 @@ fn get_metrics() -> u64 {
         }
     });
 
-    count_instructions(|| {
+    benchmark(|| {
         ic_btc_canister::get_metrics();
     })
 }
 
 // Benchmarks inserting 100 block headers into a tree containing 1000 blocks
 #[query]
-fn insert_block_headers() -> u64 {
+fn insert_block_headers() -> BenchResult {
     let blocks_to_insert = 1000;
     let block_headers_to_insert = 100;
 
@@ -110,7 +113,7 @@ fn insert_block_headers() -> u64 {
     });
 
     // Benchmark inserting the block headers.
-    count_instructions(|| {
+    benchmark(|| {
         with_state_mut(|s| {
             ic_btc_canister::state::insert_next_block_headers(s, next_block_headers.as_slice());
         });
@@ -119,7 +122,7 @@ fn insert_block_headers() -> u64 {
 
 // Inserts the same block headers multiple times.
 #[query]
-fn insert_block_headers_multiple_times() -> u64 {
+fn insert_block_headers_multiple_times() -> BenchResult {
     ic_btc_canister::init(Config {
         network: Network::Testnet,
         ..Config::default()
@@ -140,7 +143,7 @@ fn insert_block_headers_multiple_times() -> u64 {
     });
 
     // Benchmark inserting the block headers.
-    count_instructions(|| {
+    benchmark(|| {
         with_state_mut(|s| {
             for _ in 0..10 {
                 ic_btc_canister::state::insert_next_block_headers(s, next_block_headers.as_slice());
@@ -149,11 +152,23 @@ fn insert_block_headers_multiple_times() -> u64 {
     })
 }
 
-// Returns the number of instructions consumed by the given function.
-fn count_instructions<R>(f: impl FnOnce() -> R) -> u64 {
+#[derive(Debug, PartialEq, Deserialize, CandidType)]
+pub struct BenchResult {
+    measurements: BTreeMap<String, u64>,
+}
+
+/// Benchmarks the given function.
+pub(crate) fn benchmark<R>(f: impl FnOnce() -> R) -> BenchResult {
     let start = ic_cdk::api::performance_counter(0);
     f();
-    ic_cdk::api::performance_counter(0) - start
+    let total_instructions = ic_cdk::api::performance_counter(0) - start;
+
+    let measurements = btreemap! {
+        "instructions".to_string() => total_instructions,
+        "stable_memory_size".to_string() => ic_cdk::api::stable::stable64_size()
+    };
+
+    BenchResult { measurements }
 }
 
 fn main() {}

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -25,6 +25,11 @@ serde_bytes = { workspace = true }
 name = "ic-btc-canister"
 path = "src/main.rs"
 
+# There are no benchmarks in the library itself, so by default it's turned off
+# to avoid having `cargo bench` look for benchmarks there.
+[lib]
+bench = false
+
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
 bitcoin = { workspace = true, features = ["rand"] } # needed for generating secp256k1 keys.


### PR DESCRIPTION
Replaces `criterion` with our own custom logic for reporting benchmarks. Our own benchmarking reporting offers a number of advantages over `criterion`:

* A simple file for persisting benchmark results across commits.
* The ability to track multiple measurements (e.g. instruction counts and memory)
* An option to persist the results at your leisure (criterion always persists)