### PR TITLE
chore: add mainnet explorer bitcoinexplorer.org

### DIFF
--- a/watchdog/candid.did
+++ b/watchdog/candid.did
@@ -24,6 +24,7 @@ type bitcoin_block_api = variant {
     api_blockcypher_com_mainnet;
     api_blockcypher_com_testnet;
     bitcoin_canister;
+    bitcoinexplorer_org_mainnet;
     blockchain_info_mainnet;
     blockstream_info_mainnet;
     blockstream_info_testnet;

--- a/watchdog/src/bitcoin_block_apis.rs
+++ b/watchdog/src/bitcoin_block_apis.rs
@@ -31,6 +31,9 @@ pub enum BitcoinBlockApi {
     #[serde(rename = "bitcoin_canister")]
     BitcoinCanister, // Not an explorer.
 
+    #[serde(rename = "bitcoinexplorer_org_mainnet")]
+    BitcoinExplorerOrgMainnet,
+
     #[serde(rename = "blockchain_info_mainnet")]
     BlockchainInfoMainnet,
 
@@ -98,6 +101,7 @@ impl BitcoinBlockApi {
             BitcoinBlockApi::ApiBitapsComMainnet,
             BitcoinBlockApi::ApiBlockchairComMainnet,
             BitcoinBlockApi::ApiBlockcypherComMainnet,
+            BitcoinBlockApi::BitcoinExplorerOrgMainnet,
             BitcoinBlockApi::BlockchainInfoMainnet,
             BitcoinBlockApi::BlockstreamInfoMainnet,
             BitcoinBlockApi::ChainApiBtcComMainnet,
@@ -146,6 +150,9 @@ impl BitcoinBlockApi {
                 http_request(endpoint_api_blockcypher_com_block_testnet()).await
             }
             BitcoinBlockApi::BitcoinCanister => http_request(endpoint_bitcoin_canister()).await,
+            BitcoinBlockApi::BitcoinExplorerOrgMainnet => {
+                http_request(endpoint_bitcoinexplorer_org_block_mainnet()).await
+            }
             BitcoinBlockApi::BlockchainInfoMainnet => {
                 let futures = vec![
                     http_request(endpoint_blockchain_info_height_mainnet()),

--- a/watchdog/src/bitcoin_block_apis.rs
+++ b/watchdog/src/bitcoin_block_apis.rs
@@ -292,6 +292,20 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_bitcoinexplorer_org_mainnet() {
+        test_utils::mock_mainnet_outcalls();
+        run_test(
+            BitcoinBlockApi::BitcoinExplorerOrgMainnet,
+            vec![(endpoint_bitcoinexplorer_org_block_mainnet(), 1)],
+            json!({
+                "height": 861687,
+                "hash": "00000000000000000000fde077ede6f8ea5b0b03631eb7467bd344808998dced",
+            }),
+        )
+        .await;
+    }
+
+    #[tokio::test]
     async fn test_api_blockchair_com_mainnet() {
         test_utils::mock_mainnet_outcalls();
         run_test(

--- a/watchdog/src/bitcoin_block_apis.rs
+++ b/watchdog/src/bitcoin_block_apis.rs
@@ -495,6 +495,10 @@ mod test {
             ),
             (BitcoinBlockApi::BitcoinCanister, "bitcoin_canister"),
             (
+                BitcoinBlockApi::BitcoinExplorerOrgMainnet,
+                "bitcoinexplorer_org_mainnet",
+            ),
+            (
                 BitcoinBlockApi::BlockchainInfoMainnet,
                 "blockchain_info_mainnet",
             ),

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -69,6 +69,7 @@ impl Config {
                 BitcoinBlockApi::ApiBitapsComMainnet,
                 BitcoinBlockApi::ApiBlockchairComMainnet,
                 BitcoinBlockApi::ApiBlockcypherComMainnet,
+                BitcoinBlockApi::BitcoinExplorerOrgMainnet,
                 BitcoinBlockApi::BlockchainInfoMainnet,
                 BitcoinBlockApi::BlockstreamInfoMainnet,
                 BitcoinBlockApi::ChainApiBtcComMainnet,
@@ -88,8 +89,7 @@ impl Config {
             delay_before_first_fetch_sec: DELAY_BEFORE_FIRST_FETCH_SEC,
             interval_between_fetches_sec: INTERVAL_BETWEEN_FETCHES_SEC,
             explorers: vec![
-                // NOTE: Disabled due to flakiness.
-                // BitcoinBlockApi::ApiBitapsComTestnet,
+                BitcoinBlockApi::ApiBitapsComTestnet,
                 BitcoinBlockApi::ApiBlockchairComTestnet,
                 BitcoinBlockApi::ApiBlockcypherComTestnet,
                 BitcoinBlockApi::BlockstreamInfoTestnet,

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -89,7 +89,8 @@ impl Config {
             delay_before_first_fetch_sec: DELAY_BEFORE_FIRST_FETCH_SEC,
             interval_between_fetches_sec: INTERVAL_BETWEEN_FETCHES_SEC,
             explorers: vec![
-                BitcoinBlockApi::ApiBitapsComTestnet,
+                // NOTE: Disabled due to flakiness.
+                // BitcoinBlockApi::ApiBitapsComTestnet,
                 BitcoinBlockApi::ApiBlockchairComTestnet,
                 BitcoinBlockApi::ApiBlockcypherComTestnet,
                 BitcoinBlockApi::BlockstreamInfoTestnet,

--- a/watchdog/src/endpoints.rs
+++ b/watchdog/src/endpoints.rs
@@ -171,10 +171,9 @@ pub fn endpoint_bitcoinexplorer_org_block_mainnet() -> HttpRequestConfig {
         }),
         |raw| {
             apply_to_body_json(raw, |json| {
-                let data = json["data"].clone();
                 json!({
-                    "height": data["height"].as_u64(),
-                    "hash": data["hash"].as_str(),
+                    "height": json["height"].as_u64(),
+                    "hash": json["hash"].as_str(),
                 })
             })
         },
@@ -558,6 +557,7 @@ mod test {
                 "transform_api_blockchair_com_block",
                 "transform_api_blockcypher_com_block",
                 "transform_bitcoin_canister",
+                "transform_bitcoinexplorer_org_block",
                 "transform_blockchain_info_hash",
                 "transform_blockchain_info_height",
                 "transform_blockstream_info_hash",

--- a/watchdog/src/endpoints.rs
+++ b/watchdog/src/endpoints.rs
@@ -4,9 +4,9 @@ use crate::print;
 use crate::{
     transform_api_bitaps_com_block, transform_api_blockchair_com_block,
     transform_api_blockcypher_com_block, transform_bitcoin_canister,
-    transform_blockchain_info_hash, transform_blockchain_info_height,
-    transform_blockstream_info_hash, transform_blockstream_info_height,
-    transform_chain_api_btc_com_block,
+    transform_bitcoinexplorer_org_block, transform_blockchain_info_hash,
+    transform_blockchain_info_height, transform_blockstream_info_hash,
+    transform_blockstream_info_height, transform_chain_api_btc_com_block,
 };
 use ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs};
 use regex::Regex;
@@ -156,6 +156,26 @@ pub fn endpoint_bitcoin_canister() -> HttpRequestConfig {
                         .to_string()
                     })
                     .unwrap_or_default()
+            })
+        },
+    )
+}
+
+/// Creates a config for fetching mainnet block data from bitcoinexplorer.org.
+pub fn endpoint_bitcoinexplorer_org_block_mainnet() -> HttpRequestConfig {
+    HttpRequestConfig::new(
+        "https://bitcoinexplorer.org/api/blocks/tip",
+        Some(TransformFnWrapper {
+            name: "transform_bitcoinexplorer_org_block",
+            func: transform_bitcoinexplorer_org_block,
+        }),
+        |raw| {
+            apply_to_body_json(raw, |json| {
+                let data = json["data"].clone();
+                json!({
+                    "height": data["height"].as_u64(),
+                    "hash": data["hash"].as_str(),
+                })
             })
         },
     )

--- a/watchdog/src/fetch.rs
+++ b/watchdog/src/fetch.rs
@@ -72,6 +72,10 @@ mod test {
                     height: Some(700003),
                 },
                 BlockInfo {
+                    provider: BitcoinBlockApi::BitcoinExplorerOrgMainnet,
+                    height: Some(861687),
+                },
+                BlockInfo {
                     provider: BitcoinBlockApi::BlockchainInfoMainnet,
                     height: Some(700004),
                 },
@@ -100,6 +104,10 @@ mod test {
         assert_eq!(
             result,
             vec![
+                BlockInfo {
+                    provider: BitcoinBlockApi::ApiBitapsComTestnet,
+                    height: Some(2000001),
+                },
                 BlockInfo {
                     provider: BitcoinBlockApi::ApiBlockchairComTestnet,
                     height: Some(2000002),
@@ -142,6 +150,10 @@ mod test {
                     height: None,
                 },
                 BlockInfo {
+                    provider: BitcoinBlockApi::BitcoinExplorerOrgMainnet,
+                    height: None,
+                },
+                BlockInfo {
                     provider: BitcoinBlockApi::BlockchainInfoMainnet,
                     height: None,
                 },
@@ -170,6 +182,10 @@ mod test {
         assert_eq!(
             result,
             vec![
+                BlockInfo {
+                    provider: BitcoinBlockApi::ApiBitapsComTestnet,
+                    height: None,
+                },
                 BlockInfo {
                     provider: BitcoinBlockApi::ApiBlockchairComTestnet,
                     height: None,

--- a/watchdog/src/fetch.rs
+++ b/watchdog/src/fetch.rs
@@ -105,10 +105,6 @@ mod test {
             result,
             vec![
                 BlockInfo {
-                    provider: BitcoinBlockApi::ApiBitapsComTestnet,
-                    height: Some(2000001),
-                },
-                BlockInfo {
                     provider: BitcoinBlockApi::ApiBlockchairComTestnet,
                     height: Some(2000002),
                 },
@@ -182,10 +178,6 @@ mod test {
         assert_eq!(
             result,
             vec![
-                BlockInfo {
-                    provider: BitcoinBlockApi::ApiBitapsComTestnet,
-                    height: None,
-                },
                 BlockInfo {
                     provider: BitcoinBlockApi::ApiBlockchairComTestnet,
                     height: None,

--- a/watchdog/src/health.rs
+++ b/watchdog/src/health.rs
@@ -56,18 +56,22 @@ pub fn health_status() -> HealthStatus {
     )
 }
 
-/// Compares the source with the other explorers.
-fn compare(source: Option<BlockInfo>, explorers: Vec<BlockInfo>, config: Config) -> HealthStatus {
-    let height_source = source.and_then(|block| block.height);
+fn calculate_height_target(explorers: &[BlockInfo], config: &Config) -> Option<u64> {
     let heights = explorers
         .iter()
         .filter_map(|block| block.height)
         .collect::<Vec<_>>();
-    let height_target = if heights.len() < config.min_explorers as usize {
+    if heights.len() < config.min_explorers as usize {
         None // Not enough data from explorers.
     } else {
         median(heights)
-    };
+    }
+}
+
+/// Compares the source with the other explorers.
+fn compare(source: Option<BlockInfo>, explorers: Vec<BlockInfo>, config: Config) -> HealthStatus {
+    let height_source = source.and_then(|block| block.height);
+    let height_target = calculate_height_target(&explorers, &config);
     let height_diff = height_source
         .zip(height_target)
         .map(|(source, target)| source as i64 - target as i64);

--- a/watchdog/src/health.rs
+++ b/watchdog/src/health.rs
@@ -110,14 +110,14 @@ fn compare(source: Option<BlockInfo>, explorers: Vec<BlockInfo>, config: Config)
 /// The median of the given values.
 fn median(mut values: Vec<u64>) -> Option<u64> {
     let length = values.len();
+
     if length == 0 {
         return None;
     }
 
-    values.sort_unstable();
+    values.sort();
 
     let mid_index = length / 2;
-    // If even number of elements, take the average of the two middle ones.
     let median_value = if length % 2 == 0 {
         (values[mid_index - 1] + values[mid_index]) / 2
     } else {

--- a/watchdog/src/lib.rs
+++ b/watchdog/src/lib.rs
@@ -154,6 +154,11 @@ fn transform_bitcoin_canister(raw: TransformArgs) -> HttpResponse {
 }
 
 #[query]
+fn transform_bitcoinexplorer_org_block(raw: TransformArgs) -> HttpResponse {
+    endpoint_bitcoinexplorer_org_block_mainnet().transform(raw)
+}
+
+#[query]
 fn transform_blockchain_info_hash(raw: TransformArgs) -> HttpResponse {
     endpoint_blockchain_info_hash_mainnet().transform(raw)
 }

--- a/watchdog/src/test_utils.rs
+++ b/watchdog/src/test_utils.rs
@@ -20,6 +20,10 @@ pub fn mock_mainnet_outcalls() {
             BITCOIN_CANISTER_MAINNET_RESPONSE,
         ),
         (
+            endpoint_bitcoinexplorer_org_block_mainnet(),
+            BITCOINEXPLORER_ORG_MAINNET_RESPONSE,
+        ),
+        (
             endpoint_blockchain_info_hash_mainnet(),
             BLOCKCHAIN_INFO_HASH_MAINNET_RESPONSE,
         ),
@@ -96,6 +100,7 @@ pub fn mock_all_outcalls_404() {
         endpoint_api_blockcypher_com_block_mainnet(),
         endpoint_api_blockcypher_com_block_testnet(),
         endpoint_bitcoin_canister(),
+        endpoint_bitcoinexplorer_org_block_mainnet(),
         endpoint_blockchain_info_hash_mainnet(),
         endpoint_blockchain_info_height_mainnet(),
         endpoint_blockstream_info_hash_mainnet(),
@@ -119,6 +124,7 @@ pub fn mock_all_outcalls_abusing_api() {
         endpoint_api_blockcypher_com_block_mainnet(),
         endpoint_api_blockcypher_com_block_testnet(),
         endpoint_bitcoin_canister(),
+        endpoint_bitcoinexplorer_org_block_mainnet(),
         endpoint_blockchain_info_hash_mainnet(),
         endpoint_blockchain_info_height_mainnet(),
         endpoint_blockstream_info_hash_mainnet(),
@@ -349,6 +355,12 @@ pub const BITCOIN_CANISTER_TESTNET_RESPONSE: &str = r#"{
     # HELP address_utxos_length The number of UTXOs that are owned by supported addresses.
     # TYPE address_utxos_length gauge
     address_utxos_length 28388537 1682533330541
+}"#;
+
+// https://bitcoinexplorer.org/api/blocks/tip
+pub const BITCOINEXPLORER_ORG_MAINNET_RESPONSE: &str = r#"{
+    "height": 861687,
+    "hash": "00000000000000000000fde077ede6f8ea5b0b03631eb7467bd344808998dced"
 }"#;
 
 // https://blockchain.info/q/latesthash


### PR DESCRIPTION
This PR adds `bitcoinexplorer.org` as a Bitcoin mainnet explorer, expanding the total number of data sources to 7.

By increasing the number of explorers, we enhance data diversity and improve overall stability.
