### PR TITLE
fix: do not include canbench in production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,9 @@
 target
 out
+bootstrap/canister_state*
+bootstrap/block_headers
+bootstrap/utxodump*
+bootstrap/data*
 
 # Filter out all "hidden" files and directories
 .*

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -61,12 +61,6 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
 
-      - name: Install brew packages (mac)
-        if: runner.os == 'macOS'
-        run: |
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          brew install llvm
-
       - name: Install Rust
         run: |
           rustup update $RUST_VERSION --no-self-update
@@ -90,6 +84,12 @@ jobs:
           mv pocket-ic-x86_64-linux pocket-ic
           chmod +x pocket-ic
           mv pocket-ic ./canister/
+
+      - name: Install brew packages (mac)
+        if: runner.os == 'macOS'
+        run: |
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          brew install llvm
 
       - name: Run Tests
         shell: bash

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-12 ]
+        os: [ ubuntu-20.04, macos-13 ]
 
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
     needs: cargo-build
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-12 ]
+        os: [ ubuntu-20.04, macos-13 ]
 
     steps:
       - uses: actions/checkout@v4
@@ -88,7 +88,7 @@ jobs:
       - name: Install brew packages (mac)
         if: runner.os == 'macOS'
         run: |
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          #/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           brew install llvm
 
       - name: Run Tests

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -67,6 +67,24 @@ jobs:
           rustup default $RUST_VERSION
           rustup target add wasm32-unknown-unknown
 
+      - name: Install PocketIC (mac)
+        if: runner.os == 'macOS'
+        run: |
+          wget https://github.com/dfinity/pocketic/releases/download/5.0.0/pocket-ic-x86_64-darwin.gz
+          gzip -d pocket-ic-x86_64-darwin.gz
+          mv pocket-ic-x86_64-darwin pocket-ic
+          chmod +x pocket-ic
+          mv pocket-ic ./canister/
+
+      - name: Install PocketIC (linux)
+        if: runner.os == 'Linux'
+        run: |
+          wget https://github.com/dfinity/pocketic/releases/download/5.0.0/pocket-ic-x86_64-linux.gz
+          gzip -d pocket-ic-x86_64-linux.gz
+          mv pocket-ic-x86_64-linux pocket-ic
+          chmod +x pocket-ic
+          mv pocket-ic ./canister/
+
       - name: Run Tests
         shell: bash
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -61,6 +61,12 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
 
+      - name: Install brew packages (mac)
+        if: runner.os == 'macOS'
+        run: |
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          brew install llvm
+
       - name: Install Rust
         run: |
           rustup update $RUST_VERSION --no-self-update

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -88,7 +88,6 @@ jobs:
       - name: Install brew packages (mac)
         if: runner.os == 'macOS'
         run: |
-          #/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           brew install llvm
 
       - name: Run Tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +323,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -567,7 +579,7 @@ dependencies = [
  "pretty 0.10.0",
  "serde",
  "serde_bytes",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "thiserror",
 ]
 
@@ -782,6 +794,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +834,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -954,6 +991,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1059,12 @@ checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -1325,6 +1374,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,24 +1422,18 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hmac"
@@ -1431,6 +1493,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1452,6 +1515,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1512,7 +1576,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_repr",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "simple_asn1",
  "thiserror",
  "time",
