### PR TITLE
bench: measure memory usage when serializing unstable blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "hex",
  "ic-btc-canister",
  "ic-btc-interface",
+ "ic-btc-test-utils",
  "ic-btc-types",
  "ic-cdk 0.12.1",
  "ic-cdk-macros 0.8.4",
@@ -467,9 +468,9 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "canbench-rs"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5d551419a1547b5064111df7bfa6e87818750e7f6df611067a02e63a9cbb31"
+checksum = "53574f268dbe23dc83f891a4751b118a6ba927c8bc92e839ff108f3aaf151aa9"
 dependencies = [
  "canbench-rs-macros",
  "candid 0.10.8",
@@ -479,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs-macros"
-version = "0.1.0"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5acd4a41fd2e7018508f7442d7ae90957a913c6fa0e4b767e5be9a8cc5848c8"
+checksum = "d454906c77138a3802a7a680259cca7c006e9b268ba6905f7f4f2b8b74293fa4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1439,6 +1440,7 @@ dependencies = [
  "async-std",
  "bitcoin",
  "byteorder",
+ "canbench-rs",
  "candid 0.10.8",
  "candid_parser",
  "ciborium",
@@ -1476,6 +1478,7 @@ name = "ic-btc-test-utils"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
+ "ic-btc-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ resolver = "2"
 [workspace.dependencies]
 bitcoin = "0.28.1"
 byteorder = "1.4.3"
+canbench-rs = { version = "0.1.1" }
 candid = "0.10.6"
 candid_parser = { version = "0.1.4" }
 ciborium = "0.2.1"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -10,7 +10,7 @@ bench = false
 
 [dependencies]
 bitcoin = { workspace = true, features = ["use-serde"]}
-canbench-rs = "0.1.4"
+canbench-rs = { workspace = true }
 candid = { workspace = true }
 hex = { workspace = true }
 ic-cdk = { workspace = true }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -10,11 +10,12 @@ bench = false
 
 [dependencies]
 bitcoin = { workspace = true, features = ["use-serde"]}
-canbench-rs = "0.1.1"
+canbench-rs = "0.1.4"
 candid = { workspace = true }
 hex = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
-ic-btc-canister = { workspace = true }
+ic-btc-canister = { workspace = true, features = ["canbench-rs"] }
 ic-btc-interface = { workspace = true }
+ic-btc-test-utils = { workspace = true }
 ic-btc-types = { workspace = true }

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -162,8 +162,8 @@ fn pre_upgrade_with_many_unstable_blocks() -> BenchResult {
 
     // Insert the blocks.
     with_state_mut(|s| {
-        for idx in 1..blocks.len() {
-            ic_btc_canister::state::insert_block(s, blocks[idx].clone()).unwrap();
+        for block in blocks.into_iter().skip(1) {
+            ic_btc_canister::state::insert_block(s, block).unwrap();
         }
     });
 

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -1,26 +1,44 @@
 benches:
   get_metrics:
     total:
-      instructions: 86997911
+      instructions: 86997217
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   insert_300_blocks:
     total:
-      instructions: 561768522
+      instructions: 561767322
       heap_increase: 6
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers:
     total:
-      instructions: 3895777371
+      instructions: 3895777071
       heap_increase: 2
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers_multiple_times:
     total:
-      instructions: 13898429217
+      instructions: 13898426217
       heap_increase: 7
       stable_memory_increase: 0
     scopes: {}
+  pre_upgrade_with_many_unstable_blocks:
+    total:
+      instructions: 10241277202
+      heap_increase: 10005
+      stable_memory_increase: 2944
+    scopes:
+      serialize_blocktree:
+        instructions: 6556144810
+        heap_increase: 5908
+        stable_memory_increase: 0
+      serialize_blocktree_flatten:
+        instructions: 735757574
+        heap_increase: 1802
+        stable_memory_increase: 0
+      serialize_blocktree_serialize:
+        instructions: 5820385168
+        heap_increase: 4106
+        stable_memory_increase: 0
 version: 0.1.1

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -25,20 +25,20 @@ benches:
     scopes: {}
   pre_upgrade_with_many_unstable_blocks:
     total:
-      instructions: 10241277202
-      heap_increase: 10005
+      instructions: 10240847648
+      heap_increase: 9995
       stable_memory_increase: 2944
     scopes:
       serialize_blocktree:
-        instructions: 6556144810
-        heap_increase: 5908
+        instructions: 6555715256
+        heap_increase: 5898
         stable_memory_increase: 0
       serialize_blocktree_flatten:
-        instructions: 735757574
-        heap_increase: 1802
+        instructions: 735694725
+        heap_increase: 1792
         stable_memory_increase: 0
       serialize_blocktree_serialize_seq:
-        instructions: 5820385168
+        instructions: 5820018463
         heap_increase: 4106
         stable_memory_increase: 0
 version: 0.1.1

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -37,7 +37,7 @@ benches:
         instructions: 735757574
         heap_increase: 1802
         stable_memory_increase: 0
-      serialize_blocktree_serialize:
+      serialize_blocktree_serialize_seq:
         instructions: 5820385168
         heap_increase: 4106
         stable_memory_increase: 0

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 bitcoin = { workspace = true, features = ["use-serde"] }
 # An optional dependency to benchmark parts of the code.
-canbench-rs = { version = "0.1.4", optional = true }
+canbench-rs = { workspace = true, optional = true }
 candid = { workspace = true }
 ciborium = { workspace = true }
 hex = { workspace = true }

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 
 [dependencies]
 bitcoin = { workspace = true, features = ["use-serde"] }
+# An optional dependency to benchmark parts of the code.
+canbench-rs = { version = "0.1.4", optional = true }
 candid = { workspace = true }
 ciborium = { workspace = true }
 hex = { workspace = true }

--- a/canister/src/blocktree/serde.rs
+++ b/canister/src/blocktree/serde.rs
@@ -13,6 +13,9 @@ use std::fmt;
 // overflow if the structure is very deep.
 impl Serialize for BlockTree {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[cfg(feature = "canbench-rs")]
+        let _p = canbench_rs::bench_scope("serialize_blocktree");
+
         // Flatten a block tree into a list.
         fn flatten(tree: &BlockTree, flattened_tree: &mut Vec<(Block, usize)>) {
             flattened_tree.push((tree.root.clone(), tree.children.len()));
@@ -23,7 +26,14 @@ impl Serialize for BlockTree {
         }
 
         let mut flattened_tree = vec![];
-        flatten(self, &mut flattened_tree);
+        {
+            #[cfg(feature = "canbench-rs")]
+            let _p = canbench_rs::bench_scope("serialize_blocktree_flatten");
+            flatten(self, &mut flattened_tree);
+        }
+
+        #[cfg(feature = "canbench-rs")]
+        let _p = canbench_rs::bench_scope("serialize_blocktree_serialize");
 
         let mut seq = serializer.serialize_seq(Some(flattened_tree.len()))?;
         for e in flattened_tree {

--- a/canister/src/blocktree/serde.rs
+++ b/canister/src/blocktree/serde.rs
@@ -33,7 +33,7 @@ impl Serialize for BlockTree {
         }
 
         #[cfg(feature = "canbench-rs")]
-        let _p = canbench_rs::bench_scope("serialize_blocktree_serialize");
+        let _p = canbench_rs::bench_scope("serialize_blocktree_serialize_seq");
 
         let mut seq = serializer.serialize_seq(Some(flattened_tree.len()))?;
         for e in flattened_tree {

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -286,8 +286,8 @@ pub(crate) fn is_synced() -> bool {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test_utils::build_regtest_chain;
     use ic_btc_interface::{Network, NetworkInRequest};
+    use ic_btc_test_utils::build_regtest_chain;
     use proptest::prelude::*;
 
     proptest! {

--- a/canister/src/test_utils.rs
+++ b/canister/src/test_utils.rs
@@ -71,18 +71,6 @@ pub fn build_chain(
     )
 }
 
-/// Builds a random chain with the given number of block and transactions
-/// and starting with the Regtest genesis block.
-pub fn build_regtest_chain(num_blocks: u32, num_transactions_per_block: u32) -> Vec<Block> {
-    let network = Network::Regtest;
-    build_chain_with_genesis_block(
-        network,
-        genesis_block(network),
-        num_blocks,
-        num_transactions_per_block,
-    )
-}
-
 fn build_chain_with_genesis_block(
     network: Network,
     genesis_block: Block,

--- a/scripts/canbench_ci_run_benchmark.sh
+++ b/scripts/canbench_ci_run_benchmark.sh
@@ -22,7 +22,7 @@ CANBENCH_RESULTS_FILE="$CANISTER_PATH/canbench_results.yml"
 MAIN_BRANCH_RESULTS_FILE="$MAIN_BRANCH_DIR/$CANBENCH_RESULTS_FILE"
 
 # Install canbench
-cargo install canbench
+cargo install canbench --version 0.1.1
 
 # Verify that canbench results are available.
 if [ ! -f "$CANBENCH_RESULTS_FILE" ]; then

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -11,3 +11,4 @@ repository = "https://github.com/dfinity/bitcoin-canister"
 
 [dependencies]
 bitcoin = {version = "0.28.1", features = ["rand"]} # needed for generating secp256k1 keys.
+ic-btc-types = { workspace = true }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -81,7 +81,7 @@ impl BlockBuilder {
 }
 
 /// Builds a random chain with the given number of block and transactions
-/// and starting with the Regtest genesis block.
+/// starting with the Regtest genesis block.
 pub fn build_regtest_chain(num_blocks: u32, num_transactions_per_block: u32) -> Vec<Block> {
     let genesis_block = Block::new(genesis_block(Network::Regtest));
 


### PR DESCRIPTION
Adds a benchmark to measure how much heap memory is being used when upgrading with a large number of unstable blocks. This is the codepath that we'll need to optimize in order to avoid running out of heap memory in the future.