### PR TITLE
feat: re-enable tracking api.bitaps.com testnet explorer in watchdog canister

### DIFF
--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -89,8 +89,7 @@ impl Config {
             delay_before_first_fetch_sec: DELAY_BEFORE_FIRST_FETCH_SEC,
             interval_between_fetches_sec: INTERVAL_BETWEEN_FETCHES_SEC,
             explorers: vec![
-                // NOTE: Disabled due to flakiness.
-                // BitcoinBlockApi::ApiBitapsComTestnet,
+                BitcoinBlockApi::ApiBitapsComTestnet,
                 BitcoinBlockApi::ApiBlockchairComTestnet,
                 BitcoinBlockApi::ApiBlockcypherComTestnet,
                 BitcoinBlockApi::BlockstreamInfoTestnet,

--- a/watchdog/src/fetch.rs
+++ b/watchdog/src/fetch.rs
@@ -105,6 +105,10 @@ mod test {
             result,
             vec![
                 BlockInfo {
+                    provider: BitcoinBlockApi::ApiBitapsComTestnet,
+                    height: Some(2000001),
+                },
+                BlockInfo {
                     provider: BitcoinBlockApi::ApiBlockchairComTestnet,
                     height: Some(2000002),
                 },
@@ -178,6 +182,10 @@ mod test {
         assert_eq!(
             result,
             vec![
+                BlockInfo {
+                    provider: BitcoinBlockApi::ApiBitapsComTestnet,
+                    height: None,
+                },
                 BlockInfo {
                     provider: BitcoinBlockApi::ApiBlockchairComTestnet,
                     height: None,


### PR DESCRIPTION
This PR re-enables the `api.bitaps.com` explorer for the testnet.

It was previously disabled due to instability, but with the stricter height target calculation introduced in [PR327](https://github.com/dfinity/bitcoin-canister/pull/327), this should improve the stability of testnet alerts.
