### PR TITLE
chore: Update gitignore and minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,13 @@ canister_ids.json
 .canbench
 
 *.wasm.gz
+
+bootstrap/data/
+bootstrap/canister_state/
+bootstrap/block_headers
+bootstrap/canister_state.bin
+bootstrap/unstable_blocks
+bootstrap/chunk_hashes.txt
+bootstrap/utxodump_shuffled.csv
+bootstrap/utxodump.csv
+chunk_hashes.txt

--- a/scripts/build-canister.sh
+++ b/scripts/build-canister.sh
@@ -41,15 +41,15 @@ if [[ "$STATUS" -eq "0" ]]; then
 
     if [[ "$CANISTER" == "ic-btc-canister" ]]; then
       ./target/bin/ic-wasm \
-      "./target/$TARGET/release/$CANISTER.wasm" \
-      -o "./target/$TARGET/release/$CANISTER.wasm" \
+      "./target/$TARGET/${PROFILE}/$CANISTER.wasm" \
+      -o "./target/$TARGET/${PROFILE}/$CANISTER.wasm" \
       metadata candid:service -f "$SCRIPT_DIR/../canister/candid.did" -v public
     fi
 
     if [[ "$CANISTER" == "watchdog" ]]; then
       ./target/bin/ic-wasm \
-      "./target/$TARGET/release/$CANISTER.wasm" \
-      -o "./target/$TARGET/release/$CANISTER.wasm" \
+      "./target/$TARGET/${PROFILE}/$CANISTER.wasm" \
+      -o "./target/$TARGET/${PROFILE}/$CANISTER.wasm" \
       metadata candid:service -f "$SCRIPT_DIR/../watchdog/candid.did" -v public
     fi
 


### PR DESCRIPTION
This updates `gitignore` file for the bootstrap artifacts and paths in `build-canister`.