### PR TITLE
fix: fix header adjustment interval underflow

### DIFF
--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -749,26 +749,28 @@ mod test {
     fn test_compute_next_difficulty_for_backdated_blocks() {
         // Arrange: Set up the test network and parameters
         let network = Network::Testnet;
-        let chain_length = DIFFICULTY_ADJUSTMENT_INTERVAL - 1; // To trigger difficulty adjustment
-        let initial_difficulty = 486604799;
+        let chain_length = DIFFICULTY_ADJUSTMENT_INTERVAL - 1; // To trigger the difficulty adjustment.
+        let genesis_difficulty = 486604799;
 
         // Create the genesis header and initialize the header store
-        let genesis_header = genesis_header(initial_difficulty);
+        let genesis_header = genesis_header(genesis_difficulty);
         let mut store = SimpleHeaderStore::new(genesis_header, 0);
 
         // Populate the header chain with timestamps decreasing by 1 second
-        (1..chain_length).for_each(|_| {
+        let mut last_header = genesis_header;
+        for _ in 1..chain_length {
             let new_header = BlockHeader {
-                prev_blockhash: genesis_header.block_hash(),
-                time: genesis_header.time - 1, // Each new block is 1 second earlier
+                prev_blockhash: last_header.block_hash(),
+                time: last_header.time - 1, // Each new block is 1 second earlier
                 bits: pow_limit_bits(&network),
-                ..genesis_header
+                ..last_header
             };
             store.add(new_header);
-        });
+            last_header = new_header; // Update the last header for the next iteration
+        }
 
         // Act: Compute the next difficulty
-        let difficulty = compute_next_difficulty(&network, &store, &genesis_header, chain_length);
+        let difficulty = compute_next_difficulty(&network, &store, &last_header, chain_length);
 
         // Assert: Verify the computed difficulty matches the expected value
         assert_eq!(difficulty, 473956288);

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -755,8 +755,6 @@ mod test {
         // Create the genesis header and initialize the header store
         let genesis_header = genesis_header(genesis_difficulty);
         let mut store = SimpleHeaderStore::new(genesis_header, 0);
-
-        // Populate the header chain with timestamps decreasing by 1 second
         let mut last_header = genesis_header;
         for _ in 1..chain_length {
             let new_header = BlockHeader {
@@ -765,13 +763,13 @@ mod test {
                 ..last_header
             };
             store.add(new_header);
-            last_header = new_header; // Update the last header for the next iteration
+            last_header = new_header;
         }
 
-        // Act: Compute the next difficulty
+        // Act.
         let difficulty = compute_next_difficulty(&network, &store, &last_header, chain_length);
 
-        // Assert: Verify the computed difficulty matches the expected value
+        // Assert.
         assert_eq!(difficulty, 473956288);
     }
 }

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -762,7 +762,6 @@ mod test {
             let new_header = BlockHeader {
                 prev_blockhash: last_header.block_hash(),
                 time: last_header.time - 1, // Each new block is 1 second earlier
-                bits: pow_limit_bits(&network),
                 ..last_header
             };
             store.add(new_header);

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -746,7 +746,7 @@ mod test {
     }
 
     #[test]
-    fn test_compute_next_difficulty_new_block_with_earlier_timestamp() {
+    fn test_compute_next_difficulty_for_backdated_blocks() {
         // Arrange: Set up the test network and initial parameters
         let network = Network::Testnet;
         let chain_length = DIFFICULTY_ADJUSTMENT_INTERVAL - 1;

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -254,7 +254,6 @@ fn compute_next_difficulty(
 
     let height = prev_height + 1;
     if height % DIFFICULTY_ADJUSTMENT_INTERVAL != 0 || no_pow_retargeting(network) {
-        println!("ABC quick return: {}", prev_header.bits);
         return prev_header.bits;
     }
 

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -748,29 +748,30 @@ mod test {
 
     #[test]
     fn test_compute_next_difficulty_new_block_with_earlier_timestamp() {
-        // Arrange.
+        // Arrange: Set up the test network and initial parameters
         let network = Network::Testnet;
-        let initial_pow = 0;
-        let chain_length = 2015;
-        let pow_limit = pow_limit_bits(&network);
-        let h0 = genesis_header(initial_pow);
-        let mut store = SimpleHeaderStore::new(h0, 0);
-        let mut last_header = h0;
+        let chain_length = DIFFICULTY_ADJUSTMENT_INTERVAL - 1;
+
+        // Create the genesis header and initialize the store
+        // by the header chain with timestamps decreasing by 1 second.
+        let genesis_header = genesis_header(0);
+        let mut store = SimpleHeaderStore::new(genesis_header, 0);
+        let mut last_header = genesis_header;
         for _ in 1..chain_length {
             let new_header = BlockHeader {
                 prev_blockhash: last_header.block_hash(),
-                time: last_header.time - 1, // new block is 1 second earlier.
-                bits: pow_limit,
+                time: last_header.time - 1, // Each new block is 1 second earlier
+                bits: pow_limit_bits(&network),
                 ..last_header
             };
             store.add(new_header);
             last_header = new_header;
         }
 
-        // Act.
+        // Act: Compute the next difficulty
         let difficulty = compute_next_difficulty(&network, &store, &last_header, chain_length);
 
-        // Assert.
+        // Assert: Verify the computed difficulty matches the expected value
         assert_eq!(difficulty, 473956288);
     }
 }


### PR DESCRIPTION
This PR addresses an underflow issue in the calculation of the adjustment interval.

The issue arises because the `time` field in a block header is permitted to have a roughly 3-hour window around the current time (1 hour in the past and 2 hours in the future). This can result in the newest block having a smaller timestamp, especially on testnet networks where many blocks can be created within a short time frame (e.g., over 2'016 blocks in 1 hour).

Reference "MIT Lecture on Bitcoin syncronization" [youtube](https://youtu.be/1Qws70XGSq4?si=oQkIHCk6URu52byz&t=692).
