### PR TITLE
fix: panic when building bitcoin state in bootstrap script

### DIFF
--- a/bootstrap/state-builder/src/build_address_utxos.rs
+++ b/bootstrap/state-builder/src/build_address_utxos.rs
@@ -91,8 +91,7 @@ fn main() {
                     )
                     .unwrap(),
                     (),
-                )
-                .unwrap();
+                );
         }
     }
 

--- a/bootstrap/state-builder/src/build_address_utxos.rs
+++ b/bootstrap/state-builder/src/build_address_utxos.rs
@@ -75,23 +75,22 @@ fn main() {
         if let Some(address) = address {
             let address: Address = address.into();
 
-            address_utxos
-                .insert(
-                    Blob::try_from(
-                        AddressUtxo {
-                            address,
-                            height,
-                            outpoint: OutPoint {
-                                txid: txid.clone(),
-                                vout,
-                            },
-                        }
-                        .to_bytes()
-                        .as_ref(),
-                    )
-                    .unwrap(),
-                    (),
-                );
+            address_utxos.insert(
+                Blob::try_from(
+                    AddressUtxo {
+                        address,
+                        height,
+                        outpoint: OutPoint {
+                            txid: txid.clone(),
+                            vout,
+                        },
+                    }
+                    .to_bytes()
+                    .as_ref(),
+                )
+                .unwrap(),
+                (),
+            );
         }
     }
 

--- a/bootstrap/state-builder/src/build_balances.rs
+++ b/bootstrap/state-builder/src/build_balances.rs
@@ -94,7 +94,7 @@ fn main() {
 
     // Write the balances into a stable btreemap.
     for (address, amount) in balances.into_iter() {
-        stable_balances.insert(address, amount).unwrap();
+        stable_balances.insert(address, amount);
     }
 
     println!("Writing stable structure to file...");


### PR DESCRIPTION
When trying to build the bitcoin state from the bootstrap scripts, the last step (`./6_compute_canister_state.sh`) fails with the following:

```
Shuffling...
Writing to stable structure...
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', bootstrap/state-builder/src/build_balances.rs:97:49
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This is because, previously `insert` on `StableBTreeMap` returned a result. Currently, `insert` doesn't fail and that unwrap is no longer needed.