### PR TITLE
fix: make the bitcoin testnet watchdog less sensitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "ic-btc-interface"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "candid 0.10.0",
  "ciborium",

--- a/dfx.json
+++ b/dfx.json
@@ -13,6 +13,12 @@
       "build": "./scripts/build-canister.sh watchdog-canister",
       "wasm": "./target/wasm32-unknown-unknown/release/watchdog-canister.wasm.gz"
     },
+    "watchdog-health-status-test": {
+      "type": "custom",
+      "candid": "./watchdog/candid.did",
+      "build": "./scripts/build-canister.sh watchdog-canister health_status_test",
+      "wasm": "./target/wasm32-unknown-unknown/release/watchdog-canister.wasm.gz"
+    },
     "watchdog-upgradability-test": {
       "type": "custom",
       "candid": "./watchdog/candid.did",

--- a/scripts/build-canister.sh
+++ b/scripts/build-canister.sh
@@ -22,7 +22,7 @@ if [[ -z "$FEATURES" ]]; then
   cargo build --bin "$CANISTER" --target "$TARGET" --release
 else
   # Features provided
-  cargo build --bin "$CANISTER" --target "$TARGET" --release --features $FEATURES
+  cargo build --bin "$CANISTER" --target "$TARGET" --release --features "$FEATURES"
 fi
 
 # Navigate to root directory.

--- a/scripts/build-canister.sh
+++ b/scripts/build-canister.sh
@@ -5,6 +5,7 @@ TARGET="wasm32-unknown-unknown"
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 CANISTER=$1
+FEATURES=${2:-}
 
 pushd "$SCRIPT_DIR"
 
@@ -16,7 +17,13 @@ if [ "$(uname)" == "Darwin" ]; then
   export CC="${LLVM_PATH}/bin/clang"
 fi
 
-cargo build --bin "$CANISTER" --target "$TARGET" --release
+if [[ -z "$FEATURES" ]]; then
+  # No features provided
+  cargo build --bin "$CANISTER" --target "$TARGET" --release
+else
+  # Features provided
+  cargo build --bin "$CANISTER" --target "$TARGET" --release --features $FEATURES
+fi
 
 # Navigate to root directory.
 cd ..

--- a/watchdog/Cargo.toml
+++ b/watchdog/Cargo.toml
@@ -25,6 +25,9 @@ ic-http = { workspace = true }
 serde_bytes = { workspace = true }
 ic-btc-interface = { workspace = true }
 
+[features]
+health_status_test = []
+
 [dev-dependencies]
 tokio = { workspace = true }
 assert-json-diff = "2.0.2"

--- a/watchdog/candid.did
+++ b/watchdog/candid.did
@@ -95,7 +95,7 @@ type flag = variant {
     disabled;
 };
 
-service : (opt config) -> {
+service : (bitcoin_network) -> {
     /// Returns the health status of the Bitcoin canister.
     health_status : () -> (health_status) query;
 

--- a/watchdog/e2e-tests/health_status.sh
+++ b/watchdog/e2e-tests/health_status.sh
@@ -13,7 +13,7 @@ trap "dfx stop" EXIT SIGINT
 dfx start --background --clean
 
 # Deploy the watchdog canister.
-deploy_watchdog_canister_mainnet
+dfx deploy --no-wallet watchdog-health-status-test --argument "(variant { mainnet })"
 
 # Check health status has specific fields.
 check_health_status_fields

--- a/watchdog/e2e-tests/upgradability.sh
+++ b/watchdog/e2e-tests/upgradability.sh
@@ -14,22 +14,7 @@ set -Eexuo pipefail
 REFERENCE_CANISTER_NAME="watchdog-upgradability-test"
 BITCOIN_NETWORK=mainnet
 BITCOIN_CANISTER_ID=ghsi2-tqaaa-aaaan-aaaca-cai
-ARGUMENT="(opt record {
-  bitcoin_network = variant { ${BITCOIN_NETWORK} };
-  blocks_behind_threshold = 2;
-  blocks_ahead_threshold = 2;
-  min_explorers = 3;
-  bitcoin_canister_principal = principal \"${BITCOIN_CANISTER_ID}\";
-  delay_before_first_fetch_sec = 1;
-  interval_between_fetches_sec = 300;
-  explorers = vec {
-    variant { api_blockchair_com_mainnet };
-    variant { api_blockcypher_com_mainnet };
-    variant { blockchain_info_mainnet };
-    variant { blockstream_info_mainnet };
-    variant { chain_api_btc_com_mainnet };
-  };
-})"
+ARGUMENT="(variant { mainnet })"
 
 # Source the utility functions.
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

--- a/watchdog/e2e-tests/upgradability.sh
+++ b/watchdog/e2e-tests/upgradability.sh
@@ -12,8 +12,6 @@ set -Eexuo pipefail
 
 # Constants.
 REFERENCE_CANISTER_NAME="watchdog-upgradability-test"
-BITCOIN_NETWORK=mainnet
-BITCOIN_CANISTER_ID=ghsi2-tqaaa-aaaan-aaaca-cai
 ARGUMENT="(variant { mainnet })"
 
 # Source the utility functions.

--- a/watchdog/e2e-tests/utils.sh
+++ b/watchdog/e2e-tests/utils.sh
@@ -2,8 +2,6 @@
 
 # Function to deploy the watchdog canister for mainnet bitcoin_canister.
 deploy_watchdog_canister_mainnet() {
-  BITCOIN_NETWORK=mainnet
-  BITCOIN_CANISTER_ID=ghsi2-tqaaa-aaaan-aaaca-cai
   dfx deploy --no-wallet watchdog --argument "(variant { mainnet })"
 }
 

--- a/watchdog/e2e-tests/utils.sh
+++ b/watchdog/e2e-tests/utils.sh
@@ -4,22 +4,7 @@
 deploy_watchdog_canister_mainnet() {
   BITCOIN_NETWORK=mainnet
   BITCOIN_CANISTER_ID=ghsi2-tqaaa-aaaan-aaaca-cai
-  dfx deploy --no-wallet watchdog --argument "(opt record {
-    bitcoin_network = variant { ${BITCOIN_NETWORK} };
-    blocks_behind_threshold = 2;
-    blocks_ahead_threshold = 2;
-    min_explorers = 2;
-    bitcoin_canister_principal = principal \"${BITCOIN_CANISTER_ID}\";
-    delay_before_first_fetch_sec = 1;
-    interval_between_fetches_sec = 300;
-    explorers = vec {
-      variant { api_blockchair_com_mainnet };
-      variant { api_blockcypher_com_mainnet };
-      variant { blockchain_info_mainnet };
-      variant { blockstream_info_mainnet };
-      variant { chain_api_btc_com_mainnet };
-    };
-  })"
+  dfx deploy --no-wallet watchdog --argument "(variant { mainnet })"
 }
 
 # Function to get watchdog canister metrics.

