### PR TITLE
chore: enable watchdog_health_status test on CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -595,10 +595,9 @@ jobs:
       - name: check benchmark result
         if: ${{ needs.benchmark.result != 'success' }}
         run: exit 1
-      # After EXC-1514 (fixing watchdog_health_status test) remove comments.
-      #- name: check watchdog_health_status result
-      #  if: ${{ needs.watchdog_health_status.result != 'success' }}
-      #  run: exit 1
+      - name: check watchdog_health_status result
+        if: ${{ needs.watchdog_health_status.result != 'success' }}
+        run: exit 1
       - name: check watchdog_get_config result
         if: ${{ needs.watchdog_get_config.result != 'success' }}
         run: exit 1


### PR DESCRIPTION
This PR enables `watchdog_health_status` test on CI, the test was fixed in previous PR.