@@ -1524,6 +1588,7 @@ dependencies = [
 name = "ic-btc-canister"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "async-std",
  "bitcoin",
  "byteorder",
@@ -1542,6 +1607,7 @@ dependencies = [
  "ic-stable-structures",
  "lazy_static",
  "maplit",
+ "pocket-ic",
  "proptest 0.9.6",
  "serde",
  "serde_bytes",
@@ -1619,6 +1685,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-cdk"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8859bc2b863a77750acf199e1fb7e3fc403e1b475855ba13f59cb4e4036d238"
+dependencies = [
+ "candid 0.10.8",
+ "ic-cdk-macros 0.13.2",
+ "ic0 0.21.1",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "ic-cdk-macros"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1716,20 @@ name = "ic-cdk-macros"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5a618e4020cea88e933d8d2f8c7f86d570ec06213506a80d4f2c520a9bba512"
+dependencies = [
+ "candid 0.10.8",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ic-cdk-macros"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45800053d80a6df839a71aaea5797e723188c0b992618208ca3b941350c7355"
 dependencies = [
  "candid 0.10.8",
  "proc-macro2",
@@ -1669,7 +1762,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_bytes",
- "sha2 0.10.6",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -1709,7 +1802,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_repr",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "thiserror",
 ]
 
@@ -1749,7 +1842,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_bytes",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "thiserror",
 ]
 
@@ -1774,6 +1867,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.1",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,7 +1897,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1811,7 +1914,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "io-lifetimes",
  "rustix 0.37.25",
  "windows-sys 0.48.0",
@@ -1860,7 +1963,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "signature",
 ]
 
@@ -1932,7 +2035,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.4.6",
 ]
 
 [[package]]
@@ -2052,6 +2155,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,6 +2176,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,13 +2196,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
+ "hermit-abi",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2088,6 +2211,16 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-bigint"
@@ -2119,16 +2252,6 @@ checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg 1.1.0",
  "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
-dependencies = [
- "hermit-abi 0.2.6",
- "libc",
 ]
 
 [[package]]
@@ -2174,6 +2297,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,7 +2317,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.6",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -2261,7 +2396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -2319,6 +2454,28 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "pocket-ic"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629f46b7ab8a8d2fee02220ef8e99ae552c7e220117efa1ce0882ff09c8fb038"
+dependencies = [
+ "base64 0.13.1",
+ "candid 0.10.8",
+ "hex",
+ "ic-cdk 0.13.2",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "sha2 0.10.8",
+ "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2752,6 +2909,15 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
@@ -2790,6 +2956,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -2800,11 +2967,13 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -2813,6 +2982,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-socks",
  "tokio-util",
  "tower-service",
  "url",
@@ -2900,6 +3070,19 @@ dependencies = [
  "rustls-webpki 0.102.5",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3035,6 +3218,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "schemars"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.71",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3075,6 +3291,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3107,6 +3346,17 @@ name = "serde_derive"
 version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3173,9 +3423,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3189,7 +3439,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a975c1bc0941703000eaf232c4d8ce188d8d5408d6344b6b2c8c6262772828"
 dependencies = [
  "hex",
- "sha2 0.10.6",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -3476,6 +3735,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3528,29 +3797,27 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
 dependencies = [
- "autocfg 1.1.0",
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2 0.5.7",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3565,6 +3832,18 @@ checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
  "tokio",
 ]
 
@@ -3593,7 +3872,7 @@ version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "toml_datetime",
  "winnow",
 ]
@@ -3637,6 +3916,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3654,6 +3945,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3679,6 +4013,15 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -3756,6 +4099,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
+assert_matches = "1.5.0"
 bitcoin = "0.28.1"
 byteorder = "1.4.3"
 canbench-rs = { version = "0.1.1" }
@@ -46,6 +47,7 @@ ic-http = { path = "./ic-http" }
 ic-metrics-encoder = "1.0.0"
 ic-stable-structures = "0.5.2"
 lazy_static = "1.4.0"
+pocket-ic = "4.0.0"
 serde = "1.0.171"
 serde_bytes = "0.11"
 serde_json = "1.0.94"

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,10 +61,10 @@ RUN \
     cp target/wasm32-unknown-unknown/release/ic-btc-canister.wasm.gz ic-btc-canister.wasm.gz && \
     sha256sum ic-btc-canister.wasm.gz && \
     # Building uploader canister...
-    scripts/build-canister.sh uploader-canister && \
-    cp target/wasm32-unknown-unknown/release/uploader-canister.wasm.gz uploader-canister.wasm.gz && \
-    sha256sum uploader-canister.wasm.gz && \
+    scripts/build-canister.sh uploader && \
+    cp target/wasm32-unknown-unknown/release/uploader.wasm.gz uploader.wasm.gz && \
+    sha256sum uploader.wasm.gz && \
     # Building watchdog canister...
-    scripts/build-canister.sh watchdog-canister && \
-    cp target/wasm32-unknown-unknown/release/watchdog-canister.wasm.gz watchdog-canister.wasm.gz && \
-    sha256sum watchdog-canister.wasm.gz
+    scripts/build-canister.sh watchdog && \
+    cp target/wasm32-unknown-unknown/release/watchdog.wasm.gz watchdog.wasm.gz && \
+    sha256sum watchdog.wasm.gz

--- a/bootstrap/6_compute_canister_state.sh
+++ b/bootstrap/6_compute_canister_state.sh
@@ -22,23 +22,23 @@ fi
 mkdir $CANISTER_STATE_DIR
 
 echo "Computing balances..."
-cargo run --release --bin build-balances -- \
+cargo run -p state-builder --release --bin build-balances -- \
    --output $CANISTER_STATE_DIR/balances --network "$NETWORK" --utxos-dump-path $UTXO_FILE
 
 echo "Computing address UTXOs..."
-cargo run --release --bin build-address-utxos -- \
+cargo run -p state-builder --release --bin build-address-utxos -- \
    --output $CANISTER_STATE_DIR/address_utxos --network "$NETWORK" --utxos-dump-path $UTXO_FILE
 
 echo "Computing UTXOs..."
-cargo run --release --bin build-utxos --features file_memory -- \
+cargo run -p state-builder --release --bin build-utxos --features file_memory -- \
    --output $CANISTER_STATE_DIR --network "$NETWORK" --utxos-dump-path $UTXO_FILE
 
 echo "Combining the state into $CANISTER_STATE_FILE"
-cargo run --release --bin combine-state -- \
+cargo run -p state-builder --release --bin combine-state -- \
    --output $CANISTER_STATE_FILE --canister-state-dir $CANISTER_STATE_DIR
 
 echo "Building state struct.."
-cargo run --release --bin main-state-builder --features file_memory -- \
+cargo run -p state-builder --release --bin main-state-builder --features file_memory -- \
    --canister-state "$CANISTER_STATE_FILE" \
    --canister-state-dir "$CANISTER_STATE_DIR" \
    --network "$NETWORK" \

--- a/bootstrap/uploader/Cargo.toml
+++ b/bootstrap/uploader/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 build = "src/build.rs"
 
 [[bin]]
-name = "uploader-canister"
+name = "uploader"
 path = "src/main.rs"
 
 # The upload script is added here as an example and not a binary because making it

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -33,6 +33,7 @@ path = "src/main.rs"
 bench = false
 
 [dev-dependencies]
+assert_matches = { workspace = true }
 async-std = { version = "1.12.0", features = ["attributes"] }
 bitcoin = { workspace = true, features = ["rand"] } # needed for generating secp256k1 keys.
 byteorder = { workspace = true }
@@ -40,6 +41,7 @@ candid_parser = { workspace = true }
 ic-btc-test-utils = { workspace = true }
 ic-btc-types = { workspace = true, features = ["mock_difficulty"] }
 maplit = "1.0.2"
+pocket-ic = { workspace = true }
 proptest = "0.9.4"
 tempfile = { workspace = true }
 test-strategy = "0.3.1"

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -126,6 +126,15 @@ fn inspect_message() {
     }
 }
 
+// Expose a method to know if canbench is included in the binary or not.
+// This is used in a test to ensure that canbench is _not_ included in the
+// production binary.
+#[cfg(feature = "canbench-rs")]
+#[update]
+pub fn has_canbench() -> bool {
+    true
+}
+
 fn main() {}
 
 #[cfg(test)]

--- a/canister/tests/integration_tests.rs
+++ b/canister/tests/integration_tests.rs
@@ -28,7 +28,7 @@ fn canister_wasm() -> Vec<u8> {
     std::fs::read(get_full_path(WASM_PATH)).unwrap()
 }
 
-fn with_bitcoin_canister<F: Fn(PocketIc, CanisterId) -> ()>(test: F) -> () {
+fn with_bitcoin_canister<F: Fn(PocketIc, CanisterId)>(test: F) {
     println!("Building the bitcoin canister...");
     build_canister();
     println!("Done.");

--- a/canister/tests/integration_tests.rs
+++ b/canister/tests/integration_tests.rs
@@ -1,0 +1,75 @@
+use candid::{encode_one, Encode, Principal};
+use ic_btc_interface::InitConfig;
+use ic_cdk::api::management_canister::main::CanisterId;
+use pocket_ic::{ErrorCode, PocketIc, PocketIcBuilder, UserError};
+use std::{path::PathBuf, process::Command};
+
+const BUILD_SCRIPT: &str = "scripts/build-canister.sh";
+const WASM_PATH: &str = "target/wasm32-unknown-unknown/release/ic-btc-canister.wasm.gz";
+
+// Executes a bash script to build the bitcoin canister wasm.
+fn build_canister() {
+    let output = Command::new("bash")
+        .arg(get_full_path(BUILD_SCRIPT))
+        .arg("ic-btc-canister")
+        .output()
+        .expect("Failed to execute command");
+
+    // Check if the command was successful
+    assert!(
+        output.status.success(),
+        "Command failed with error: {}",
+        std::str::from_utf8(&output.stderr).unwrap()
+    );
+}
+
+// Reads the canister wasm.
+fn canister_wasm() -> Vec<u8> {
+    std::fs::read(get_full_path(WASM_PATH)).unwrap()
+}
+
+fn with_bitcoin_canister<F: Fn(PocketIc, CanisterId) -> ()>(test: F) -> () {
+    println!("Building the bitcoin canister...");
+    build_canister();
+    println!("Done.");
+
+    println!("Installing the bitcoin canister...");
+    let pic = PocketIcBuilder::new().with_bitcoin_subnet().build();
+    let canister_id = pic.create_canister();
+    let wasm_bytes = canister_wasm();
+    pic.install_canister(
+        canister_id,
+        wasm_bytes,
+        Encode!(&InitConfig::default()).unwrap(),
+        None,
+    );
+
+    // Run the test.
+    test(pic, canister_id);
+}
+
+fn get_full_path(path: &str) -> PathBuf {
+    PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        .join("..")
+        .join(path)
+}
+
+// If canbench is included in the canister, there'll be an endpoint called "has_canbench".
+// This test ensures this endpoint doesn't exist.
+#[test]
+fn canbench_is_not_in_bitcoin_canister() {
+    with_bitcoin_canister(|pic: PocketIc, canister_id: CanisterId| {
+        assert_matches::assert_matches!(
+            pic.update_call(
+                canister_id,
+                Principal::anonymous(),
+                "has_canbench",
+                encode_one(()).unwrap(),
+            ),
+            Err(UserError {
+                code: ErrorCode::CanisterMethodNotFound,
+                ..
+            })
+        );
+    });
+}

--- a/dfx.json
+++ b/dfx.json
@@ -10,8 +10,8 @@
     "watchdog": {
       "type": "custom",
       "candid": "./watchdog/candid.did",
-      "build": "./scripts/build-canister.sh watchdog-canister",
-      "wasm": "./target/wasm32-unknown-unknown/release/watchdog-canister.wasm.gz"
+      "build": "./scripts/build-canister.sh watchdog",
+      "wasm": "./target/wasm32-unknown-unknown/release/watchdog.wasm.gz"
     },
     "watchdog-upgradability-test": {
       "type": "custom",

--- a/scripts/build-canister.sh
+++ b/scripts/build-canister.sh
@@ -19,10 +19,10 @@ fi
 
 if [[ -z "$FEATURES" ]]; then
   # No features provided
-  cargo build -p $CANISTER --target "$TARGET" --release
+  cargo build -p "$CANISTER" --target "$TARGET" --release
 else
   # Features provided
-  cargo build -p $CANISTER --target "$TARGET" --release --features "$FEATURES"
+  cargo build -p "$CANISTER" --target "$TARGET" --release --features "$FEATURES"
 fi
 
 # Navigate to root directory.

--- a/scripts/build-canister.sh
+++ b/scripts/build-canister.sh
@@ -17,6 +17,9 @@ if [ "$(uname)" == "Darwin" ]; then
   export CC="${LLVM_PATH}/bin/clang"
 fi
 
+# NOTE: `-p` is used rather than `--bin` due to a quirk in cargo where, if --bin
+# is used, it may include features that specified by benchmarking/testing crates
+# that aren't needed in production.
 if [[ -z "$FEATURES" ]]; then
   # No features provided
   cargo build -p "$CANISTER" --target "$TARGET" --release

--- a/scripts/build-canister.sh
+++ b/scripts/build-canister.sh
@@ -19,10 +19,10 @@ fi
 
 if [[ -z "$FEATURES" ]]; then
   # No features provided
-  cargo build --bin "$CANISTER" --target "$TARGET" --release
+  cargo build -p $CANISTER --target "$TARGET" --release
 else
   # Features provided
-  cargo build --bin "$CANISTER" --target "$TARGET" --release --features "$FEATURES"
+  cargo build -p $CANISTER --target "$TARGET" --release --features "$FEATURES"
 fi
 
 # Navigate to root directory.

--- a/watchdog/Cargo.toml
+++ b/watchdog/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [[bin]]
-name = "watchdog-canister"
+name = "watchdog"
 path = "src/main.rs"
 
 [dependencies]


### PR DESCRIPTION
## Problem
Running `pre_upgrade` in the bootstrapping scripts fails with an error that `stable64_size` is only available in canisters.

## Solution
The bootstrapping scripts do not run the canister code as Wasm, and do not have access to IC-level APIs. Upon further investigation, the reason `stable64_size` was needed was because we were accidentally including `canbench` into the compilation of the canister code - it should only be included when we're benchmarking.

To fix this, the `build-scripts.sh` has been updated to build using `--package` rather than `--bin` - that actually builds the canister from the correct root `Cargo.toml` file and therefore doesn't include any additional features that were required by other packages.

I used this opportunity to add a test using `PocketIC`.
