### PR TITLE
feat (EXC-1590): make burning cycles configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 target
 .dfx
 canister_ids.json
+.canbench
 
 *.wasm.gz

--- a/canister/candid.did
+++ b/canister/candid.did
@@ -35,6 +35,7 @@ type config = record {
   api_access : flag;
   disable_api_if_not_fully_synced : flag;
   watchdog_canister : opt principal;
+  burn_cycles : flag;
 };
 
 type fees = record {
@@ -89,6 +90,7 @@ type set_config_request = record {
   api_access : opt flag;
   disable_api_if_not_fully_synced : opt flag;
   watchdog_canister : opt opt principal;
+  burn_cycles : opt bool;
 };
 
 service bitcoin : (config) -> {

--- a/canister/candid.did
+++ b/canister/candid.did
@@ -90,7 +90,7 @@ type set_config_request = record {
   api_access : opt flag;
   disable_api_if_not_fully_synced : opt flag;
   watchdog_canister : opt opt principal;
-  burn_cycles : opt bool;
+  burn_cycles : opt flag;
 };
 
 service bitcoin : (config) -> {

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -18,9 +18,7 @@ use ic_btc_types::{Block, BlockHash};
 pub async fn heartbeat() {
     print("Starting heartbeat...");
 
-    // Burn any cycles in the canister's balance (to count towards the IC's cycles burn rate)
-    let cycles_burnt = cycles_burn();
-    add_cycles_burnt_to_metric(cycles_burnt);
+    maybe_burn_cycles();
 
     if ingest_stable_blocks_into_utxoset() {
         // Exit the heartbeat if stable blocks had been ingested.
@@ -241,6 +239,14 @@ fn add_cycles_burnt_to_metric(cycles_burnt: u128) {
             s.metrics.cycles_burnt = Some(cycles_burnt);
         }
     });
+}
+
+/// Burns any cycles in the canister's balance (to count towards the IC's cycles burn rate).
+fn maybe_burn_cycles() {
+    if with_state(|s| s.burn_cycles == Flag::Enabled) {
+        let cycles_burnt = cycles_burn();
+        add_cycles_burnt_to_metric(cycles_burnt);
+    }
 }
 
 #[cfg(test)]

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -93,6 +93,7 @@ pub fn init(config: Config) {
     with_state_mut(|s| s.syncing_state.syncing = config.syncing);
     with_state_mut(|s| s.disable_api_if_not_fully_synced = config.disable_api_if_not_fully_synced);
     with_state_mut(|s| s.watchdog_canister = config.watchdog_canister);
+    with_state_mut(|s| s.burn_cycles = config.burn_cycles);
     with_state_mut(|s| s.fees = config.fees);
 }
 
@@ -143,6 +144,7 @@ pub fn get_config() -> Config {
         api_access: s.api_access,
         disable_api_if_not_fully_synced: s.disable_api_if_not_fully_synced,
         watchdog_canister: s.watchdog_canister,
+        burn_cycles: s.burn_cycles,
     })
 }
 

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -60,6 +60,12 @@ pub struct State {
     /// The watchdog canister has the authority to disable the Bitcoin canister's API
     /// if it suspects that there is a problem.
     pub watchdog_canister: Option<Principal>,
+
+    /// If enabled, continuously burns all cycles in the canister's balance
+    /// to count towards the IC's burn rate.
+    /// NOTE: serde(default) is used here for backward-compatibility.
+    #[serde(default)]
+    pub burn_cycles: Flag,
 }
 
 impl State {
@@ -85,6 +91,7 @@ impl State {
             api_access: Flag::Enabled,
             disable_api_if_not_fully_synced: Flag::Enabled,
             watchdog_canister: None,
+            burn_cycles: Flag::Disabled,
         }
     }
 

--- a/e2e-tests/upgradability.sh
+++ b/e2e-tests/upgradability.sh
@@ -32,6 +32,7 @@ ARGUMENT="(record {
  api_access = variant { enabled };
  disable_api_if_not_fully_synced = variant { enabled };
  watchdog_canister = null;
+ burn_cycles = variant { enabled };
 })"
 
 # Run dfx stop if we run into errors and remove the downloaded wasm.

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -472,7 +472,7 @@ pub enum Flag {
     Disabled,
 }
 
-/// The payload used to initialize the canister.
+/// The config and payload used to initialize the canister.
 #[derive(CandidType, Deserialize, Debug)]
 pub struct Config {
     pub stability_threshold: u128,
@@ -499,6 +499,10 @@ pub struct Config {
     /// The watchdog canister has the authority to disable the Bitcoin canister's API
     /// if it suspects that there is a problem.
     pub watchdog_canister: Option<Principal>,
+
+    /// If enabled, continuously burns all cycles in its balance
+    /// (to count towards the IC's burn rate).
+    pub burn_cycles: Flag,
 }
 
 impl Default for Config {
@@ -512,6 +516,7 @@ impl Default for Config {
             api_access: Flag::Enabled,
             disable_api_if_not_fully_synced: Flag::Enabled,
             watchdog_canister: None,
+            burn_cycles: Flag::Disabled,
         }
     }
 }


### PR DESCRIPTION
# Problem
The latest version of the Bitcoin canister automatically burns all cycles it receives. DFX is unable to upgrade to that version since deploying it on a local app subnet immediately results in it being uninstalled.

# Solution
Make burning cycles configurable, such that DFX can disable it when deploying the Bitcoin canister locally.