--- a/watchdog/e2e-tests/utils.sh
+++ b/watchdog/e2e-tests/utils.sh
@@ -43,7 +43,7 @@ check_health_status_fields() {
     "explorers"
   )
   
-  health_status=$(dfx canister call watchdog health_status --query)
+  health_status=$(dfx canister call watchdog-health-status-test health_status --query)
   for field in "${FIELDS[@]}"; do
     if ! [[ $health_status == *"$field = "* ]]; then
       echo "FAIL: $field not found in health status of ${0##*/}"
@@ -59,7 +59,7 @@ check_health_status_data() {
   has_enough_data=0
   for ((i=1; i<=ITERATIONS; i++))
   do
-    health_status=$(dfx canister call watchdog health_status --query)
+    health_status=$(dfx canister call watchdog-health-status-test health_status --query)
     if ! [[ $health_status == *"height_status = variant { not_enough_data }"* ]]; then
       has_enough_data=1
       break

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -3,12 +3,6 @@ use candid::CandidType;
 use candid::Principal;
 use serde::{Deserialize, Serialize};
 
-/// The minimum number of explorers to compare against.
-#[cfg(not(feature = "health_status_test"))]
-const MIN_EXPLORERS: u64 = 3;
-#[cfg(feature = "health_status_test")]
-const MIN_EXPLORERS: u64 = 2;
-
 /// Mainnet bitcoin canister principal.
 const MAINNET_BITCOIN_CANISTER_PRINCIPAL: &str = "ghsi2-tqaaa-aaaan-aaaca-cai";
 
@@ -62,6 +56,14 @@ pub struct Config {
 impl Config {
     /// Creates a new configuration for the mainnet.
     pub fn mainnet() -> Self {
+        #[cfg(not(feature = "health_status_test"))]
+        const MIN_EXPLORERS: u64 = 3;
+
+        // Due to dfx not supporting ipv4, only two explorers support ipv6 and
+        // can be part of the health_status_test.
+        #[cfg(feature = "health_status_test")]
+        const MIN_EXPLORERS: u64 = 2;
+
         Self {
             bitcoin_network: BitcoinNetwork::Mainnet,
             blocks_behind_threshold: 2,
@@ -88,13 +90,12 @@ impl Config {
             bitcoin_network: BitcoinNetwork::Testnet,
             blocks_behind_threshold: 100,
             blocks_ahead_threshold: 100,
-            min_explorers: MIN_EXPLORERS,
+            min_explorers: 2,
             bitcoin_canister_principal: Principal::from_text(TESTNET_BITCOIN_CANISTER_PRINCIPAL)
                 .unwrap(),
             delay_before_first_fetch_sec: DELAY_BEFORE_FIRST_FETCH_SEC,
             interval_between_fetches_sec: INTERVAL_BETWEEN_FETCHES_SEC,
             explorers: vec![
-                BitcoinBlockApi::ApiBitapsComTestnet,
                 BitcoinBlockApi::ApiBlockchairComTestnet,
                 BitcoinBlockApi::ApiBlockcypherComTestnet,
                 BitcoinBlockApi::BlockstreamInfoTestnet,

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -3,16 +3,6 @@ use candid::CandidType;
 use candid::Principal;
 use serde::{Deserialize, Serialize};
 
-/// The Bitcoin network to use.
-const BITCOIN_NETWORK: BitcoinNetwork = BitcoinNetwork::Mainnet;
-
-/// Below this threshold, the canister is considered to be behind.
-/// This value is positive, but it will be converted to negative.
-const BLOCKS_BEHIND_THRESHOLD: u64 = 2;
-
-/// Above this threshold, the canister is considered to be ahead.
-const BLOCKS_AHEAD_THRESHOLD: u64 = 2;
-
 /// The minimum number of explorers to compare against.
 const MIN_EXPLORERS: u64 = 3;
 
@@ -67,20 +57,12 @@ pub struct Config {
 }
 
 impl Config {
-    /// Creates a new configuration depending on the Bitcoin network.
-    pub fn new() -> Self {
-        match BITCOIN_NETWORK {
-            BitcoinNetwork::Mainnet => Self::mainnet(),
-            BitcoinNetwork::Testnet => Self::testnet(),
-        }
-    }
-
     /// Creates a new configuration for the mainnet.
     pub fn mainnet() -> Self {
         Self {
             bitcoin_network: BitcoinNetwork::Mainnet,
-            blocks_behind_threshold: BLOCKS_BEHIND_THRESHOLD,
-            blocks_ahead_threshold: BLOCKS_AHEAD_THRESHOLD,
+            blocks_behind_threshold: 2,
+            blocks_ahead_threshold: 2,
             min_explorers: MIN_EXPLORERS,
             bitcoin_canister_principal: Principal::from_text(MAINNET_BITCOIN_CANISTER_PRINCIPAL)
                 .unwrap(),
@@ -101,8 +83,8 @@ impl Config {
     pub fn testnet() -> Self {
         Self {
             bitcoin_network: BitcoinNetwork::Testnet,
-            blocks_behind_threshold: BLOCKS_BEHIND_THRESHOLD,
-            blocks_ahead_threshold: BLOCKS_AHEAD_THRESHOLD,
+            blocks_behind_threshold: 100,
+            blocks_ahead_threshold: 100,
             min_explorers: MIN_EXPLORERS,
             bitcoin_canister_principal: Principal::from_text(TESTNET_BITCOIN_CANISTER_PRINCIPAL)
                 .unwrap(),
@@ -131,12 +113,6 @@ impl Config {
     pub fn get_bitcoin_canister_endpoint(&self) -> String {
         let principal = self.bitcoin_canister_principal.to_text();
         format!("https://{principal}.raw.ic0.app/metrics")
-    }
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -4,7 +4,10 @@ use candid::Principal;
 use serde::{Deserialize, Serialize};
 
 /// The minimum number of explorers to compare against.
+#[cfg(not(feature = "health_status_test"))]
 const MIN_EXPLORERS: u64 = 3;
+#[cfg(feature = "health_status_test")]
+const MIN_EXPLORERS: u64 = 2;
 
 /// Mainnet bitcoin canister principal.
 const MAINNET_BITCOIN_CANISTER_PRINCIPAL: &str = "ghsi2-tqaaa-aaaan-aaaca-cai";

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -96,6 +96,8 @@ impl Config {
             delay_before_first_fetch_sec: DELAY_BEFORE_FIRST_FETCH_SEC,
             interval_between_fetches_sec: INTERVAL_BETWEEN_FETCHES_SEC,
             explorers: vec![
+                // NOTE: Disabled due to flakiness.
+                // BitcoinBlockApi::ApiBitapsComTestnet,
                 BitcoinBlockApi::ApiBlockchairComTestnet,
                 BitcoinBlockApi::ApiBlockcypherComTestnet,
                 BitcoinBlockApi::BlockstreamInfoTestnet,

--- a/watchdog/src/fetch.rs
+++ b/watchdog/src/fetch.rs
@@ -101,10 +101,6 @@ mod test {
             result,
             vec![
                 BlockInfo {
-                    provider: BitcoinBlockApi::ApiBitapsComTestnet,
-                    height: Some(2000001),
-                },
-                BlockInfo {
                     provider: BitcoinBlockApi::ApiBlockchairComTestnet,
                     height: Some(2000002),
                 },
@@ -174,10 +170,6 @@ mod test {
         assert_eq!(
             result,
             vec![
-                BlockInfo {
-                    provider: BitcoinBlockApi::ApiBitapsComTestnet,
-                    height: None,
-                },
                 BlockInfo {
                     provider: BitcoinBlockApi::ApiBlockchairComTestnet,
                     height: None,


### PR DESCRIPTION
Sets the threshold for blocks ahead/behind from +/- 2 to +/- 100 for bitcoin testnet given that bitcoin testnet often has surges in blocks when the difficulty is low.

The configs of the watchdog canister were not being maintained in this repo, and instead were only maintained in the NNS proposals. After a discussion with @maksymar, we agreed to maintain the configurations here instead to make them easier to review and track.

As a result, the watchdog canister has now been updated to require a bitcoin network when being initialized, and based on that network it'll use the hard-coded bitcoin mainnet/testnet config.