### PR TITLE
fix: canbench can run in dependabot PRs (part 1)

### DIFF
--- a/.github/workflows/canbench-post-comment.yml
+++ b/.github/workflows/canbench-post-comment.yml
@@ -1,0 +1,38 @@
+name: Post Canbench results
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  download-results:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-benchmarks.outputs.matrix }}
+      pr_number: ${{ steps.set-benchmarks.outputs.pr_number }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - id: set-benchmarks
+        run: bash ./scripts/canbench_ci_download_canbench.sh
+
+  post-comment:
+    runs-on: ubuntu-latest
+    needs: [download-results]
+    strategy:
+      matrix: ${{fromJSON(needs.download-results.outputs.matrix)}}
+    steps:
+      - name: Post comment
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            ${{ matrix.benchmark.result }}
+          comment_tag: ${{ matrix.benchmark.title }}
+          pr_number: ${{ needs.download-results.outputs.pr_number }}
+

--- a/scripts/canbench_ci_download_artifacts.sh
+++ b/scripts/canbench_ci_download_artifacts.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -Eexuo pipefail
+
+# Identifies the benchmarks provided in the artifacts and outputs them.
+
+json_array="["
+# Loop through each file with prefix "canbench_result_" in the current directory
+for file in canbench_result_*; do
+if [ -e "$file" ]; then  # Check if the file exists.
+  # Read the content of the file, escaping double quotes and adding escaped newlines
+  content=$(<"$file/$file" sed 's/"/\\"/g' | awk '{printf "%s\\n", $0}' | sed '$ s/\\n$//')
+
+  # Construct a JSON object for the current file with "title" and "result" keys
+  json_object="{\"title\":\"$file\",\"result\":\"$content\"},"
+
+  # Append the JSON object to the array string
+  json_array+="$json_object"
+fi
+done
+
+# Remove the trailing comma from the JSON array string
+json_array=${json_array%,}
+
+# Close the JSON array string
+json_array+="]"
+
+# Output the benchmarks and PR number to be used by the next job.
+echo "matrix={\"benchmark\": $json_array}" >> "$GITHUB_OUTPUT"
+echo "pr_number=$(cat ./pr_number/pr_number)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
CI for dependabot PRs like #288 are failing because `canbench` doesn't have the right permissions set up to post a comment with the benchmarking results.

This PR, and a follow-up one, will update CI to fix those permissions as we had done in the `stable-structures` and `canbench` repos.