### PR TITLE
chore: reduce the max instructions of heartbeats from 4B to 2B

### DIFF
--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -391,7 +391,7 @@ mod test {
 
         // Set a large step for the performance_counter to exceed the instructions limit quickly.
         // This value allows ingesting 3 inputs/outputs per round.
-        runtime::set_performance_counter_step(1_000_000_000);
+        runtime::set_performance_counter_step(500_000_000);
 
         // Fetch blocks.
         heartbeat().await;
@@ -508,7 +508,7 @@ mod test {
 
         // Set a large step for the performance_counter to exceed the instructions limit quickly.
         // This value allows ingesting 3 transactions inputs/outputs per round.
-        runtime::set_performance_counter_step(1_000_000_000);
+        runtime::set_performance_counter_step(500_000_000);
 
         // Fetch blocks.
         heartbeat().await;

--- a/canister/src/tests.rs
+++ b/canister/src/tests.rs
@@ -461,7 +461,7 @@ async fn time_slices_large_block_with_multiple_transactions() {
 
     // Set a large step for the performance_counter to exceed the instructions limit quickly.
     // This value allows ingesting 2 transactions inputs/outputs per round.
-    runtime::set_performance_counter_step(1_500_000_000);
+    runtime::set_performance_counter_step(750_000_000);
 
     // Fetch blocks.
     heartbeat().await;

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -555,8 +555,9 @@ impl PartialEq for UtxoSet {
 // Checks that we're not approaching the instructions limit.
 fn default_should_time_slice() -> Box<dyn FnMut() -> bool> {
     // The threshold at which time slicing kicks in.
-    // At the time of this writing it is equivalent to 80% of the maximum instructions limit.
-    const MAX_INSTRUCTIONS_THRESHOLD: u64 = 4_000_000_000;
+    // At the time of this writing it is equivalent to 40% of the maximum instructions limit.
+    // NOTE: We've reduced this limit from 4B to 2B in an effort to keep the FR stable.
+    const MAX_INSTRUCTIONS_THRESHOLD: u64 = 2_000_000_000;
 
     // NOTE: We're using `inc_performance_counter` here to also increment the mock performance
     // counter in the unit tests.


### PR DESCRIPTION
In an effort to make the FR of the Bitcoin subnet more stable, we reduce the amount of instructions we aim to execute in a single heartbeat execution from 4B instructions to 2B instructions. The hypothesis is that this will lead to a higher and more stable FR overall.