### PR TITLE
chore: update threshold of watchdog testnet canister

### DIFF
--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -80,8 +80,8 @@ impl Config {
     pub fn testnet() -> Self {
         Self {
             bitcoin_network: BitcoinNetwork::Testnet,
-            blocks_behind_threshold: 100,
-            blocks_ahead_threshold: 100,
+            blocks_behind_threshold: 1000,
+            blocks_ahead_threshold: 1000,
             min_explorers: 2,
             bitcoin_canister_principal: Principal::from_text(TESTNET_BITCOIN_CANISTER_PRINCIPAL)
                 .unwrap(),


### PR DESCRIPTION
With recent block surges it's becoming more common for the bitcoin testnet to be ahead of external block explorers. To avoid disabling the bitcoin testnet API for extended periods of time, this commit makes the watchdog less sensitive to differences in height between the bitcoin testnet canister and external explorers, making it less likely for it to disable the Bitcoin API for developers.