### PR TITLE
fix: uploader canister compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3569,19 +3569,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha256"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18278f6a914fa3070aa316493f7d2ddfb9ac86ebc06fa3b83bffda487e9065b0"
-dependencies = [
- "async-trait",
- "bytes",
- "hex",
- "sha2 0.10.8",
- "tokio",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4228,11 +4215,12 @@ dependencies = [
  "async-std",
  "candid 0.10.10",
  "clap",
+ "hex",
  "ic-agent",
  "ic-cdk 0.15.1",
  "ic-cdk-macros 0.15.0",
  "serde",
- "sha256",
+ "sha2 0.10.8",
  "url",
 ]
 

--- a/bootstrap/uploader/Cargo.toml
+++ b/bootstrap/uploader/Cargo.toml
@@ -21,10 +21,11 @@ path = "src/compute_hashes.rs"
 
 [dependencies]
 candid = { workspace = true }
+hex.workspace = true
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
-sha256 = "1.1.1"
 serde = { workspace = true }
+sha2 = "0.10.8"
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }

--- a/bootstrap/uploader/src/compute_hashes.rs
+++ b/bootstrap/uploader/src/compute_hashes.rs
@@ -25,7 +25,13 @@ fn main() {
             break;
         }
 
-        let hash = sha256::digest(&chunk[0..bytes_read]);
+        let hash = {
+            use sha2::Digest;
+            let mut hasher = sha2::Sha256::new();
+            hasher.update(&chunk[0..bytes_read]);
+            let digest_bytes = hasher.finalize();
+            hex::encode(digest_bytes)
+        };
         println!("{}", hash);
     }
 }

--- a/bootstrap/uploader/src/main.rs
+++ b/bootstrap/uploader/src/main.rs
@@ -51,7 +51,13 @@ fn upload_chunk(chunk_start: u64, bytes: Vec<u8>) {
 
     // Verify that the hash of `bytes` matches some hash that we expect.
     let expected_hash = CHUNK_HASHES[(chunk_start / CHUNK_SIZE_IN_PAGES) as usize];
-    let actual_hash = sha256::digest(&*bytes);
+    let actual_hash = {
+        use sha2::Digest;
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(&*bytes);
+        let digest_bytes = hasher.finalize();
+        hex::encode(&digest_bytes)
+    };
     if actual_hash != expected_hash {
         panic!(
             "Expected digest {} but found {}. bytes snippet {:?}",

--- a/bootstrap/uploader/src/main.rs
+++ b/bootstrap/uploader/src/main.rs
@@ -56,7 +56,7 @@ fn upload_chunk(chunk_start: u64, bytes: Vec<u8>) {
         let mut hasher = sha2::Sha256::new();
         hasher.update(&*bytes);
         let digest_bytes = hasher.finalize();
-        hex::encode(&digest_bytes)
+        hex::encode(digest_bytes)
     };
     if actual_hash != expected_hash {
         panic!(


### PR DESCRIPTION
The upload canister compilation was failing with the following error:

```
error: Only features sync,macros,io-util,rt,time are supported on wasm.
   --> /Users/ielashi/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.3/src/lib.rs:467:1
    |
467 | compile_error!("Only features sync,macros,io-util,rt,time are supported on wasm.");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This is due to a dependency on `tokio`, which for some reason `sha256` crate needs. This commit replaces `sha256` with `sha2` which has no such dependencies and fixes the compilation.

It turns out there are not tests to ensure the compilation of the upload canister is correct. These should be added, but better done in a separate PR.