### PR TITLE
fix: fix network validation in bootstrap scripts

### DIFF
--- a/bootstrap/utils.sh
+++ b/bootstrap/utils.sh
@@ -7,10 +7,16 @@ set -euo pipefail
 validate_network() {
     local network=$1
     local valid_networks=("mainnet" "testnet")
-    if ! [[ " ${valid_networks[*]} " =~ $network ]]; then
-        echo "Error: NETWORK must be one of ${valid_networks[*]}."
-        exit 1
-    fi
+
+    for valid_network in "${valid_networks[@]}"; do
+        if [[ "$network" == "$valid_network" ]]; then
+            # Network is valid
+            return 0
+        fi
+    done
+
+    echo "Error: NETWORK must be one of [ ${valid_networks[*]} ]."
+    exit 1
 }
 
 # Generate the Bitcoin configuration file with optional parameters.


### PR DESCRIPTION
This PR fixes the network validation to avoid substring matching.

It was possible to have a partial match with `net` for either `mainnet` or `testnet`.