### PR TITLE
chore: bump dfx from 0.15.2 to 0.16.0

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,7 +2,7 @@ name: CI Checks
 
 env:
   RUST_VERSION: 1.68.0
-  DFX_VERSION: 0.15.2
+  DFX_VERSION: 0.16.0
 
 on:
   push:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,7 +1,7 @@
 name: CI Checks
 
 env:
-  RUST_VERSION: 1.68.0
+  RUST_VERSION: 1.70.0
   DFX_VERSION: 0.16.0
 
 on:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM ubuntu@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3
 
 # NOTE: if this version is updated, then the version in rust-toolchain.toml
 # should be updated as well.
-ARG rust_version=1.68.0
+ARG rust_version=1.70.0
 
 # Setting the timezone and installing the necessary dependencies
 ENV TZ=UTC

--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.15.2",
+  "dfx": "0.16.0",
   "canisters": {
     "bitcoin": {
       "type": "custom",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # NOTE: if this version is updated, then the version in the Dockerfile should
 # also be updated.
-channel = "1.68.0"
+channel = "1.70.0"
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
This PR updates dfx version from 0.15.2 to 0.16.0.

This is a preparation to fix IPv4 support for HTTP outcall tests of watchdog canister.