### PR TITLE
docs: Update development-guide.md

### DIFF
--- a/development-guide.md
+++ b/development-guide.md
@@ -40,4 +40,5 @@ Only after all the expected canisters were deployed the `pre-release` can be tur
 4. Attach the Bitcoin Canister's and Watchdog's WASM to the release notes (and nothing else).
     - Add calculated checksums into release notes
 5. Finalize the release once all the expected canisters were upgraded
+    - (Optionally) provide links to corresponding NNS proposals
     - Uncheck `Set as a pre-release` box to indicate that it's all deployed

--- a/development-guide.md
+++ b/development-guide.md
@@ -6,30 +6,15 @@ The canisters in this repository are deployed in production by submitting propos
 
 Below are the steps needed to cut a release:
 
-### Bitcoin Canister
-
 1. Locally, from the same commit as the release is intended, build the canisters by running `docker build -t canisters .`.
 2. Extract the wasm of the Bitcoin Canister by running `docker run --rm --entrypoint cat canisters /ic-btc-canister.wasm.gz > ic-btc-canister.wasm.gz`.
-3. Compute the checksum of the canister by running `sha256sum ic-btc-canister.wasm.gz`.
-4. On the [releases page](https://github.com/dfinity/bitcoin-canister/releases), click on "Draft a new release". Make sure the right commit is selected.
-5. Create a new tag with the name: `release/<yyyy-mm-dd>`.
-6. Set the title to be: `Bitcoin Canister Release (<yyyy-mm-dd>)`.
-7. Add release notes. Github can generate the release notes by clicking on "Generated Release Notes". Modify as needed.
-8. Add the commit hash of the Bitcoin Canister's wasm from step 3 to the release notes.
-9. Attach the Bitcoin Canister's wasm to the release notes (and nothing else).
-10. Check the "Set as a pre-release" box to indicate that this release hasn't been deployed to production yet.
-11. Once the Bitcoin mainnet canister is upgraded to this version, uncheck the "Set as a pre-release" box to indicate that it's deployed.
-
-### Watchdog Canister
-
-1. Locally, from the same commit as the release is intended, build the canisters by running `docker build -t canisters .`.
-2. Extract the wasm of the Watchdog Canister by running `docker run --rm --entrypoint cat canisters /watchdog-canister.wasm.gz > watchdog-canister.wasm.gz`.
-3. Compute the checksum of the canister by running `sha256sum watchdog-canister.wasm.gz`.
-4. On the [releases page](https://github.com/dfinity/bitcoin-canister/releases), click on "Draft a new release". Make sure the right commit is selected.
-5. Create a new tag with the name: `watchdog/release/<yyyy-mm-dd>`.
-6. Set the title to be: `Watchdog Canister Release (<yyyy-mm-dd>)`.
-7. Add release notes. Github can generate the release notes by clicking on "Generated Release Notes". Modify as needed.
-8. Add the commit hash of the Watchdog Canister's wasm from step 3 to the release notes.
-9. Attach the Watchdog Canister's wasm to the release notes (and nothing else).
-10. Check the "Set as a pre-release" box to indicate that this release hasn't been deployed to production yet.
-11. Once the Watchdog for the Bitcoin mainnet canister is upgraded to this version, uncheck the "Set as a pre-release" box to indicate that it's deployed.
+3. Extract the wasm of the Watchdog Canister by running `docker run --rm --entrypoint cat canisters /watchdog-canister.wasm.gz > watchdog-canister.wasm.gz`.
+4. Compute the checksum of the canister by running `sha256sum ic-btc-canister.wasm.gz`.
+5. Compute the checksum of the canister by running `sha256sum watchdog-canister.wasm.gz`.
+6. On the [releases page](https://github.com/dfinity/bitcoin-canister/releases), click on "Draft a new release". Make sure the right commit is selected.
+7. Create a new tag with the name: `release/<yyyy-mm-dd>`.
+8. Set the title to be: `Release (<yyyy-mm-dd>)`.
+9. Add release notes. Github can generate the release notes by clicking on "Generated Release Notes". Modify as needed.
+10. Attach the Bitcoin Canister's and Watchdog's wasm to the release notes (and nothing else).
+11. Check the "Set as a pre-release" box to indicate that this release hasn't been deployed to production yet.
+12. Once the Bitcoin mainnet canister and watchdog mainnet is upgraded to this version, uncheck the "Set as a pre-release" box to indicate that it's deployed.

--- a/development-guide.md
+++ b/development-guide.md
@@ -37,7 +37,7 @@ Only after all the expected canisters were deployed the `pre-release` can be tur
     ic-btc-canister.wasm.gz  watchdog-canister.wasm.gz
 
     # Compute checksums.
-    $ sha256sum ic-btc-canister.wasm.gz watchdog-canister.wasm.gz
+    $ sha256sum *.wasm.gz
     09f5647a45ff6d5d05b2b0ed48613fb2365b5fe6573ba0e901509c39fb9564ac  ic-btc-canister.wasm.gz
     cc58b2a32517f9907f0d3c77bc8c099d0a65d8194a8d9bc0ad7df357ee867a07  watchdog-canister.wasm.gz
     ```

--- a/development-guide.md
+++ b/development-guide.md
@@ -23,7 +23,7 @@ Only after all the expected canisters were deployed the `pre-release` can be tur
     # Checkout the repo with a given commit.
     $ git clone https://github.com/dfinity/bitcoin-canister &&\
         cd bitcoin-canister &&\
-        git checkout aff3eef
+        git checkout aff3eef  # <- make sure the right commit is provided.
 
     # Use docker to reproducibly build canister WASMs.
     $ docker build -t canisters .

--- a/development-guide.md
+++ b/development-guide.md
@@ -1,20 +1,46 @@
 # Development Guide
 
-## Preparing Releases
+## Release Preparation
 
 The canisters in this repository are deployed in production by submitting proposals to the Internet Computer's [Network Nervous System](https://internetcomputer.org/nns).
 
-Below are the steps needed to cut a release:
+Due to limitations in GitHub's release handling, we cannot create separate latest releases for the Bitcoin canister and the Watchdog canister. Therefore, we include both artifacts in each latest release. 
 
-1. Locally, from the same commit as the release is intended, build the canisters by running `docker build -t canisters .`.
-2. Extract the wasm of the Bitcoin Canister by running `docker run --rm --entrypoint cat canisters /ic-btc-canister.wasm.gz > ic-btc-canister.wasm.gz`.
-3. Extract the wasm of the Watchdog Canister by running `docker run --rm --entrypoint cat canisters /watchdog-canister.wasm.gz > watchdog-canister.wasm.gz`.
-4. Compute the checksum of the canister by running `sha256sum ic-btc-canister.wasm.gz`.
-5. Compute the checksum of the canister by running `sha256sum watchdog-canister.wasm.gz`.
-6. On the [releases page](https://github.com/dfinity/bitcoin-canister/releases), click on "Draft a new release". Make sure the right commit is selected.
-7. Create a new tag with the name: `release/<yyyy-mm-dd>`.
-8. Set the title to be: `Release (<yyyy-mm-dd>)`.
-9. Add release notes. Github can generate the release notes by clicking on "Generated Release Notes". Modify as needed.
-10. Attach the Bitcoin Canister's and Watchdog's wasm to the release notes (and nothing else).
-11. Check the "Set as a pre-release" box to indicate that this release hasn't been deployed to production yet.
-12. Once the Bitcoin mainnet canister and watchdog mainnet is upgraded to this version, uncheck the "Set as a pre-release" box to indicate that it's deployed.
+Only after all the expected canisters were deployed the `pre-release` can be turned into a proper `latest release`.
+
+## Steps to Cut a Release
+
+1. Identify the commit for the release, eg. `aff3eef`
+2. Draft a new pre-release
+    - Click on `Draft a new release` at the [releases page](https://github.com/dfinity/bitcoin-canister/releases), make sure the right commit is selected
+    - Create a new tag with the name `release/<yyyy-mm-dd>`
+    - Set the title to be `release/<yyyy-mm-dd>`
+    - Check the `Set as a pre-release` box to indicate that this release has not been deployed to production yet
+    - Add release notes. Github can generate the release notes by clicking on `Generated Release Notes`, modify as needed
+3. Prepare canister WASM files and compute their checksums
+    - **Note**: there is no guarantee on Mac M1 for reproducible build, preferably use Ubuntu
+    ```shell
+    # Checkout the repo with a given commit.
+    $ git clone https://github.com/dfinity/bitcoin-canister &&\
+        cd bitcoin-canister &&\
+        git checkout aff3eef
+
+    # Use docker to reproducibly build canister WASMs.
+    $ docker build -t canisters .
+
+    # Extract WASM files.
+    $ docker run --rm --entrypoint cat canisters /ic-btc-canister.wasm.gz > ic-btc-canister.wasm.gz
+    $ docker run --rm --entrypoint cat canisters /watchdog-canister.wasm.gz > watchdog-canister.wasm.gz
+
+    # Verify that the files are present.
+    $ ls *.wasm.gz
+    ic-btc-canister.wasm.gz  watchdog-canister.wasm.gz
+
+    # Compute checksums.
+    $ sha256sum ic-btc-canister.wasm.gz watchdog-canister.wasm.gz
+    09f5647a45ff6d5d05b2b0ed48613fb2365b5fe6573ba0e901509c39fb9564ac  ic-btc-canister.wasm.gz
+    cc58b2a32517f9907f0d3c77bc8c099d0a65d8194a8d9bc0ad7df357ee867a07  watchdog-canister.wasm.gz
+    ```
+4. Attach the Bitcoin Canister's and Watchdog's WASM to the release notes (and nothing else).
+5. Finalize the release once all the expected canisters were upgraded
+    - Uncheck `Set as a pre-release` box to indicate that it's all deployed

--- a/development-guide.md
+++ b/development-guide.md
@@ -42,5 +42,6 @@ Only after all the expected canisters were deployed the `pre-release` can be tur
     cc58b2a32517f9907f0d3c77bc8c099d0a65d8194a8d9bc0ad7df357ee867a07  watchdog-canister.wasm.gz
     ```
 4. Attach the Bitcoin Canister's and Watchdog's WASM to the release notes (and nothing else).
+    - Add calculated checksums into release notes
 5. Finalize the release once all the expected canisters were upgraded
     - Uncheck `Set as a pre-release` box to indicate that it's all deployed

--- a/development-guide.md
+++ b/development-guide.md
@@ -32,10 +32,6 @@ Only after all the expected canisters were deployed the `pre-release` can be tur
     $ docker run --rm --entrypoint cat canisters /ic-btc-canister.wasm.gz > ic-btc-canister.wasm.gz
     $ docker run --rm --entrypoint cat canisters /watchdog-canister.wasm.gz > watchdog-canister.wasm.gz
 
-    # Verify that the files are present.
-    $ ls *.wasm.gz
-    ic-btc-canister.wasm.gz  watchdog-canister.wasm.gz
-
     # Compute checksums.
     $ sha256sum *.wasm.gz
     09f5647a45ff6d5d05b2b0ed48613fb2365b5fe6573ba0e901509c39fb9564ac  ic-btc-canister.wasm.gz

--- a/development-guide.md
+++ b/development-guide.md
@@ -18,7 +18,7 @@ Only after all the expected canisters were deployed the `pre-release` can be tur
     - Check the `Set as a pre-release` box to indicate that this release has not been deployed to production yet
     - Add release notes. Github can generate the release notes by clicking on `Generated Release Notes`, modify as needed
 3. Prepare canister WASM files and compute their checksums
-    - **Note**: there is no guarantee on Mac M1 for reproducible build, preferably use Ubuntu
+    - **Note**: there is no reproducibility guarantee on Mac M1s, preferably use Ubuntu or Intel Macs
     ```shell
     # Checkout the repo with a given commit.
     $ git clone https://github.com/dfinity/bitcoin-canister &&\
@@ -41,4 +41,4 @@ Only after all the expected canisters were deployed the `pre-release` can be tur
     - Add calculated checksums into release notes
 5. Finalize the release once all the expected canisters were upgraded
     - (Optional) Provide links to corresponding NNS proposals
-    - Uncheck `Set as a pre-release` box to indicate that it's all deployed
+    - Uncheck `Set as a pre-release` box and check `Set as the latest release ` to indicate that the release is fully deployed

--- a/development-guide.md
+++ b/development-guide.md
@@ -40,5 +40,5 @@ Only after all the expected canisters were deployed the `pre-release` can be tur
 4. Attach the Bitcoin Canister's and Watchdog's WASM to the release notes (and nothing else).
     - Add calculated checksums into release notes
 5. Finalize the release once all the expected canisters were upgraded
-    - (Optionally) provide links to corresponding NNS proposals
+    - (Optional) Provide links to corresponding NNS proposals
     - Uncheck `Set as a pre-release` box to indicate that it's all deployed


### PR DESCRIPTION
Github doesn't have a good flow for handling releases for two different artifacts. For example, we cannot have a release marked as the latest release for the Bitcoin canister and a different release marked as the latest release for the watchdog canister.

Instead, we now always release the Bitcoin canister and watchdog canister together, and they'll all need to be re-deployed in the case of a new release.

If there happens to be only modifications in one of the binaries, say, the watchdog canister, then in theory the Wasm for the Bitcoin canister would be unchanged, and would therefore not need a release.