### PR TITLE
feat: improve height target calculation for watchdog canister

### DIFF
--- a/watchdog/src/health.rs
+++ b/watchdog/src/health.rs
@@ -56,6 +56,7 @@ pub fn health_status() -> HealthStatus {
     )
 }
 
+/// Returns the median if `min_explorers` are within the block range around it.
 fn calculate_height_target(
     heights: &[u64],
     min_explorers: usize,
@@ -66,10 +67,10 @@ fn calculate_height_target(
         return None;
     }
 
-    let median = median(heights)? as i64;
+    let threshold = median(heights)? as i64;
     let (lo, hi) = (
-        (median + blocks_behind_threshold).max(0) as u64,
-        (median + blocks_ahead_threshold).max(0) as u64,
+        threshold.saturating_add(blocks_behind_threshold) as u64,
+        threshold.saturating_add(blocks_ahead_threshold) as u64,
     );
     let valid_explorers = heights
         .iter()
@@ -77,8 +78,7 @@ fn calculate_height_target(
         .count();
 
     if valid_explorers >= min_explorers {
-        // Return the median if enough explorers are within range.
-        Some(median as u64)
+        Some(threshold as u64)
     } else {
         None
     }

--- a/watchdog/src/health.rs
+++ b/watchdog/src/health.rs
@@ -178,17 +178,15 @@ mod test {
 
     #[test]
     fn test_calculate_height_target_not_enough_explorers() {
-        // Within threshold.
         test_calculate_height_target(CalculateHeightTargetTestData {
-            heights: &[10, 12],
+            heights: &[10, 12], // Within threshold.
             min_explorers: 3,
             blocks_behind_threshold: -1,
             blocks_ahead_threshold: 1,
             expected: None,
         });
-        // Outside threshold.
         test_calculate_height_target(CalculateHeightTargetTestData {
-            heights: &[10, 13],
+            heights: &[10, 13], // Outside threshold.
             min_explorers: 3,
             blocks_behind_threshold: -1,
             blocks_ahead_threshold: 1,
@@ -198,17 +196,15 @@ mod test {
 
     #[test]
     fn test_calculate_height_target_explorers_not_in_range() {
-        // Above threshold.
         test_calculate_height_target(CalculateHeightTargetTestData {
-            heights: &[10, 10, 12],
+            heights: &[10, 10, 12], // Above threshold.
             min_explorers: 3,
             blocks_behind_threshold: -1,
             blocks_ahead_threshold: 1,
             expected: None,
         });
-        // Below threshold.
         test_calculate_height_target(CalculateHeightTargetTestData {
-            heights: &[8, 10, 10],
+            heights: &[8, 10, 10], // Below threshold.
             min_explorers: 3,
             blocks_behind_threshold: -1,
             blocks_ahead_threshold: 1,
@@ -218,17 +214,15 @@ mod test {
 
     #[test]
     fn test_calculate_height_target_explorers_are_in_range() {
-        // Above threshold.
         test_calculate_height_target(CalculateHeightTargetTestData {
-            heights: &[10, 10, 11],
+            heights: &[10, 10, 11], // Above threshold.
             min_explorers: 3,
             blocks_behind_threshold: -1,
             blocks_ahead_threshold: 1,
             expected: Some(10),
         });
-        // Below threshold.
         test_calculate_height_target(CalculateHeightTargetTestData {
-            heights: &[9, 10, 10],
+            heights: &[9, 10, 10], // Below threshold.
             min_explorers: 3,
             blocks_behind_threshold: -1,
             blocks_ahead_threshold: 1,

--- a/watchdog/src/health.rs
+++ b/watchdog/src/health.rs
@@ -157,6 +157,7 @@ mod test {
         assert_eq!(median(&[20, 15, 10]), Some(15));
     }
 
+    /// Test data for `calculate_height_target`.
     struct CalculateHeightTargetTestData {
         heights: &'static [u64],
         min_explorers: usize,
@@ -165,6 +166,7 @@ mod test {
         expected: Option<u64>,
     }
 
+    /// Tests `calculate_height_target` with the given test data.
     fn test_calculate_height_target(params: CalculateHeightTargetTestData) {
         assert_eq!(
             calculate_height_target(

--- a/watchdog/src/health.rs
+++ b/watchdog/src/health.rs
@@ -178,8 +178,17 @@ mod test {
 
     #[test]
     fn test_calculate_height_target_not_enough_explorers() {
+        // Within threshold.
         test_calculate_height_target(CalculateHeightTargetTestData {
-            heights: &[10],
+            heights: &[10, 12],
+            min_explorers: 3,
+            blocks_behind_threshold: -1,
+            blocks_ahead_threshold: 1,
+            expected: None,
+        });
+        // Outside threshold.
+        test_calculate_height_target(CalculateHeightTargetTestData {
+            heights: &[10, 13],
             min_explorers: 3,
             blocks_behind_threshold: -1,
             blocks_ahead_threshold: 1,
@@ -189,8 +198,17 @@ mod test {
 
     #[test]
     fn test_calculate_height_target_explorers_not_in_range() {
+        // Above threshold.
         test_calculate_height_target(CalculateHeightTargetTestData {
-            heights: &[10, 20, 30],
+            heights: &[10, 10, 12],
+            min_explorers: 3,
+            blocks_behind_threshold: -1,
+            blocks_ahead_threshold: 1,
+            expected: None,
+        });
+        // Below threshold.
+        test_calculate_height_target(CalculateHeightTargetTestData {
+            heights: &[8, 10, 10],
             min_explorers: 3,
             blocks_behind_threshold: -1,
             blocks_ahead_threshold: 1,
@@ -200,12 +218,21 @@ mod test {
 
     #[test]
     fn test_calculate_height_target_explorers_are_in_range() {
+        // Above threshold.
         test_calculate_height_target(CalculateHeightTargetTestData {
-            heights: &[10, 11, 12],
+            heights: &[10, 10, 11],
             min_explorers: 3,
             blocks_behind_threshold: -1,
             blocks_ahead_threshold: 1,
-            expected: Some(11),
+            expected: Some(10),
+        });
+        // Below threshold.
+        test_calculate_height_target(CalculateHeightTargetTestData {
+            heights: &[9, 10, 10],
+            min_explorers: 3,
+            blocks_behind_threshold: -1,
+            blocks_ahead_threshold: 1,
+            expected: Some(10),
         });
     }
 

--- a/watchdog/src/health.rs
+++ b/watchdog/src/health.rs
@@ -72,10 +72,7 @@ fn calculate_height_target(
         threshold.saturating_add(blocks_behind_threshold) as u64,
         threshold.saturating_add(blocks_ahead_threshold) as u64,
     );
-    let valid_explorers = heights
-        .iter()
-        .filter(|&height| (lo..=hi).contains(height))
-        .count();
+    let valid_explorers = heights.iter().filter(|&x| (lo..=hi).contains(x)).count();
 
     if valid_explorers >= min_explorers {
         Some(threshold as u64)

--- a/watchdog/src/health.rs
+++ b/watchdog/src/health.rs
@@ -157,14 +157,15 @@ mod test {
         assert_eq!(median(&[20, 15, 10]), Some(15));
     }
 
-    struct CalculateHeightTargetParams {
+    struct CalculateHeightTargetTestData {
         heights: &'static [u64],
         min_explorers: usize,
         blocks_behind_threshold: i64,
         blocks_ahead_threshold: i64,
+        expected: Option<u64>,
     }
 
-    fn test_calculate_height_target(params: CalculateHeightTargetParams, expected: Option<u64>) {
+    fn test_calculate_height_target(params: CalculateHeightTargetTestData) {
         assert_eq!(
             calculate_height_target(
                 params.heights,
@@ -172,47 +173,41 @@ mod test {
                 params.blocks_behind_threshold,
                 params.blocks_ahead_threshold
             ),
-            expected
+            params.expected
         );
     }
 
     #[test]
     fn test_calculate_height_target_not_enough_explorers() {
-        test_calculate_height_target(
-            CalculateHeightTargetParams {
-                heights: &[10],
-                min_explorers: 3,
-                blocks_behind_threshold: -1,
-                blocks_ahead_threshold: 1,
-            },
-            None,
-        );
+        test_calculate_height_target(CalculateHeightTargetTestData {
+            heights: &[10],
+            min_explorers: 3,
+            blocks_behind_threshold: -1,
+            blocks_ahead_threshold: 1,
+            expected: None,
+        });
     }
 
     #[test]
     fn test_calculate_height_target_explorers_not_in_range() {
-        test_calculate_height_target(
-            CalculateHeightTargetParams {
-                heights: &[10, 20, 30],
-                min_explorers: 3,
-                blocks_behind_threshold: -1,
-                blocks_ahead_threshold: 1,
-            },
-            None,
-        );
+        test_calculate_height_target(CalculateHeightTargetTestData {
+            heights: &[10, 20, 30],
+            min_explorers: 3,
+            blocks_behind_threshold: -1,
+            blocks_ahead_threshold: 1,
+            expected: None,
+        });
     }
 
     #[test]
     fn test_calculate_height_target_explorers_are_in_range() {
-        test_calculate_height_target(
-            CalculateHeightTargetParams {
-                heights: &[10, 11, 12],
-                min_explorers: 3,
-                blocks_behind_threshold: -1,
-                blocks_ahead_threshold: 1,
-            },
-            Some(11),
-        );
+        test_calculate_height_target(CalculateHeightTargetTestData {
+            heights: &[10, 11, 12],
+            min_explorers: 3,
+            blocks_behind_threshold: -1,
+            blocks_ahead_threshold: 1,
+            expected: Some(11),
+        });
     }
 
     #[test]

--- a/watchdog/src/health.rs
+++ b/watchdog/src/health.rs
@@ -157,19 +157,62 @@ mod test {
         assert_eq!(median(&[20, 15, 10]), Some(15));
     }
 
+    struct CalculateHeightTargetParams {
+        heights: &'static [u64],
+        min_explorers: usize,
+        blocks_behind_threshold: i64,
+        blocks_ahead_threshold: i64,
+    }
+
+    fn test_calculate_height_target(params: CalculateHeightTargetParams, expected: Option<u64>) {
+        assert_eq!(
+            calculate_height_target(
+                params.heights,
+                params.min_explorers,
+                params.blocks_behind_threshold,
+                params.blocks_ahead_threshold
+            ),
+            expected
+        );
+    }
+
     #[test]
     fn test_calculate_height_target_not_enough_explorers() {
-        assert_eq!(calculate_height_target(&[10], 3, -1, 1), None);
+        test_calculate_height_target(
+            CalculateHeightTargetParams {
+                heights: &[10],
+                min_explorers: 3,
+                blocks_behind_threshold: -1,
+                blocks_ahead_threshold: 1,
+            },
+            None,
+        );
     }
 
     #[test]
     fn test_calculate_height_target_explorers_not_in_range() {
-        assert_eq!(calculate_height_target(&[10, 20, 30], 3, -1, 1), None);
+        test_calculate_height_target(
+            CalculateHeightTargetParams {
+                heights: &[10, 20, 30],
+                min_explorers: 3,
+                blocks_behind_threshold: -1,
+                blocks_ahead_threshold: 1,
+            },
+            None,
+        );
     }
 
     #[test]
     fn test_calculate_height_target_explorers_are_in_range() {
-        assert_eq!(calculate_height_target(&[10, 11, 12], 3, -1, 1), Some(11));
+        test_calculate_height_target(
+            CalculateHeightTargetParams {
+                heights: &[10, 11, 12],
+                min_explorers: 3,
+                blocks_behind_threshold: -1,
+                blocks_ahead_threshold: 1,
+            },
+            Some(11),
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR makes calculation of height target for watchdog canister more strict.

- Before: The target height is the median of explorer heights if there are enough explorers (>= `min_explorers`).
- After: The target height is the median only if enough explorers (>= `min_explorers`) are within a defined range of the median.

Configs (currently in prod):
- `mainnet` -- explorers 6, min_explorers 3, blocks range [-2, 2]
- `testnet` -- explorers 3, min_explorers 2, blocks range [-1000, 1000]

Making the height target calculation more strict for the `testnet` is necessary because the `testnet` has fewer explorers and greater instability, leading to large block height divergences. A stricter calculation helps reduce noise and false positives by ensuring only explorers with closely aligned heights are considered valid, improving accuracy and stability.

Mainnet explorers: 
<img width="684" alt="image" src="https://github.com/user-attachments/assets/119299a0-ed5f-40cf-94eb-f08ef9774709">
<img width="684" alt="image" src="https://github.com/user-attachments/assets/77dab57a-3cd4-4d50-9229-ee7ab42d9643">

Testnet explorers: 
<img width="684" alt="image" src="https://github.com/user-attachments/assets/7d75c6d5-48a7-493c-bc93-7fff7f0dd510">
<img width="684" alt="image" src="https://github.com/user-attachments/assets/cded3b13-362f-4c2a-bec5-bae7e2b1339e">
