### PR TITLE
chore: rename usage of BlockHeader to Header for bitcoin crate v.0.32.4 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ target
 .dfx
 canister_ids.json
 .canbench
+pocket-ic
 
 *.wasm.gz
 

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1,5 +1,5 @@
 use bitcoin::consensus::Decodable;
-use bitcoin::{consensus::Encodable, Block as BitcoinBlock, BlockHeader};
+use bitcoin::{consensus::Encodable, Block as BitcoinBlock, BlockHeader as Header};
 use canbench_rs::{bench, bench_fn, BenchResult};
 use ic_btc_canister::{types::BlockHeaderBlob, with_state_mut};
 use ic_btc_interface::{InitConfig, Network};
@@ -103,8 +103,7 @@ fn insert_block_headers() -> BenchResult {
         let mut next_block_headers = vec![];
         for i in blocks_to_insert..blocks_to_insert + block_headers_to_insert {
             let mut block_header_blob = vec![];
-            BlockHeader::consensus_encode(blocks[i as usize].header(), &mut block_header_blob)
-                .unwrap();
+            Header::consensus_encode(blocks[i as usize].header(), &mut block_header_blob).unwrap();
             next_block_headers.push(BlockHeaderBlob::from(block_header_blob));
         }
 
@@ -133,8 +132,7 @@ fn insert_block_headers_multiple_times() -> BenchResult {
         let mut next_block_headers = vec![];
         for i in 0..1000 {
             let mut block_header_blob = vec![];
-            BlockHeader::consensus_encode(blocks[i as usize].header(), &mut block_header_blob)
-                .unwrap();
+            Header::consensus_encode(blocks[i as usize].header(), &mut block_header_blob).unwrap();
             next_block_headers.push(BlockHeaderBlob::from(block_header_blob));
         }
 

--- a/canister/src/block_header_store.rs
+++ b/canister/src/block_header_store.rs
@@ -1,6 +1,6 @@
 use crate::{memory::Memory, types::BlockHeaderBlob};
 use bitcoin::consensus::{Decodable, Encodable};
-use bitcoin::BlockHeader;
+use bitcoin::BlockHeader as Header;
 use ic_btc_interface::Height;
 use ic_btc_types::{Block, BlockHash};
 use ic_stable_structures::StableBTreeMap;
@@ -57,13 +57,13 @@ impl BlockHeaderStore {
         self.block_heights.insert(height, block_hash);
     }
 
-    pub fn get_with_block_hash(&self, block_hash: &BlockHash) -> Option<BlockHeader> {
+    pub fn get_with_block_hash(&self, block_hash: &BlockHash) -> Option<Header> {
         self.block_headers
             .get(block_hash)
             .map(deserialize_block_header)
     }
 
-    pub fn get_with_height(&self, height: u32) -> Option<BlockHeader> {
+    pub fn get_with_height(&self, height: u32) -> Option<Header> {
         self.block_heights.get(&height).map(|block_hash| {
             self.block_headers
                 .get(&block_hash)
@@ -83,8 +83,8 @@ impl BlockHeaderStore {
     }
 }
 
-fn deserialize_block_header(block_header_blob: BlockHeaderBlob) -> BlockHeader {
-    BlockHeader::consensus_decode(block_header_blob.as_slice())
+fn deserialize_block_header(block_header_blob: BlockHeaderBlob) -> Header {
+    Header::consensus_decode(block_header_blob.as_slice())
         .expect("block header decoding must succeed")
 }
 

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -270,10 +270,10 @@ mod test {
         types::{Address, BlockBlob, GetSuccessorsCompleteResponse, GetSuccessorsPartialResponse},
         utxo_set::IngestingBlock,
     };
-    use bitcoin::BlockHeader;
+    use bitcoin::BlockHeader as Header;
     use ic_btc_interface::{InitConfig, Network};
 
-    fn build_block(prev_header: &BlockHeader, address: Address, num_transactions: u128) -> Block {
+    fn build_block(prev_header: &Header, address: Address, num_transactions: u128) -> Block {
         let mut block = BlockBuilder::with_prev_header(prev_header);
         let mut value = 1;
         for _ in 0..num_transactions {

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -11,7 +11,7 @@ use crate::{
     validation::ValidationContext,
     UtxoSet,
 };
-use bitcoin::{consensus::Decodable, BlockHeader};
+use bitcoin::{consensus::Decodable, BlockHeader as Header};
 use candid::Principal;
 use ic_btc_interface::{Fees, Flag, Height, MillisatoshiPerByte, Network};
 use ic_btc_types::{Block, BlockHash, OutPoint};
@@ -207,7 +207,7 @@ pub fn insert_next_block_headers(state: &mut State, next_block_headers: &[BlockH
             break;
         }
 
-        let block_header = match BlockHeader::consensus_decode(block_header_blob.as_slice()) {
+        let block_header = match Header::consensus_decode(block_header_blob.as_slice()) {
             Ok(header) => header,
             Err(err) => {
                 print(&format!(

--- a/canister/src/test_utils.rs
+++ b/canister/src/test_utils.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use bitcoin::{
     hashes::Hash, secp256k1::rand::rngs::OsRng, secp256k1::Secp256k1, Address as BitcoinAddress,
-    BlockHeader, PublicKey, Script, WScriptHash, Witness,
+    BlockHeader as Header, PublicKey, Script, WScriptHash, Witness,
 };
 use ic_btc_interface::Network;
 use ic_btc_test_utils::{
@@ -146,7 +146,7 @@ impl BlockBuilder {
         }
     }
 
-    pub fn with_prev_header(prev_header: &BlockHeader) -> Self {
+    pub fn with_prev_header(prev_header: &Header) -> Self {
         Self {
             builder: ExternalBlockBuilder::with_prev_header(*prev_header),
             mock_difficulty: None,
@@ -235,7 +235,7 @@ impl TransactionBuilder {
 
 pub struct BlockChainBuilder {
     num_blocks: u32,
-    prev_block_header: Option<BlockHeader>,
+    prev_block_header: Option<Header>,
     #[allow(clippy::type_complexity)]
     difficulty_ranges: Vec<((Bound<usize>, Bound<usize>), u64)>,
 }

--- a/canister/src/tests.rs
+++ b/canister/src/tests.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use crate::{init, test_utils::random_p2pkh_address};
 use bitcoin::consensus::{Decodable, Encodable};
-use bitcoin::{Block as BitcoinBlock, BlockHeader};
+use bitcoin::{Block as BitcoinBlock, BlockHeader as Header};
 use byteorder::{LittleEndian, ReadBytesExt};
 use ic_btc_interface::{Flag, GetUtxosResponse, InitConfig, Network, Txid, UtxosFilter};
 use ic_btc_interface::{OutPoint, Utxo};
@@ -541,7 +541,7 @@ async fn test_rejections_counting() {
 }
 
 // Serialize header.
-fn get_header_blob(header: &BlockHeader) -> BlockHeaderBlob {
+fn get_header_blob(header: &Header) -> BlockHeaderBlob {
     let mut header_buff = vec![];
     header.consensus_encode(&mut header_buff).unwrap();
     header_buff.into()

--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -334,10 +334,10 @@ impl BlockHeaderBlob {
 impl From<Vec<u8>> for BlockHeaderBlob {
     fn from(bytes: Vec<u8>) -> Self {
         assert_eq!(
-            bytes.len() as u32,
-            Self::MAX_SIZE,
-            "Header must {} bytes",
-            Self::MAX_SIZE,
+            bytes.len(),
+            Self::MAX_SIZE as usize,
+            "Header must be exactly {} bytes",
+            Self::MAX_SIZE
         );
         Self(bytes)
     }

--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -1,5 +1,6 @@
 use bitcoin::{
-    Address as BitcoinAddress, Network as BitcoinNetwork, Script, TxOut as BitcoinTxOut,
+    Address as BitcoinAddress, BlockHeader as Header, Network as BitcoinNetwork, Script,
+    TxOut as BitcoinTxOut,
 };
 use candid::CandidType;
 use ic_btc_interface::{
@@ -315,11 +316,11 @@ impl BoundedStorable for BlockHeaderBlob {
     const IS_FIXED_SIZE: bool = true;
 }
 
-impl From<&bitcoin::BlockHeader> for BlockHeaderBlob {
-    fn from(header: &bitcoin::BlockHeader) -> Self {
+impl From<&Header> for BlockHeaderBlob {
+    fn from(header: &Header) -> Self {
         use bitcoin::consensus::Encodable;
         let mut block_header_blob = vec![];
-        bitcoin::BlockHeader::consensus_encode(header, &mut block_header_blob).unwrap();
+        Header::consensus_encode(header, &mut block_header_blob).unwrap();
         Self(block_header_blob)
     }
 }
@@ -335,7 +336,7 @@ impl From<Vec<u8>> for BlockHeaderBlob {
         assert_eq!(
             bytes.len() as u32,
             Self::MAX_SIZE,
-            "BlockHeader must {} bytes",
+            "Header must {} bytes",
             Self::MAX_SIZE,
         );
         Self(bytes)

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -6,7 +6,7 @@ use crate::{
     types::{Address, TxOut},
     UtxoSet,
 };
-use bitcoin::BlockHeader;
+use bitcoin::BlockHeader as Header;
 use ic_btc_interface::{Height, Network};
 use ic_btc_types::{Block, BlockHash, OutPoint};
 use outpoints_cache::OutPointsCache;
@@ -121,7 +121,7 @@ impl UnstableBlocks {
     // Inserts the block header of the block that should be received.
     pub fn insert_next_block_header(
         &mut self,
-        block_header: BlockHeader,
+        block_header: Header,
         stable_height: Height,
     ) -> Result<(), BlockDoesNotExtendTree> {
         let prev_block_hash = BlockHash::from(block_header.prev_blockhash);
@@ -142,7 +142,7 @@ impl UnstableBlocks {
     }
 
     /// Returns true if the given block header is already stored as one of the next block headers.
-    pub fn has_next_block_header(&self, block_header: &BlockHeader) -> bool {
+    pub fn has_next_block_header(&self, block_header: &Header) -> bool {
         self.next_block_headers
             .get_header(&BlockHash::from(block_header.block_hash()))
             .is_some()
@@ -153,12 +153,12 @@ impl UnstableBlocks {
         self.next_block_headers.get_max_height()
     }
 
-    // Returns BlockHeader chain from the tip up to the first block
+    // Returns Header chain from the tip up to the first block
     // header outside the main chain in the reverse order.
     pub fn get_next_block_headers_chain_with_tip(
         &self,
         tip_block_hash: BlockHash,
-    ) -> Vec<(&BlockHeader, BlockHash)> {
+    ) -> Vec<(&Header, BlockHash)> {
         let mut chain = vec![];
         let mut curr_hash = tip_block_hash;
         while let Some(curr_header) = self.next_block_headers.get_header(&curr_hash) {
@@ -174,7 +174,7 @@ impl UnstableBlocks {
         &self,
         stable_height: Height,
         heights: std::ops::RangeInclusive<Height>,
-    ) -> impl Iterator<Item = &BlockHeader> {
+    ) -> impl Iterator<Item = &Header> {
         if *heights.end() < stable_height {
             // `stable_height` is larger than any height from the range, which implies none of the requested
             // blocks are in unstable blocks, hence the result should be an empty iterator.
@@ -1026,7 +1026,7 @@ mod test {
         assert_eq!(peek(&unstable_blocks), None);
     }
 
-    fn get_block_headers_helper(block_num: usize) -> (UnstableBlocks, Vec<BlockHeader>) {
+    fn get_block_headers_helper(block_num: usize) -> (UnstableBlocks, Vec<Header>) {
         let mut headers = vec![];
         let block_0 = BlockBuilder::genesis().build();
         headers.push(*block_0.header());

--- a/canister/src/unstable_blocks/next_block_headers.rs
+++ b/canister/src/unstable_blocks/next_block_headers.rs
@@ -1,4 +1,4 @@
-use bitcoin::BlockHeader;
+use bitcoin::BlockHeader as Header;
 use ic_btc_interface::Height;
 use ic_btc_types::BlockHash;
 use serde::{Deserialize, Serialize};
@@ -6,12 +6,12 @@ use std::collections::BTreeMap;
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 pub struct NextBlockHeaders {
-    hash_to_height_and_header: BTreeMap<BlockHash, (Height, BlockHeader)>,
+    hash_to_height_and_header: BTreeMap<BlockHash, (Height, Header)>,
     height_to_hash: BTreeMap<Height, Vec<BlockHash>>,
 }
 
 impl NextBlockHeaders {
-    pub fn insert(&mut self, block_header: BlockHeader, height: Height) {
+    pub fn insert(&mut self, block_header: Header, height: Height) {
         let block_hash = BlockHash::from(block_header.block_hash());
         let hash_vec = self.height_to_hash.entry(height).or_default();
 
@@ -57,7 +57,7 @@ impl NextBlockHeaders {
             .map(|(height, _)| height)
     }
 
-    pub fn get_header(&self, hash: &BlockHash) -> Option<&BlockHeader> {
+    pub fn get_header(&self, hash: &BlockHash) -> Option<&Header> {
         self.hash_to_height_and_header.get(hash).map(|res| &res.1)
     }
 }

--- a/canister/src/validation.rs
+++ b/canister/src/validation.rs
@@ -1,18 +1,18 @@
 use crate::{blocktree::BlockDoesNotExtendTree, state::State, unstable_blocks};
-use bitcoin::BlockHeader;
+use bitcoin::BlockHeader as Header;
 use ic_btc_validation::HeaderStore;
 
 /// A structure passed to the validation crate to validate a specific block header.
 pub struct ValidationContext<'a> {
     state: &'a State,
     // BlockHash is stored in order to avoid repeatedly calling to
-    // BlockHeader::block_hash() which is expensive.
-    chain: Vec<(&'a BlockHeader, ic_btc_types::BlockHash)>,
+    // Header::block_hash() which is expensive.
+    chain: Vec<(&'a Header, ic_btc_types::BlockHash)>,
 }
 
 impl<'a> ValidationContext<'a> {
     /// Initialize a `ValidationContext` for the given block header.
-    pub fn new(state: &'a State, header: &BlockHeader) -> Result<Self, BlockDoesNotExtendTree> {
+    pub fn new(state: &'a State, header: &Header) -> Result<Self, BlockDoesNotExtendTree> {
         // Retrieve the chain that the given header extends.
         // The given header must extend one of the unstable blocks.
         let prev_block_hash = header.prev_blockhash.into();
@@ -30,7 +30,7 @@ impl<'a> ValidationContext<'a> {
     /// The given block header can be in the 'NextBlockHeaders'.
     pub fn new_with_next_block_headers(
         state: &'a State,
-        header: &BlockHeader,
+        header: &Header,
     ) -> Result<Self, BlockDoesNotExtendTree> {
         let prev_block_hash = header.prev_blockhash.into();
         let next_block_headers_chain = state
@@ -50,7 +50,7 @@ impl<'a> ValidationContext<'a> {
 
 /// Implements the `HeaderStore` trait that's used for validating headers.
 impl<'a> HeaderStore for ValidationContext<'a> {
-    fn get_with_block_hash(&self, hash: &bitcoin::BlockHash) -> Option<BlockHeader> {
+    fn get_with_block_hash(&self, hash: &bitcoin::BlockHash) -> Option<Header> {
         // Check if the header is in the chain.
         let hash = ic_btc_types::BlockHash::from(hash.to_vec());
         for item in self.chain.iter() {
@@ -69,7 +69,7 @@ impl<'a> HeaderStore for ValidationContext<'a> {
         self.state.utxos.next_height() + self.chain.len() as u32 - 1
     }
 
-    fn get_with_height(&self, height: u32) -> Option<BlockHeader> {
+    fn get_with_height(&self, height: u32) -> Option<Header> {
         if height < self.state.utxos.next_height() {
             // The height requested is for a stable block.
             // Retrieve the block header from the stable block headers.

--- a/e2e-tests/disable-api-if-not-fully-synced-flag/src/main.rs
+++ b/e2e-tests/disable-api-if-not-fully-synced-flag/src/main.rs
@@ -1,6 +1,6 @@
 use bitcoin::{
-    blockdata::constants::genesis_block, consensus::Encodable, Address, Block, BlockHeader,
-    Network as BitcoinNetwork,
+    blockdata::constants::genesis_block, consensus::Encodable, Address, Block,
+    BlockHeader as Header, Network as BitcoinNetwork,
 };
 use candid::CandidType;
 use ic_btc_test_utils::{BlockBuilder, TransactionBuilder};
@@ -153,7 +153,7 @@ fn append_block(block: &Block) {
     BLOCKS.with(|b| b.borrow_mut().push(block_bytes));
 }
 
-fn append_block_header(block_header: &BlockHeader) {
+fn append_block_header(block_header: &Header) {
     let mut block_bytes = vec![];
     block_header.consensus_encode(&mut block_bytes).unwrap();
     BLOCK_HEADERS.with(|b| b.borrow_mut().push(block_bytes));

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,8 +1,8 @@
 use bitcoin::blockdata::constants::genesis_block;
 use bitcoin::{
     secp256k1::rand::rngs::OsRng, secp256k1::Secp256k1, util::uint::Uint256, Address,
-    Block as BitcoinBlock, BlockHash, BlockHeader, KeyPair, Network, OutPoint, PublicKey, Script,
-    Transaction, TxIn, TxMerkleNode, TxOut, Witness, XOnlyPublicKey,
+    Block as BitcoinBlock, BlockHash, BlockHeader as Header, KeyPair, Network, OutPoint, PublicKey,
+    Script, Transaction, TxIn, TxMerkleNode, TxOut, Witness, XOnlyPublicKey,
 };
 use ic_btc_types::Block;
 use std::str::FromStr;
@@ -34,7 +34,7 @@ fn coinbase_input() -> TxIn {
 }
 
 pub struct BlockBuilder {
-    prev_header: Option<BlockHeader>,
+    prev_header: Option<Header>,
     transactions: Vec<Transaction>,
 }
 
@@ -46,7 +46,7 @@ impl BlockBuilder {
         }
     }
 
-    pub fn with_prev_header(prev_header: BlockHeader) -> Self {
+    pub fn with_prev_header(prev_header: Header) -> Self {
         Self {
             prev_header: Some(prev_header),
             transactions: vec![],
@@ -119,16 +119,16 @@ pub fn build_regtest_chain(num_blocks: u32, num_transactions_per_block: u32) -> 
     blocks
 }
 
-fn genesis(merkle_root: TxMerkleNode) -> BlockHeader {
+fn genesis(merkle_root: TxMerkleNode) -> Header {
     let target = Uint256([
         0xffffffffffffffffu64,
         0xffffffffffffffffu64,
         0xffffffffffffffffu64,
         0x7fffffffffffffffu64,
     ]);
-    let bits = BlockHeader::compact_target_from_u256(&target);
+    let bits = Header::compact_target_from_u256(&target);
 
-    let mut header = BlockHeader {
+    let mut header = Header {
         version: 1,
         time: 0,
         nonce: 0,
@@ -225,11 +225,11 @@ impl Default for TransactionBuilder {
     }
 }
 
-fn header(prev_header: &BlockHeader, merkle_root: TxMerkleNode) -> BlockHeader {
+fn header(prev_header: &Header, merkle_root: TxMerkleNode) -> Header {
     let time = prev_header.time + 60 * 10; // 10 minutes.
-    let bits = BlockHeader::compact_target_from_u256(&prev_header.target());
+    let bits = Header::compact_target_from_u256(&prev_header.target());
 
-    let mut header = BlockHeader {
+    let mut header = Header {
         version: 1,
         time,
         nonce: 0,
@@ -242,7 +242,7 @@ fn header(prev_header: &BlockHeader, merkle_root: TxMerkleNode) -> BlockHeader {
     header
 }
 
-fn solve(header: &mut BlockHeader) {
+fn solve(header: &mut Header) {
     let target = header.target();
     while header.validate_pow(&target).is_err() {
         header.nonce += 1;

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -2,7 +2,7 @@
 //! NOTE: These types are _not_ part of the interface.
 
 use bitcoin::{
-    util::uint::Uint256, Block as BitcoinBlock, Network as BitcoinNetwork,
+    util::uint::Uint256, Block as BitcoinBlock, BlockHeader as Header, Network as BitcoinNetwork,
     OutPoint as BitcoinOutPoint,
 };
 use candid::CandidType;
@@ -37,7 +37,7 @@ impl Block {
         }
     }
 
-    pub fn header(&self) -> &bitcoin::BlockHeader {
+    pub fn header(&self) -> &Header {
         &self.block.header
     }
 
@@ -365,7 +365,7 @@ fn target_difficulty() {
     assert_eq!(
         Block::target_difficulty(
             Network::Mainnet,
-            bitcoin::BlockHeader::u256_from_compact_target(0x1b0404cb)
+            Header::u256_from_compact_target(0x1b0404cb)
         ),
         16_307
     );
@@ -375,7 +375,7 @@ fn target_difficulty() {
     assert_eq!(
         Block::target_difficulty(
             Network::Mainnet,
-            bitcoin::BlockHeader::u256_from_compact_target(386397584)
+            Header::u256_from_compact_target(386397584)
         ),
         35_364_065_900_457
     );
@@ -385,7 +385,7 @@ fn target_difficulty() {
     assert_eq!(
         Block::target_difficulty(
             Network::Mainnet,
-            bitcoin::BlockHeader::u256_from_compact_target(386877668)
+            Header::u256_from_compact_target(386877668)
         ),
         18_415_156_832_118
     );
@@ -395,7 +395,7 @@ fn target_difficulty() {
     assert_eq!(
         Block::target_difficulty(
             Network::Testnet,
-            bitcoin::BlockHeader::u256_from_compact_target(422681968)
+            Header::u256_from_compact_target(422681968)
         ),
         86_564_599
     );
@@ -405,7 +405,7 @@ fn target_difficulty() {
     assert_eq!(
         Block::target_difficulty(
             Network::Testnet,
-            bitcoin::BlockHeader::u256_from_compact_target(457142912)
+            Header::u256_from_compact_target(457142912)
         ),
         1_032
     );

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -1,4 +1,4 @@
-use bitcoin::{util::uint::Uint256, BlockHash, BlockHeader, Network};
+use bitcoin::{util::uint::Uint256, BlockHash, BlockHeader as Header, Network};
 
 use crate::{
     constants::{
@@ -37,10 +37,10 @@ const ONE_HOUR: u64 = 3_600;
 
 pub trait HeaderStore {
     /// Returns the header with the given block hash.
-    fn get_with_block_hash(&self, hash: &BlockHash) -> Option<BlockHeader>;
+    fn get_with_block_hash(&self, hash: &BlockHash) -> Option<Header>;
 
     /// Returns the header at the given height.
-    fn get_with_height(&self, height: u32) -> Option<BlockHeader>;
+    fn get_with_height(&self, height: u32) -> Option<Header>;
 
     /// Returns the height of the tip that the new header will extend.
     fn height(&self) -> u32;
@@ -58,7 +58,7 @@ pub trait HeaderStore {
 pub fn validate_header(
     network: &Network,
     store: &impl HeaderStore,
-    header: &BlockHeader,
+    header: &Header,
     current_time: u64,
 ) -> Result<(), ValidateHeaderError> {
     let prev_height = store.height();
@@ -115,7 +115,7 @@ fn timestamp_is_less_than_2h_in_future(
 /// "Block timestamp must not be more than two hours in the future"
 fn is_timestamp_valid(
     store: &impl HeaderStore,
-    header: &BlockHeader,
+    header: &Header,
     current_time: u64,
 ) -> Result<(), ValidateHeaderError> {
     timestamp_is_less_than_2h_in_future(header.time as u64, current_time)?;
@@ -146,7 +146,7 @@ fn is_timestamp_valid(
 fn get_next_target(
     network: &Network,
     store: &impl HeaderStore,
-    prev_header: &BlockHeader,
+    prev_header: &Header,
     prev_height: BlockHeight,
     timestamp: u32,
 ) -> Uint256 {
@@ -165,7 +165,7 @@ fn get_next_target(
                 } else {
                     //If the block has been found within 20 minutes, then use the previous
                     // difficulty target that is not equal to the maximum difficulty target
-                    BlockHeader::u256_from_compact_target(find_next_difficulty_in_chain(
+                    Header::u256_from_compact_target(find_next_difficulty_in_chain(
                         network,
                         store,
                         prev_header,
@@ -173,7 +173,7 @@ fn get_next_target(
                     ))
                 }
             } else {
-                BlockHeader::u256_from_compact_target(compute_next_difficulty(
+                Header::u256_from_compact_target(compute_next_difficulty(
                     network,
                     store,
                     prev_header,
@@ -181,7 +181,7 @@ fn get_next_target(
                 ))
             }
         }
-        Network::Bitcoin | Network::Signet => BlockHeader::u256_from_compact_target(
+        Network::Bitcoin | Network::Signet => Header::u256_from_compact_target(
             compute_next_difficulty(network, store, prev_header, prev_height),
         ),
     }
@@ -197,7 +197,7 @@ fn get_next_target(
 fn find_next_difficulty_in_chain(
     network: &Network,
     store: &impl HeaderStore,
-    prev_header: &BlockHeader,
+    prev_header: &Header,
     prev_height: BlockHeight,
 ) -> u32 {
     // This is the maximum difficulty target for the network
@@ -244,7 +244,7 @@ fn find_next_difficulty_in_chain(
 fn compute_next_difficulty(
     network: &Network,
     store: &impl HeaderStore,
-    prev_header: &BlockHeader,
+    prev_header: &Header,
     prev_height: BlockHeight,
 ) -> u32 {
     // Difficulty is adjusted only once in every interval of 2 weeks (2016 blocks)
@@ -302,7 +302,7 @@ fn compute_next_difficulty(
     target = Uint256::min(target, max_target(network));
 
     // Converting the target (Uint256) into a 32 bit representation used by Bitcoin
-    BlockHeader::compact_target_from_u256(&target)
+    Header::compact_target_from_u256(&target)
 }
 
 #[cfg(test)]
@@ -324,7 +324,7 @@ mod test {
 
     #[derive(Clone)]
     struct StoredHeader {
-        header: BlockHeader,
+        header: Header,
         height: BlockHeight,
     }
 
@@ -336,7 +336,7 @@ mod test {
     }
 
     impl SimpleHeaderStore {
-        fn new(initial_header: BlockHeader, height: BlockHeight) -> Self {
+        fn new(initial_header: Header, height: BlockHeight) -> Self {
             let initial_hash = initial_header.block_hash();
             let tip_hash = initial_header.block_hash();
             let mut headers = HashMap::new();
@@ -356,7 +356,7 @@ mod test {
             }
         }
 
-        fn add(&mut self, header: BlockHeader) {
+        fn add(&mut self, header: Header) {
             let prev = self
                 .headers
                 .get(&header.prev_blockhash)
@@ -373,11 +373,11 @@ mod test {
     }
 
     impl HeaderStore for SimpleHeaderStore {
-        fn get_with_block_hash(&self, hash: &BlockHash) -> Option<BlockHeader> {
+        fn get_with_block_hash(&self, hash: &BlockHash) -> Option<Header> {
             self.headers.get(hash).map(|stored| stored.header)
         }
 
-        fn get_with_height(&self, height: u32) -> Option<BlockHeader> {
+        fn get_with_height(&self, height: u32) -> Option<Header> {
             let blocks_to_traverse = self.height - height;
             let mut header = self.headers.get(&self.tip_hash).unwrap().header;
             for _ in 0..blocks_to_traverse {
@@ -395,14 +395,14 @@ mod test {
         }
     }
 
-    fn deserialize_header(encoded_bytes: &str) -> BlockHeader {
+    fn deserialize_header(encoded_bytes: &str) -> Header {
         let bytes = Vec::from_hex(encoded_bytes).expect("failed to decoded bytes");
         deserialize(bytes.as_slice()).expect("failed to deserialize")
     }
 
     /// This function reads `num_headers` headers from `tests/data/headers.csv`
     /// and returns them.
-    fn get_bitcoin_headers() -> Vec<BlockHeader> {
+    fn get_bitcoin_headers() -> Vec<Header> {
         let rdr = Reader::from_path(
             PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
                 .join("tests/data/headers.csv"),
@@ -412,7 +412,7 @@ mod test {
         let mut headers = vec![];
         for result in rdr.records() {
             let record = result.unwrap();
-            let header = BlockHeader {
+            let header = Header {
                 version: i32::from_str_radix(record.get(0).unwrap(), 16).unwrap(),
                 prev_blockhash: BlockHash::from_str(record.get(1).unwrap()).unwrap(),
                 merkle_root: TxMerkleNode::from_str(record.get(2).unwrap()).unwrap(),
@@ -516,7 +516,7 @@ mod test {
         store.add(header_705601);
         store.add(header_705602);
 
-        let mut header = BlockHeader {
+        let mut header = Header {
             version: 0x20800004,
             prev_blockhash: BlockHash::from_hex(
                 "00000000000000000001eea12c0de75000c2546da22f7bf42d805c1d2769b6ef",
@@ -637,7 +637,7 @@ mod test {
             let header = line.unwrap();
             // If this line fails make sure you install git-lfs.
             let header = hex::decode(header.trim()).unwrap();
-            let header = BlockHeader::consensus_decode(header.as_slice()).unwrap();
+            let header = Header::consensus_decode(header.as_slice()).unwrap();
             headers.push(header);
         }
 
@@ -656,7 +656,7 @@ mod test {
             // Assert that the expected next target matches the next header's target.
             assert_eq!(
                 expected_next_target,
-                BlockHeader::u256_from_compact_target(headers[i + 1].bits)
+                Header::u256_from_compact_target(headers[i + 1].bits)
             );
         });
     }
@@ -679,8 +679,8 @@ mod test {
         );
     }
 
-    fn genesis_header(bits: u32) -> BlockHeader {
-        BlockHeader {
+    fn genesis_header(bits: u32) -> Header {
+        Header {
             version: 1,
             prev_blockhash: Default::default(),
             merkle_root: Default::default(),
@@ -690,8 +690,8 @@ mod test {
         }
     }
 
-    fn next_block_header(prev: BlockHeader, bits: u32) -> BlockHeader {
-        BlockHeader {
+    fn next_block_header(prev: Header, bits: u32) -> Header {
+        Header {
             prev_blockhash: prev.block_hash(),
             time: prev.time + TEN_MINUTES,
             bits,
@@ -705,7 +705,7 @@ mod test {
         network: &Network,
         initial_pow: u32,
         chain_length: u32,
-    ) -> (SimpleHeaderStore, BlockHeader) {
+    ) -> (SimpleHeaderStore, Header) {
         let pow_limit = pow_limit_bits(network);
         let h0 = genesis_header(initial_pow);
         let mut store = SimpleHeaderStore::new(h0, 0);
@@ -742,7 +742,7 @@ mod test {
                 last_header.time + TEN_MINUTES,
             );
             // Assert.
-            assert_eq!(target, BlockHeader::u256_from_compact_target(expected_pow));
+            assert_eq!(target, Header::u256_from_compact_target(expected_pow));
         }
     }
 
@@ -758,7 +758,7 @@ mod test {
         let mut store = SimpleHeaderStore::new(genesis_header, 0);
         let mut last_header = genesis_header;
         for _ in 1..chain_length {
-            let new_header = BlockHeader {
+            let new_header = Header {
                 prev_blockhash: last_header.block_hash(),
                 time: last_header.time - 1, // Each new block is 1 second earlier
                 ..last_header

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -635,6 +635,7 @@ mod test {
         let mut headers = vec![];
         for line in rdr.lines() {
             let header = line.unwrap();
+            println!("ABC header: {}", header);
             let header = hex::decode(header.trim()).unwrap();
             let header = BlockHeader::consensus_decode(header.as_slice()).unwrap();
             headers.push(header);

--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -635,7 +635,7 @@ mod test {
         let mut headers = vec![];
         for line in rdr.lines() {
             let header = line.unwrap();
-            println!("ABC header: {}", header);
+            // If this line fails make sure you install git-lfs.
             let header = hex::decode(header.trim()).unwrap();
             let header = BlockHeader::consensus_decode(header.as_slice()).unwrap();
             headers.push(header);


### PR DESCRIPTION
This PR renames the usage of `BlockHeader` to `Header` in order to reduce the noise during the `bitcoin` crate update from `0.28.1` to `0.32.4`.

- `0.28.1` https://docs.rs/bitcoin/0.28.1/bitcoin/blockdata/block/struct.BlockHeader.html
- `0.32.4` https://docs.rs/bitcoin/0.32.4/bitcoin/block/struct.Header.html