### PR TITLE
chore: Upgrade bitcoin to version 0.32.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +291,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
 
 [[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals",
+ "bitcoin_hashes",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,9 +320,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bech32"
-version = "0.8.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "beef"
@@ -321,6 +337,7 @@ dependencies = [
  "bitcoin",
  "canbench-rs",
  "candid 0.10.8",
+ "getrandom 0.2.10",
  "hex",
  "ic-btc-canister",
  "ic-btc-interface",
@@ -370,22 +387,55 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcoin"
-version = "0.28.2"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d30fb43d287492017964a1fd7d3f82e8cc760818471c6ef2d44111e317d5c3"
+checksum = "ea507acc1cd80fc084ace38544bbcf7ced7c2aa65b653b102de0ce718df668f6"
 dependencies = [
+ "base58ck",
  "bech32",
+ "bitcoin-internals",
+ "bitcoin-io",
+ "bitcoin-units",
  "bitcoin_hashes",
+ "hex-conservative",
+ "hex_lit",
  "secp256k1",
  "serde",
 ]
 
 [[package]]
-name = "bitcoin_hashes"
-version = "0.10.0"
+name = "bitcoin-internals"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006cc91e1a1d99819bc5b8214be3555c1f0611b169f527a1fdc54ed1f2b745b0"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "340e09e8399c7bd8912f495af6aa58bea0c9214773417ffaa8f6460f93aaee56"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
  "serde",
 ]
 
@@ -394,6 +444,18 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -453,6 +515,12 @@ name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "byteorder"
@@ -899,6 +967,7 @@ version = "0.1.0"
 dependencies = [
  "bitcoin",
  "candid 0.10.8",
+ "getrandom 0.2.10",
  "ic-btc-test-utils",
  "ic-cdk 0.12.1",
  "ic-cdk-macros 0.8.4",
@@ -1026,6 +1095,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,6 +1142,12 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1301,6 +1388,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec 0.7.4",
+]
+
+[[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,6 +1593,7 @@ dependencies = [
  "ic-btc-interface",
  "ic-btc-validation",
  "ic-stable-structures",
+ "primitive-types",
  "serde",
  "serde_bytes",
 ]
@@ -1502,6 +1605,7 @@ dependencies = [
  "bitcoin",
  "csv",
  "hex",
+ "primitive-types",
  "proptest 0.9.6",
 ]
 
@@ -1645,6 +1749,26 @@ checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2075,6 +2199,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "parity-scale-codec"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2287753623c76f953acd29d15d8100bcab84d29db78fb6f352adb3c53e83b967"
+dependencies = [
+ "arrayvec 0.7.4",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6937b5e67bfba3351b87b040d48352a2fcb6ad72f81855412ce97b45c8f110"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "parking"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,7 +2364,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad9940b913ee56ddd94aec2d3cd179dd47068236f42a1a6415ccf9d880ce2a61"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "typed-arena",
 ]
 
@@ -2224,9 +2374,20 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563c9d701c3a31dfffaaf9ce23507ba09cbe0b9125ba176d15e629b0235e9acc"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "typed-arena",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
 ]
 
 [[package]]
@@ -2311,6 +2472,12 @@ checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2650,6 +2817,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
 name = "rustix"
 version = "0.37.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2783,6 +2956,7 @@ version = "0.1.0"
 dependencies = [
  "bitcoin",
  "candid 0.10.8",
+ "getrandom 0.2.10",
  "ic-btc-test-utils",
  "ic-cdk 0.12.1",
  "ic-cdk-macros 0.8.4",
@@ -2795,6 +2969,7 @@ version = "0.1.0"
 dependencies = [
  "bitcoin",
  "candid 0.10.8",
+ "getrandom 0.2.10",
  "ic-btc-test-utils",
  "ic-cdk 0.12.1",
  "ic-cdk-macros 0.8.4",
@@ -2854,20 +3029,21 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.22.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295642060261c80709ac034f52fca8e5a9fa2c7d341ded5cdb164b7c33768b2a"
+checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
- "rand 0.6.5",
+ "bitcoin_hashes",
+ "rand 0.8.5",
  "secp256k1-sys",
  "serde",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.5.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
+checksum = "1433bd67156263443f14d603720b082dd3121779323fce20cba2aa07b874bc1b"
 dependencies = [
  "cc",
 ]
@@ -3129,6 +3305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,6 +3379,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -3441,6 +3629,18 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "unarray"
@@ -3884,6 +4084,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-bitcoin = "0.28.1"
+bitcoin = "0.32.2"
 byteorder = "1.4.3"
 canbench-rs = { version = "0.1.1" }
 candid = "0.10.6"
@@ -34,6 +34,7 @@ candid_parser = { version = "0.1.4" }
 ciborium = "0.2.1"
 clap = { version = "4.0.11", features = ["derive"] }
 futures = "0.3.28"
+getrandom = { version = "0.2", default-features = false, features = ["custom"] }
 hex = "0.4.3"
 ic-btc-canister = { path = "./canister" }
 ic-btc-interface = { path = "./interface" }
@@ -46,6 +47,7 @@ ic-http = { path = "./ic-http" }
 ic-metrics-encoder = "1.0.0"
 ic-stable-structures = "0.5.2"
 lazy_static = "1.4.0"
+primitive-types = "0.12"
 serde = "1.0.171"
 serde_bytes = "0.11"
 serde_json = "1.0.94"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -9,9 +9,10 @@ path = "src/main.rs"
 bench = false
 
 [dependencies]
-bitcoin = { workspace = true, features = ["use-serde"]}
+bitcoin = { workspace = true, features = ["serde"]}
 canbench-rs = { workspace = true }
 candid = { workspace = true }
+getrandom = { workspace = true }
 hex = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1,5 +1,5 @@
 use bitcoin::consensus::Decodable;
-use bitcoin::{consensus::Encodable, Block as BitcoinBlock, BlockHeader};
+use bitcoin::{block::Header as BlockHeader, consensus::Encodable, Block as BitcoinBlock};
 use canbench_rs::{bench, bench_fn, BenchResult};
 use ic_btc_canister::{types::BlockHeaderBlob, with_state_mut};
 use ic_btc_interface::{InitConfig, Network};
@@ -22,7 +22,7 @@ fn init() {
                 .split('\n')
                 .map(|block_hex| {
                     let block_bytes = hex::decode(block_hex).unwrap();
-                    Block::new(BitcoinBlock::consensus_decode(block_bytes.as_slice()).unwrap())
+                    Block::new(BitcoinBlock::consensus_decode(&mut block_bytes.as_slice()).unwrap())
                 })
                 .collect(),
         );
@@ -173,3 +173,8 @@ fn pre_upgrade_with_many_unstable_blocks() -> BenchResult {
 }
 
 fn main() {}
+
+getrandom::register_custom_getrandom!(always_fail);
+pub fn always_fail(_buf: &mut [u8]) -> Result<(), getrandom::Error> {
+    Err(getrandom::Error::UNSUPPORTED)
+}

--- a/bootstrap/main-state-builder/Cargo.lock
+++ b/bootstrap/main-state-builder/Cargo.lock
@@ -55,16 +55,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "bech32"
-version = "0.8.1"
+name = "base58ck"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals",
+ "bitcoin_hashes",
+]
+
+[[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "binread"
@@ -91,22 +107,55 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.28.2"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d30fb43d287492017964a1fd7d3f82e8cc760818471c6ef2d44111e317d5c3"
+checksum = "ea507acc1cd80fc084ace38544bbcf7ced7c2aa65b653b102de0ce718df668f6"
 dependencies = [
+ "base58ck",
  "bech32",
+ "bitcoin-internals",
+ "bitcoin-io",
+ "bitcoin-units",
  "bitcoin_hashes",
+ "hex-conservative",
+ "hex_lit",
  "secp256k1",
  "serde",
 ]
 
 [[package]]
-name = "bitcoin_hashes"
-version = "0.10.0"
+name = "bitcoin-internals"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006cc91e1a1d99819bc5b8214be3555c1f0611b169f527a1fdc54ed1f2b745b0"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "340e09e8399c7bd8912f495af6aa58bea0c9214773417ffaa8f6460f93aaee56"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
  "serde",
 ]
 
@@ -368,6 +417,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec 0.7.4",
+]
+
+[[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
 name = "ic-btc-canister"
 version = "0.1.0"
 dependencies = [
@@ -389,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "ic-btc-interface"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "candid",
  "serde",
@@ -585,7 +649,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563c9d701c3a31dfffaaf9ce23507ba09cbe0b9125ba176d15e629b0235e9acc"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "typed-arena",
  "unicode-segmentation",
 ]
@@ -639,19 +703,20 @@ checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "secp256k1"
-version = "0.22.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295642060261c80709ac034f52fca8e5a9fa2c7d341ded5cdb164b7c33768b2a"
+checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
+ "bitcoin_hashes",
  "secp256k1-sys",
  "serde",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.5.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
+checksum = "1433bd67156263443f14d603720b082dd3121779323fce20cba2aa07b874bc1b"
 dependencies = [
  "cc",
 ]

--- a/bootstrap/main-state-builder/Cargo.toml
+++ b/bootstrap/main-state-builder/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bitcoin = "0.28.1"
+bitcoin = "0.32.2"
 clap = { version = "4.0.11", features = ["derive"] }
 ciborium = "0.2.1"
 hex = "0.4.3"

--- a/bootstrap/main-state-builder/src/main.rs
+++ b/bootstrap/main-state-builder/src/main.rs
@@ -61,7 +61,7 @@ fn read_block(reader: &mut BufReader<File>) -> Block {
     let mut block = String::new();
     reader.read_line(&mut block).unwrap();
     let block = hex::decode(block.replace('\n', "")).unwrap();
-    Block::new(BitcoinBlock::consensus_decode(block.as_slice()).unwrap())
+    Block::new(BitcoinBlock::consensus_decode(&mut block.as_slice()).unwrap())
 }
 
 fn main() {

--- a/bootstrap/state-builder/src/build_address_utxos.rs
+++ b/bootstrap/state-builder/src/build_address_utxos.rs
@@ -6,7 +6,7 @@
 //!   --network testnet \
 //!   --output balances.bin \
 //!   --utxos-dump-path utxos-dump.csv
-use bitcoin::{Address as BitcoinAddress, Script, Txid as BitcoinTxid};
+use bitcoin::{Address as BitcoinAddress, ScriptBuf, Txid as BitcoinTxid};
 use clap::Parser;
 use ic_btc_canister::types::{into_bitcoin_network, Address, AddressUtxo};
 use ic_btc_interface::Network;
@@ -51,7 +51,7 @@ fn main() {
         let line = line.unwrap();
         let parts: Vec<_> = line.split(',').collect();
 
-        let txid = Txid::from(BitcoinTxid::from_str(parts[1]).unwrap().to_vec());
+        let txid = Txid::from(BitcoinTxid::from_str(parts[1]).unwrap().as_ref());
         let vout: u32 = parts[2].parse().unwrap();
         let address_str = parts[5];
         let height: u32 = parts[0].parse().unwrap();
@@ -63,16 +63,16 @@ fn main() {
 
         // Load the address. The UTXO dump tool we use doesn't output all the addresses
         // we support, so if parsing the address itself fails, we try parsing the script directly.
-        let address = if let Ok(address) = BitcoinAddress::from_str(address_str) {
-            Some(address)
-        } else {
-            BitcoinAddress::from_script(
-                &Script::from(hex::decode(script).expect("script must be valid hex")),
-                into_bitcoin_network(args.network),
-            )
-        };
+        let address = BitcoinAddress::from_str(address_str)
+            .map(|address| address.assume_checked())
+            .or_else(|_| {
+                BitcoinAddress::from_script(
+                    &ScriptBuf::from(hex::decode(script).expect("script must be valid hex")),
+                    into_bitcoin_network(args.network),
+                )
+            });
 
-        if let Some(address) = address {
+        if let Ok(address) = address {
             let address: Address = address.into();
 
             address_utxos

--- a/bootstrap/state-builder/src/build_utxos.rs
+++ b/bootstrap/state-builder/src/build_utxos.rs
@@ -6,7 +6,7 @@
 //!   --network testnet \
 //!   --output output-dir \
 //!   --utxos-dump-path utxos-dump.csv
-use bitcoin::{Address, Txid as BitcoinTxid};
+use bitcoin::{Address, Amount, Txid as BitcoinTxid};
 use clap::Parser;
 use ic_btc_canister::{types::TxOut, with_state, with_state_mut};
 use ic_btc_interface::{Flag, InitConfig, Network};
@@ -81,7 +81,7 @@ fn main() {
             let line = line.unwrap();
             let parts: Vec<_> = line.split(',').collect();
 
-            let txid = Txid::from(BitcoinTxid::from_str(parts[1]).unwrap().to_vec());
+            let txid = Txid::from(BitcoinTxid::from_str(parts[1]).unwrap().as_ref());
             let vout: u32 = parts[2].parse().unwrap();
             let amount: u64 = parts[3].parse().unwrap();
             let script = parts[6];
@@ -96,15 +96,15 @@ fn main() {
             // Instead of using the scripts from the database, we can infer the script from the
             // address. Otherwise, we use the script in the chainstate database as-is.
             let script = match Address::from_str(address_str) {
-                Ok(address) => address.script_pubkey().as_bytes().to_vec(),
+                Ok(address) => address.assume_checked().script_pubkey().as_bytes().to_vec(),
                 Err(_) => hex::decode(script).unwrap(),
             };
 
             // Insert the UTXO
             let outpoint = OutPoint { txid, vout };
-            if !bitcoin::Script::from(script.clone()).is_provably_unspendable() {
+            if !bitcoin::ScriptBuf::from(script.clone()).is_op_return() {
                 let txout = TxOut {
-                    value: amount,
+                    value: Amount::from_sat(amount),
                     script_pubkey: script,
                 };
 

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -1,25 +1,25 @@
 benches:
   get_metrics:
     total:
-      instructions: 84790855
+      instructions: 93349358
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   insert_300_blocks:
     total:
-      instructions: 567851159
+      instructions: 567848759
       heap_increase: 7
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers:
     total:
-      instructions: 3913081716
+      instructions: 3913080916
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers_multiple_times:
     total:
-      instructions: 13975569957
+      instructions: 13975563882
       heap_increase: 7
       stable_memory_increase: 0
     scopes: {}

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -1,36 +1,36 @@
 benches:
   get_metrics:
     total:
-      instructions: 86997214
+      instructions: 84790855
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   insert_300_blocks:
     total:
-      instructions: 561767622
-      heap_increase: 6
+      instructions: 567851159
+      heap_increase: 7
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers:
     total:
-      instructions: 3895777071
-      heap_increase: 2
+      instructions: 3913081716
+      heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers_multiple_times:
     total:
-      instructions: 13898426217
+      instructions: 13975569957
       heap_increase: 7
       stable_memory_increase: 0
     scopes: {}
   pre_upgrade_with_many_unstable_blocks:
     total:
-      instructions: 5809876449
+      instructions: 5795439685
       heap_increase: 4097
       stable_memory_increase: 1792
     scopes:
       serialize_blocktree:
-        instructions: 2382106854
+        instructions: 2366746456
         heap_increase: 2048
         stable_memory_increase: 0
       serialize_blocktree_flatten:
@@ -38,7 +38,7 @@ benches:
         heap_increase: 0
         stable_memory_increase: 0
       serialize_blocktree_serialize_seq:
-        instructions: 2381902913
+        instructions: 2366542515
         heap_increase: 2048
         stable_memory_increase: 0
 version: 0.1.1

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoin = { workspace = true, features = ["use-serde"] }
+bitcoin = { workspace = true, features = ["serde"] }
 # An optional dependency to benchmark parts of the code.
 canbench-rs = { workspace = true, optional = true }
 candid = { workspace = true }

--- a/canister/src/address_utxoset.rs
+++ b/canister/src/address_utxoset.rs
@@ -67,7 +67,7 @@ impl<'a> AddressUtxoSet<'a> {
                 });
             self.added_utxos.insert(Utxo {
                 outpoint: outpoint.clone(),
-                value: txout.value,
+                value: txout.value.to_sat(),
                 height,
             });
         }
@@ -96,7 +96,7 @@ impl<'a> AddressUtxoSet<'a> {
                 Utxo {
                     outpoint,
                     height,
-                    value: tx_out.value,
+                    value: tx_out.value.to_sat(),
                 }
             });
 

--- a/canister/src/api/get_balance.rs
+++ b/canister/src/api/get_balance.rs
@@ -69,7 +69,7 @@ fn get_balance_private(request: GetBalanceRequest) -> Result<Satoshi, GetBalance
                 .get_added_outpoints(&block.block_hash(), &address)
             {
                 let (txout, _) = state.unstable_blocks.get_tx_out(outpoint).unwrap();
-                balance += txout.value;
+                balance += txout.value.to_sat();
             }
 
             for outpoint in state
@@ -77,7 +77,7 @@ fn get_balance_private(request: GetBalanceRequest) -> Result<Satoshi, GetBalance
                 .get_removed_outpoints(&block.block_hash(), &address)
             {
                 let (txout, _) = state.unstable_blocks.get_tx_out(outpoint).unwrap();
-                balance -= txout.value;
+                balance -= txout.value.to_sat();
             }
         }
 

--- a/canister/src/api/send_transaction.rs
+++ b/canister/src/api/send_transaction.rs
@@ -15,10 +15,10 @@ pub async fn send_transaction(request: SendTransactionRequest) -> Result<(), Sen
     }));
 
     // Decode the transaction as a sanity check that it's valid.
-    let tx = Transaction::consensus_decode(request.transaction.as_slice())
+    let tx = Transaction::consensus_decode(&mut request.transaction.as_slice())
         .map_err(|_| SendTransactionError::MalformedTransaction)?;
 
-    runtime::print(&format!("[send_transaction] Tx ID: {}", tx.txid()));
+    runtime::print(&format!("[send_transaction] Tx ID: {}", tx.compute_txid()));
 
     // Bump the counter for the number of (valid) requests received.
     with_state_mut(|s| {
@@ -41,6 +41,7 @@ pub async fn send_transaction(request: SendTransactionRequest) -> Result<(), Sen
 #[cfg(test)]
 mod test {
     use super::*;
+    use bitcoin::{absolute::LockTime, transaction::Version};
     use ic_btc_interface::{Fees, Flag, InitConfig, Network, NetworkInRequest};
 
     fn empty_transaction() -> Vec<u8> {
@@ -48,8 +49,8 @@ mod test {
 
         use bitcoin::consensus::Encodable;
         Transaction {
-            version: 0,
-            lock_time: 0,
+            version: Version::ONE,
+            lock_time: LockTime::ZERO,
             input: vec![],
             output: vec![],
         }

--- a/canister/src/block_header_store.rs
+++ b/canister/src/block_header_store.rs
@@ -1,6 +1,6 @@
 use crate::{memory::Memory, types::BlockHeaderBlob};
+use bitcoin::block::Header as BlockHeader;
 use bitcoin::consensus::{Decodable, Encodable};
-use bitcoin::BlockHeader;
 use ic_btc_interface::Height;
 use ic_btc_types::{Block, BlockHash};
 use ic_stable_structures::StableBTreeMap;
@@ -84,7 +84,7 @@ impl BlockHeaderStore {
 }
 
 fn deserialize_block_header(block_header_blob: BlockHeaderBlob) -> BlockHeader {
-    BlockHeader::consensus_decode(block_header_blob.as_slice())
+    BlockHeader::consensus_decode(&mut block_header_blob.as_slice())
         .expect("block header decoding must succeed")
 }
 

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -146,7 +146,7 @@ impl BlockTree {
             Some((block_subtree, _)) => {
                 assert_eq!(
                     block_subtree.root.block_hash().to_vec(),
-                    block.header().prev_blockhash.to_vec()
+                    block.header().prev_blockhash.as_ref() as &[u8]
                 );
                 // Add the block as a successor.
                 block_subtree.children.push(BlockTree::new(block));
@@ -388,7 +388,7 @@ mod test {
             for i in 1..chain.len() {
                 assert_eq!(
                     chain[i - 1].block_hash().to_vec(),
-                    chain[i].header().prev_blockhash.to_vec()
+                    chain[i].header().prev_blockhash.as_ref() as &[u8]
                 )
             }
         }
@@ -429,7 +429,7 @@ mod test {
                 for i in 1..chain.len() {
                     assert_eq!(
                         chain[i - 1].block_hash().to_vec(),
-                        chain[i].header().prev_blockhash.to_vec()
+                        chain[i].header().prev_blockhash.as_ref() as &[u8]
                     )
                 }
             }

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -152,7 +152,7 @@ fn maybe_process_response() {
                 ));
                 for block_bytes in response.blocks.iter() {
                     // Deserialize the block.
-                    let block = match BitcoinBlock::consensus_decode(block_bytes.as_slice()) {
+                    let block = match BitcoinBlock::consensus_decode(&mut block_bytes.as_slice()) {
                         Ok(block) => block,
                         Err(err) => {
                             print(&format!(
@@ -270,7 +270,7 @@ mod test {
         types::{Address, BlockBlob, GetSuccessorsCompleteResponse, GetSuccessorsPartialResponse},
         utxo_set::IngestingBlock,
     };
-    use bitcoin::BlockHeader;
+    use bitcoin::block::Header as BlockHeader;
     use ic_btc_interface::{InitConfig, Network};
 
     fn build_block(prev_header: &BlockHeader, address: Address, num_transactions: u128) -> Block {

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -11,7 +11,7 @@ use crate::{
     validation::ValidationContext,
     UtxoSet,
 };
-use bitcoin::{consensus::Decodable, BlockHeader};
+use bitcoin::{block::Header as BlockHeader, consensus::Decodable};
 use candid::Principal;
 use ic_btc_interface::{Fees, Flag, Height, MillisatoshiPerByte, Network};
 use ic_btc_types::{Block, BlockHash, OutPoint};
@@ -207,7 +207,7 @@ pub fn insert_next_block_headers(state: &mut State, next_block_headers: &[BlockH
             break;
         }
 
-        let block_header = match BlockHeader::consensus_decode(block_header_blob.as_slice()) {
+        let block_header = match BlockHeader::consensus_decode(&mut block_header_blob.as_slice()) {
             Ok(header) => header,
             Err(err) => {
                 print(&format!(

--- a/canister/src/tests.rs
+++ b/canister/src/tests.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use crate::{init, test_utils::random_p2pkh_address};
 use bitcoin::consensus::{Decodable, Encodable};
-use bitcoin::{Block as BitcoinBlock, BlockHeader};
+use bitcoin::{block::Header as BlockHeader, Block as BitcoinBlock};
 use byteorder::{LittleEndian, ReadBytesExt};
 use ic_btc_interface::{Flag, GetUtxosResponse, InitConfig, Network, Txid, UtxosFilter};
 use ic_btc_interface::{OutPoint, Utxo};

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -6,7 +6,7 @@ use crate::{
     types::{Address, TxOut},
     UtxoSet,
 };
-use bitcoin::BlockHeader;
+use bitcoin::block::Header as BlockHeader;
 use ic_btc_interface::{Height, Network};
 use ic_btc_types::{Block, BlockHash, OutPoint};
 use outpoints_cache::OutPointsCache;

--- a/canister/src/unstable_blocks/next_block_headers.rs
+++ b/canister/src/unstable_blocks/next_block_headers.rs
@@ -1,4 +1,4 @@
-use bitcoin::BlockHeader;
+use bitcoin::block::Header as BlockHeader;
 use ic_btc_interface::Height;
 use ic_btc_types::BlockHash;
 use serde::{Deserialize, Serialize};

--- a/canister/src/unstable_blocks/outpoints_cache.rs
+++ b/canister/src/unstable_blocks/outpoints_cache.rs
@@ -109,7 +109,7 @@ impl OutPointsCache {
                 };
 
                 if let Ok(address) = Address::from_script(
-                    &bitcoin::Script::from(txout.script_pubkey.clone()),
+                    &bitcoin::ScriptBuf::from(txout.script_pubkey.clone()),
                     utxos.network(),
                 ) {
                     let entry = removed_outpoints.entry(address).or_insert(vec![]);

--- a/canister/src/validation.rs
+++ b/canister/src/validation.rs
@@ -1,5 +1,5 @@
 use crate::{blocktree::BlockDoesNotExtendTree, state::State, unstable_blocks};
-use bitcoin::BlockHeader;
+use bitcoin::block::Header as BlockHeader;
 use ic_btc_validation::HeaderStore;
 
 /// A structure passed to the validation crate to validate a specific block header.
@@ -52,7 +52,7 @@ impl<'a> ValidationContext<'a> {
 impl<'a> HeaderStore for ValidationContext<'a> {
     fn get_with_block_hash(&self, hash: &bitcoin::BlockHash) -> Option<BlockHeader> {
         // Check if the header is in the chain.
-        let hash = ic_btc_types::BlockHash::from(hash.to_vec());
+        let hash = ic_btc_types::BlockHash::from(hash.as_ref());
         for item in self.chain.iter() {
             if item.1 == hash {
                 return Some(*item.0);

--- a/e2e-tests/disable-api-if-not-fully-synced-flag/Cargo.toml
+++ b/e2e-tests/disable-api-if-not-fully-synced-flag/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 bitcoin = { workspace = true }
 candid = { workspace = true }
+getrandom = { workspace = true }
 ic-btc-test-utils = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }

--- a/e2e-tests/disable-api-if-not-fully-synced-flag/src/main.rs
+++ b/e2e-tests/disable-api-if-not-fully-synced-flag/src/main.rs
@@ -1,6 +1,6 @@
 use bitcoin::{
-    blockdata::constants::genesis_block, consensus::Encodable, Address, Block, BlockHeader,
-    Network as BitcoinNetwork,
+    block::Header as BlockHeader, blockdata::constants::genesis_block, consensus::Encodable,
+    Address, Block, Network as BitcoinNetwork,
 };
 use candid::CandidType;
 use ic_btc_test_utils::{BlockBuilder, TransactionBuilder};
@@ -87,7 +87,7 @@ fn init() {
         let block = BlockBuilder::with_prev_header(prev_header)
             .with_transaction(
                 TransactionBuilder::new()
-                    .with_output(&Address::from_str(ADDRESS).unwrap(), 1)
+                    .with_output(&Address::from_str(ADDRESS).unwrap().assume_checked(), 1)
                     .build(),
             )
             .build();
@@ -99,7 +99,7 @@ fn init() {
         let next_block = BlockBuilder::with_prev_header(prev_header)
             .with_transaction(
                 TransactionBuilder::new()
-                    .with_output(&Address::from_str(ADDRESS).unwrap(), 1)
+                    .with_output(&Address::from_str(ADDRESS).unwrap().assume_checked(), 1)
                     .build(),
             )
             .build();
@@ -160,3 +160,8 @@ fn append_block_header(block_header: &BlockHeader) {
 }
 
 fn main() {}
+
+getrandom::register_custom_getrandom!(always_fail);
+pub fn always_fail(_buf: &mut [u8]) -> Result<(), getrandom::Error> {
+    Err(getrandom::Error::UNSUPPORTED)
+}

--- a/e2e-tests/scenario-1/Cargo.toml
+++ b/e2e-tests/scenario-1/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 bitcoin = { workspace = true }
 candid = { workspace = true }
+getrandom = { workspace = true }
 ic-btc-test-utils = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }

--- a/e2e-tests/scenario-1/src/main.rs
+++ b/e2e-tests/scenario-1/src/main.rs
@@ -80,10 +80,13 @@ fn init() {
     // Block 1: A single transaction that gives ADDRESS_1 50 BTC split over 10k inputs.
     let mut tx_1 = TransactionBuilder::new();
     for _ in 0..10_000 {
-        tx_1 = tx_1.with_output(&Address::from_str(ADDRESS_1).unwrap(), 500_000);
+        tx_1 = tx_1.with_output(
+            &Address::from_str(ADDRESS_1).unwrap().assume_checked(),
+            500_000,
+        );
     }
     let tx_1 = tx_1.build();
-    let tx_1_id = tx_1.txid();
+    let tx_1_id = tx_1.compute_txid();
 
     let block_1 = BlockBuilder::with_prev_header(genesis_block(network).header)
         .with_transaction(tx_1)
@@ -102,7 +105,10 @@ fn init() {
                     },
                     None,
                 )
-                .with_output(&Address::from_str(ADDRESS_2).unwrap(), 500_000)
+                .with_output(
+                    &Address::from_str(ADDRESS_2).unwrap().assume_checked(),
+                    500_000,
+                )
                 .build(),
         )
     }
@@ -119,7 +125,10 @@ fn init() {
     let block_3 = BlockBuilder::with_prev_header(block_2.header)
         .with_transaction(
             TransactionBuilder::new()
-                .with_output(&Address::from_str(ADDRESS_3).unwrap(), 500_000)
+                .with_output(
+                    &Address::from_str(ADDRESS_3).unwrap().assume_checked(),
+                    500_000,
+                )
                 .build(),
         )
         .build();
@@ -128,7 +137,10 @@ fn init() {
     let block_4 = BlockBuilder::with_prev_header(block_3.header)
         .with_transaction(
             TransactionBuilder::new()
-                .with_output(&Address::from_str(ADDRESS_4).unwrap(), 500_000)
+                .with_output(
+                    &Address::from_str(ADDRESS_4).unwrap().assume_checked(),
+                    500_000,
+                )
                 .build(),
         )
         .build();
@@ -141,12 +153,15 @@ fn init() {
             TransactionBuilder::new()
                 .with_input(
                     OutPoint {
-                        txid: block_2_tx.txid(),
+                        txid: block_2_tx.compute_txid(),
                         vout: 0,
                     },
                     None,
                 )
-                .with_output(&Address::from_str(ADDRESS_5).unwrap(), 500_000)
+                .with_output(
+                    &Address::from_str(ADDRESS_5).unwrap().assume_checked(),
+                    500_000,
+                )
                 .build(),
         )
     }
@@ -227,3 +242,8 @@ fn append_block(block: &Block) {
 }
 
 fn main() {}
+
+getrandom::register_custom_getrandom!(always_fail);
+pub fn always_fail(_buf: &mut [u8]) -> Result<(), getrandom::Error> {
+    Err(getrandom::Error::UNSUPPORTED)
+}

--- a/e2e-tests/scenario-2/Cargo.toml
+++ b/e2e-tests/scenario-2/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 bitcoin = { workspace = true }
 candid = { workspace = true }
+getrandom = { workspace = true }
 ic-btc-test-utils = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }

--- a/e2e-tests/scenario-2/src/main.rs
+++ b/e2e-tests/scenario-2/src/main.rs
@@ -1,5 +1,5 @@
 use bitcoin::{
-    blockdata::constants::genesis_block, consensus::Encodable, Address, Block,
+    absolute::LockTime, blockdata::constants::genesis_block, consensus::Encodable, Address, Block,
     Network as BitcoinNetwork,
 };
 use candid::CandidType;
@@ -88,8 +88,8 @@ fn init() {
             // A transaction giving 1 satoshi to the address.
             block = block.with_transaction(
                 TransactionBuilder::new()
-                    .with_lock_time(i)
-                    .with_output(&Address::from_str(ADDRESS).unwrap(), 1)
+                    .with_lock_time(LockTime::from_consensus(i))
+                    .with_output(&Address::from_str(ADDRESS).unwrap().assume_checked(), 1)
                     .build(),
             );
         }
@@ -136,3 +136,8 @@ fn append_block(block: &Block) {
 }
 
 fn main() {}
+
+getrandom::register_custom_getrandom!(always_fail);
+pub fn always_fail(_buf: &mut [u8]) -> Result<(), getrandom::Error> {
+    Err(getrandom::Error::UNSUPPORTED)
+}

--- a/ic-http/example_canister/Cargo.toml
+++ b/ic-http/example_canister/Cargo.toml
@@ -1,4 +1,0 @@
-[workspace]
-members = [
-    "src/canister_backend",
-]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -10,5 +10,5 @@ include = ["src", "Cargo.toml", "../LICENSE"]
 repository = "https://github.com/dfinity/bitcoin-canister"
 
 [dependencies]
-bitcoin = {version = "0.28.1", features = ["rand"]} # needed for generating secp256k1 keys.
+bitcoin = { workspace = true, features = ["rand-std"] } # needed for generating secp256k1 keys.
 ic-btc-types = { workspace = true }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -6,12 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoin = { workspace = true, features = ["use-serde"] }
+bitcoin = { workspace = true, features = ["serde"] }
 candid = { workspace = true }
 hex = { workspace = true }
 ic-btc-interface = { workspace = true }
 ic-btc-validation = { workspace = true }
 ic-stable-structures = { workspace = true }
+primitive-types = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -128,6 +128,11 @@ impl Transaction {
         self.tx.total_size()
     }
 
+    #[deprecated(note = "Use total_size() instead")]
+    pub fn size(&self) -> usize {
+        self.total_size()
+    }
+
     pub fn txid(&self) -> Txid {
         if self.txid.borrow().is_none() {
             // Compute the txid as it wasn't computed already.

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/dfinity/bitcoin-canister"
 
 [dependencies]
 bitcoin = { workspace = true }
+primitive-types = { workspace = true }
 
 [dev-dependencies]
 csv = "1.1"

--- a/validation/src/constants.rs
+++ b/validation/src/constants.rs
@@ -1,4 +1,4 @@
-use bitcoin::{util::uint::Uint256, Network};
+use bitcoin::{CompactTarget, Network, Target};
 
 use crate::BlockHeight;
 
@@ -8,45 +8,14 @@ pub const DIFFICULTY_ADJUSTMENT_INTERVAL: BlockHeight = 6 * 24 * 14;
 /// Needed to help test check for the 20 minute testnet/regtest rule
 pub const TEN_MINUTES: u32 = 60 * 10;
 
-/// Bitcoin mainnet maximum target value
-const BITCOIN_MAX_TARGET: Uint256 = Uint256([
-    0x0000000000000000,
-    0x0000000000000000,
-    0x0000000000000000,
-    0x00000000ffff0000,
-]);
-
-/// Bitcoin testnet maximum target value
-const TESTNET_MAX_TARGET: Uint256 = Uint256([
-    0x0000000000000000,
-    0x0000000000000000,
-    0x0000000000000000,
-    0x00000000ffff0000,
-]);
-
-/// Bitcoin regtest maximum target value
-const REGTEST_MAX_TARGET: Uint256 = Uint256([
-    0x0000000000000000,
-    0x0000000000000000,
-    0x0000000000000000,
-    0x7fffff0000000000,
-]);
-
-/// Bitcoin signet maximum target value
-const SIGNET_MAX_TARGET: Uint256 = Uint256([
-    0x0000000000000000u64,
-    0x0000000000000000u64,
-    0x0000000000000000u64,
-    0x00000377ae000000u64,
-]);
-
 /// Returns the maximum difficulty target depending on the network
-pub fn max_target(network: &Network) -> Uint256 {
+pub fn max_target(network: &Network) -> Target {
     match network {
-        Network::Bitcoin => BITCOIN_MAX_TARGET,
-        Network::Testnet => TESTNET_MAX_TARGET,
-        Network::Regtest => REGTEST_MAX_TARGET,
-        Network::Signet => SIGNET_MAX_TARGET,
+        Network::Bitcoin => Target::MAX_ATTAINABLE_MAINNET,
+        Network::Testnet => Target::MAX_ATTAINABLE_TESTNET,
+        Network::Regtest => Target::MAX_ATTAINABLE_REGTEST,
+        Network::Signet => Target::MAX_ATTAINABLE_SIGNET,
+        _ => unreachable!(),
     }
 }
 
@@ -56,17 +25,19 @@ pub fn no_pow_retargeting(network: &Network) -> bool {
     match network {
         Network::Bitcoin | Network::Testnet | Network::Signet => false,
         Network::Regtest => true,
+        _ => unreachable!(),
     }
 }
 
 /// Returns the PoW limit bits of the bitcoin network
-pub fn pow_limit_bits(network: &Network) -> u32 {
-    match network {
+pub fn pow_limit_bits(network: &Network) -> CompactTarget {
+    CompactTarget::from_consensus(match network {
         Network::Bitcoin => 0x1d00ffff,
         Network::Testnet => 0x1d00ffff,
         Network::Regtest => 0x207fffff,
         Network::Signet => 0x1e0377ae,
-    }
+        _ => unreachable!(),
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Upgrade bitcoin library to version 0.32.2. Notable changes are:
- A number of types now use new type instead of primitive types like u32.
- `U256` is no longer exported from bitcoin, and instead `primitive-types::U256` is used when it is needed.
- Because of changes to `Address` type, we have to use `assume_checked` when it is needed.
- Dependency on `getrandom` (due to `secp256k1` dependency) now requires `custom` flag to be used.
- Some other miscellaneous type and name changes.