### PR TITLE
chore: upgrade rust from 1.70 to 1.76

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,7 +1,7 @@
 name: CI Checks
 
 env:
-  RUST_VERSION: 1.68.0
+  RUST_VERSION: 1.76.0
   DFX_VERSION: 0.15.2
 
 on:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ members = [
     "ic-http/example_canister/src/canister_backend",
 ]
 
+resolver = "2"
+
 [workspace.dependencies]
 bitcoin = "0.28.1"
 byteorder = "1.4.3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM ubuntu@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3
 
 # NOTE: if this version is updated, then the version in rust-toolchain.toml
 # should be updated as well.
-ARG rust_version=1.68.0
+ARG rust_version=1.76.0
 
 # Setting the timezone and installing the necessary dependencies
 ENV TZ=UTC

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -106,7 +106,7 @@ fn insert_block_headers() -> BenchResult {
             let mut block_header_blob = vec![];
             BlockHeader::consensus_encode(blocks[i as usize].header(), &mut block_header_blob)
                 .unwrap();
-            next_block_headers.push(BlockHeaderBlob::try_from(block_header_blob).unwrap());
+            next_block_headers.push(BlockHeaderBlob::from(block_header_blob));
         }
 
         next_block_headers
@@ -136,7 +136,7 @@ fn insert_block_headers_multiple_times() -> BenchResult {
             let mut block_header_blob = vec![];
             BlockHeader::consensus_encode(blocks[i as usize].header(), &mut block_header_blob)
                 .unwrap();
-            next_block_headers.push(BlockHeaderBlob::try_from(block_header_blob).unwrap());
+            next_block_headers.push(BlockHeaderBlob::from(block_header_blob));
         }
 
         next_block_headers

--- a/canister/src/api/set_config.rs
+++ b/canister/src/api/set_config.rs
@@ -152,10 +152,7 @@ mod test {
                 ..Default::default()
             });
 
-            assert_eq!(
-                with_state(|s| s.syncing_state.syncing),
-                *flag
-            );
+            assert_eq!(with_state(|s| s.syncing_state.syncing), *flag);
         }
     }
 
@@ -205,10 +202,7 @@ mod test {
                 ..Default::default()
             });
 
-            assert_eq!(
-                with_state(|s| s.api_access),
-                *flag
-            );
+            assert_eq!(with_state(|s| s.api_access), *flag);
         }
     }
 

--- a/canister/src/unstable_blocks/next_block_headers.rs
+++ b/canister/src/unstable_blocks/next_block_headers.rs
@@ -13,7 +13,7 @@ pub struct NextBlockHeaders {
 impl NextBlockHeaders {
     pub fn insert(&mut self, block_header: BlockHeader, height: Height) {
         let block_hash = BlockHash::from(block_header.block_hash());
-        let hash_vec = self.height_to_hash.entry(height).or_insert_with(Vec::new);
+        let hash_vec = self.height_to_hash.entry(height).or_default();
 
         if !hash_vec.contains(&block_hash) {
             hash_vec.push(block_hash.clone());

--- a/canister/src/utxo_set/utxos.rs
+++ b/canister/src/utxo_set/utxos.rs
@@ -137,9 +137,7 @@ impl Utxos {
             return Some(<(TxOut, Height)>::from_bytes(value.as_slice().to_vec()));
         }
 
-        self.large_utxos
-            .remove(key)
-            .map(|(txout, height)| (txout, height))
+        self.large_utxos.remove(key)
     }
 
     /// Gets an iterator over the entries of the map.

--- a/canister/src/utxo_set/utxos_delta.rs
+++ b/canister/src/utxo_set/utxos_delta.rs
@@ -33,7 +33,7 @@ impl UtxosDelta {
     pub fn insert(&mut self, address: Address, outpoint: OutPoint, tx_out: TxOut, height: Height) {
         self.added_outpoints
             .entry(address.clone())
-            .or_insert(BTreeSet::new())
+            .or_default()
             .insert(outpoint.clone());
 
         self.all_added_outpoints.insert(outpoint.clone(), address);
@@ -65,7 +65,7 @@ impl UtxosDelta {
 
         self.removed_outpoints
             .entry(address)
-            .or_insert(BTreeSet::new())
+            .or_default()
             .insert(outpoint.clone());
 
         self.all_removed_outpoints.insert(outpoint.clone());

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-# NOTE: if this version is updated, then the version in the Dockerfile should
-# also be updated.
-channel = "1.68.0"
+# NOTE: if this version is updated, then the version in the Dockerfile and CI
+# should also be updated.
+channel = "1.76.0"
 targets = ["wasm32-unknown-unknown"]

--- a/watchdog/src/bitcoin_block_apis.rs
+++ b/watchdog/src/bitcoin_block_apis.rs
@@ -495,7 +495,7 @@ mod test {
         .collect();
         let all_providers = BitcoinBlockApi::providers_mainnet()
             .into_iter()
-            .chain(BitcoinBlockApi::providers_testnet().into_iter())
+            .chain(BitcoinBlockApi::providers_testnet())
             .collect::<Vec<_>>();
         for provider in all_providers {
             assert_eq!(provider.to_string(), expected[&provider].to_string());


### PR DESCRIPTION
Introducing `canbench` requires a newer version of rust, so we first upgrade to the latest version in this commit.