### PR TITLE
chore: enhancements for bootstrapping

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -331,6 +331,35 @@ jobs:
         run: |
           bash e2e-tests/set_config.sh
 
+  post_upgrade_config:
+    runs-on: ubuntu-latest
+    needs: cargo-build
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+
+      - name: Install Rust
+        run: |
+          rustup update ${{ matrix.rust }} --no-self-update
+          rustup default ${{ matrix.rust }}
+          rustup target add wasm32-unknown-unknown
+
+      - name: Install dfx
+        uses: dfinity/setup-dfx@main
+        with:
+          dfx-version: $DFX_VERSION
+
+      - name: Run post_upgrade_config test
+        run: |
+          bash e2e-tests/post_upgrade_config.sh
+
   cycles_burn:
     runs-on: ubuntu-20.04
     needs: cargo-build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,12 +810,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crunchy"
@@ -3079,9 +3076,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
@@ -3107,9 +3104,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3118,9 +3115,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -3630,11 +3627,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3653,9 +3649,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -46,3 +46,4 @@ test-strategy = "0.3.1"
 
 [features]
 file_memory = []
+legacy_preupgrade = []

--- a/canister/src/api.rs
+++ b/canister/src/api.rs
@@ -4,7 +4,7 @@ mod get_block_headers;
 mod get_utxos;
 mod metrics;
 mod send_transaction;
-mod set_config;
+pub(crate) mod set_config;
 pub use fee_percentiles::get_current_fee_percentiles;
 pub(crate) use fee_percentiles::get_current_fee_percentiles_impl;
 pub use get_balance::get_balance;

--- a/canister/src/api/set_config.rs
+++ b/canister/src/api/set_config.rs
@@ -31,7 +31,7 @@ fn set_api_access(request: SetConfigRequest) {
     });
 }
 
-fn set_config_no_verification(request: SetConfigRequest) {
+pub(crate) fn set_config_no_verification(request: SetConfigRequest) {
     crate::with_state_mut(|s| {
         if let Some(syncing) = request.syncing {
             s.syncing_state.syncing = syncing;

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -565,7 +565,6 @@ mod test {
         assert_eq!(height_2_depth, 1);
     }
 
-    #[ignore] // TODO(EXC-1639): re-enable this test.
     #[test]
     fn deserialize_very_deep_block_tree() {
         let chain = BlockChainBuilder::new(5_000).build();
@@ -581,7 +580,6 @@ mod test {
         assert_eq!(tree, new_tree);
     }
 
-    #[ignore] // TODO(EXC-1639): re-enable this test.
     #[proptest]
     fn serialize_deserialize(tree: BlockTree) {
         let mut bytes = vec![];

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -27,9 +27,9 @@ fn pre_upgrade() {
 }
 
 #[post_upgrade]
-fn post_upgrade() {
+fn post_upgrade(config_update: Option<SetConfigRequest>) {
     hook();
-    ic_btc_canister::post_upgrade();
+    ic_btc_canister::post_upgrade(config_update);
 }
 
 #[heartbeat]

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -357,7 +357,6 @@ mod test {
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(10))]
-        #[ignore] // TODO(EXC-1639): re-enable this test.
         #[test]
         fn serialize_deserialize_state(
             stability_threshold in 1..150u32,

--- a/e2e-tests/post_upgrade_config.sh
+++ b/e2e-tests/post_upgrade_config.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# A test that verifies that calling post_upgrade with a set_config_request works.
+
+# Run dfx stop if we run into errors.
+trap "dfx stop" EXIT SIGINT
+
+dfx start --background --clean
+
+# Deploy the bitcoin canister.
+dfx deploy --no-wallet bitcoin --argument "(record {
+  stability_threshold = opt 0;
+  network = opt variant { regtest };
+})"
+
+# The stability threshold is zero
+CONFIG=$(dfx canister call bitcoin get_config --query)
+if ! [[ $CONFIG == *"stability_threshold = 0"* ]]; then
+  echo "FAIL"
+  exit 1
+fi
+
+# Modify the candid file such that post_upgrade can accept a `opt set_config_request`.
+# This is necessary because post_upgrade takes a different argument from `init`, but candid
+# doesn't provide a way of specifying that and dfx doesn't provide a way to bypass type checks.
+sed -i.bak 's/service bitcoin : (init_config)/service bitcoin : (opt set_config_request)/' ./canister/candid.did
+
+# Upgrade and update the fees.
+FEES="record { get_current_fee_percentiles = 6 : nat; get_utxos_maximum = 3 : nat; get_block_headers_cycles_per_ten_instructions = 11 : nat; get_current_fee_percentiles_maximum = 7 : nat; send_transaction_per_byte = 9 : nat; get_balance = 4 : nat; get_utxos_cycles_per_ten_instructions = 2 : nat; get_block_headers_base = 10 : nat; get_utxos_base = 1 : nat; get_balance_maximum = 5 : nat; send_transaction_base = 8 : nat; get_block_headers_maximum = 12 : nat; }";
+
+dfx deploy --upgrade-unchanged bitcoin --argument "opt (record {
+  fees = opt $FEES;
+})"
+
+# Revert the modification to the candid file.
+sed -i.bak 's/service bitcoin : (opt set_config_request)/service bitcoin : (init_config)/' ./canister/candid.did
+
+# Verify the fees have been updated.
+CONFIG=$(dfx canister call bitcoin get_config --query)
+echo $CONFIG
+if ! [[ $CONFIG == *"$FEES"* ]]; then
+  echo "FAIL"
+  exit 1
+fi
+
+echo "SUCCESS"

--- a/e2e-tests/upgradability.sh
+++ b/e2e-tests/upgradability.sh
@@ -84,15 +84,20 @@ fi
 # Update the candid to point back to the new init args.
 sed -i.bak 's/service bitcoin : (config)/service bitcoin : (init_config)/' ./canister/candid.did
 
-# Deploy upgraded canister.
+echo "Deploy new version of canister (with legacy upgrade feature)..."
+# The legacy_preupgrade feature is enabled.
+sed -i.bak 's/ic-btc-canister"/ic-btc-canister legacy_preupgrade"/' ./dfx.json
 dfx deploy --no-wallet bitcoin --argument "(record { })"
 
 dfx canister start bitcoin
 dfx canister stop bitcoin
 
+# The legacy_preupgrade feature is removed.
+echo "Upgrade canister to own version..."
+sed -i.bak 's/ic-btc-canister legacy_preupgrade"/ic-btc-canister"/' ./dfx.json
+
 # Redeploy the canister to test the pre-upgrade hook.
-# TODO(EXC-1639): Re-enable this test once the canister is released.
-#dfx deploy --upgrade-unchanged bitcoin --argument "(record { })"
-#dfx canister start bitcoin
+dfx deploy --upgrade-unchanged bitcoin --argument "(record { })"
+dfx canister start bitcoin
 
 echo "SUCCESS"


### PR DESCRIPTION
1. `post_upgrade` hook now take an optional configuration. This allows the upgrade proposal after bootstrapping to set appropriate configs, particularly fees.
2. The `post_upgrade` needs to work with the bootstrapped canister and the current bitcoin mainnet canister. The bitcoin mainnet canister still has an old `pre_upgrade` hook. To address, a `legacy_preupgrade` feature has been added. When upgrading the bootstrapped testnet canister, this feature won't be enabled, but when upgrading the bitcoin mainnet canister, this feature will need to be enabled. This has the unfortunate consequence that in the upcoming release the bitcoin testnet and mainnet canister wasms won't match.