### PR TITLE
fix: [EXC-1611] script name in github action

### DIFF
--- a/.github/workflows/canbench-post-comment.yml
+++ b/.github/workflows/canbench-post-comment.yml
@@ -20,7 +20,7 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
 
       - id: set-benchmarks
-        run: bash ./scripts/canbench_ci_download_canbench.sh
+        run: bash ./scripts/canbench_ci_download_artifacts.sh
 
   post-comment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The script used in the workflow file that posts the canbench comment has a typo in it. Unfortunately can't be tested within the same PR, and so these errors aren't always possible to catch in advance.