### PR TITLE
chore: bump up canbench to 0.1.8

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -68,23 +68,23 @@ jobs:
           rustup default $RUST_VERSION
           rustup target add wasm32-unknown-unknown
 
-      # - name: Install PocketIC (mac)
-      #   if: runner.os == 'macOS'
-      #   run: |
-      #     wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_SERVER_VERSION/pocket-ic-x86_64-darwin.gz
-      #     gzip -d pocket-ic-x86_64-darwin.gz
-      #     mv pocket-ic-x86_64-darwin pocket-ic
-      #     chmod +x pocket-ic
-      #     mv pocket-ic ./canister/
+      - name: Install PocketIC (mac)
+        if: runner.os == 'macOS'
+        run: |
+          wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_SERVER_VERSION/pocket-ic-x86_64-darwin.gz
+          gzip -d pocket-ic-x86_64-darwin.gz
+          mv pocket-ic-x86_64-darwin pocket-ic
+          chmod +x pocket-ic
+          mv pocket-ic ./canister/
 
-      # - name: Install PocketIC (linux)
-      #   if: runner.os == 'Linux'
-      #   run: |
-      #     wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_SERVER_VERSION/pocket-ic-x86_64-linux.gz
-      #     gzip -d pocket-ic-x86_64-linux.gz
-      #     mv pocket-ic-x86_64-linux pocket-ic
-      #     chmod +x pocket-ic
-      #     mv pocket-ic ./canister/
+      - name: Install PocketIC (linux)
+        if: runner.os == 'Linux'
+        run: |
+          wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_SERVER_VERSION/pocket-ic-x86_64-linux.gz
+          gzip -d pocket-ic-x86_64-linux.gz
+          mv pocket-ic-x86_64-linux pocket-ic
+          chmod +x pocket-ic
+          mv pocket-ic ./canister/
 
       - name: Install brew packages (mac)
         if: runner.os == 'macOS'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,6 +3,7 @@ name: CI
 env:
   RUST_VERSION: 1.76.0
   DFX_VERSION: 0.21.0
+  POCKET_IC_SERVER_VERSION: 7.0.0
 
 on:
   push:
@@ -70,7 +71,7 @@ jobs:
       - name: Install PocketIC (mac)
         if: runner.os == 'macOS'
         run: |
-          wget https://github.com/dfinity/pocketic/releases/download/5.0.0/pocket-ic-x86_64-darwin.gz
+          wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_SERVER_VERSION/pocket-ic-x86_64-darwin.gz
           gzip -d pocket-ic-x86_64-darwin.gz
           mv pocket-ic-x86_64-darwin pocket-ic
           chmod +x pocket-ic
@@ -79,7 +80,7 @@ jobs:
       - name: Install PocketIC (linux)
         if: runner.os == 'Linux'
         run: |
-          wget https://github.com/dfinity/pocketic/releases/download/5.0.0/pocket-ic-x86_64-linux.gz
+          wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_SERVER_VERSION/pocket-ic-x86_64-linux.gz
           gzip -d pocket-ic-x86_64-linux.gz
           mv pocket-ic-x86_64-linux pocket-ic
           chmod +x pocket-ic

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,7 +3,7 @@ name: CI
 env:
   RUST_VERSION: 1.76.0
   DFX_VERSION: 0.21.0
-  POCKET_IC_VERSION: 7.0.0
+  POCKET_IC_SERVER_VERSION: 7.0.0
 
 on:
   push:
@@ -71,7 +71,7 @@ jobs:
       - name: Install PocketIC (mac)
         if: runner.os == 'macOS'
         run: |
-          wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_VERSION/pocket-ic-x86_64-darwin.gz
+          wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_SERVER_VERSION/pocket-ic-x86_64-darwin.gz
           gzip -d pocket-ic-x86_64-darwin.gz
           mv pocket-ic-x86_64-darwin pocket-ic
           chmod +x pocket-ic
@@ -80,7 +80,7 @@ jobs:
       - name: Install PocketIC (linux)
         if: runner.os == 'Linux'
         run: |
-          wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_VERSION/pocket-ic-x86_64-linux.gz
+          wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_SERVER_VERSION/pocket-ic-x86_64-linux.gz
           gzip -d pocket-ic-x86_64-linux.gz
           mv pocket-ic-x86_64-linux pocket-ic
           chmod +x pocket-ic

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,7 +3,7 @@ name: CI
 env:
   RUST_VERSION: 1.76.0
   DFX_VERSION: 0.21.0
-  POCKET_IC_SERVER_VERSION: 7.0.0
+  POCKET_IC_VERSION: 7.0.0
 
 on:
   push:
@@ -71,7 +71,7 @@ jobs:
       - name: Install PocketIC (mac)
         if: runner.os == 'macOS'
         run: |
-          wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_SERVER_VERSION/pocket-ic-x86_64-darwin.gz
+          wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_VERSION/pocket-ic-x86_64-darwin.gz
           gzip -d pocket-ic-x86_64-darwin.gz
           mv pocket-ic-x86_64-darwin pocket-ic
           chmod +x pocket-ic
@@ -80,7 +80,7 @@ jobs:
       - name: Install PocketIC (linux)
         if: runner.os == 'Linux'
         run: |
-          wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_SERVER_VERSION/pocket-ic-x86_64-linux.gz
+          wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_VERSION/pocket-ic-x86_64-linux.gz
           gzip -d pocket-ic-x86_64-linux.gz
           mv pocket-ic-x86_64-linux pocket-ic
           chmod +x pocket-ic

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -68,23 +68,23 @@ jobs:
           rustup default $RUST_VERSION
           rustup target add wasm32-unknown-unknown
 
-      - name: Install PocketIC (mac)
-        if: runner.os == 'macOS'
-        run: |
-          wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_SERVER_VERSION/pocket-ic-x86_64-darwin.gz
-          gzip -d pocket-ic-x86_64-darwin.gz
-          mv pocket-ic-x86_64-darwin pocket-ic
-          chmod +x pocket-ic
-          mv pocket-ic ./canister/
+      # - name: Install PocketIC (mac)
+      #   if: runner.os == 'macOS'
+      #   run: |
+      #     wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_SERVER_VERSION/pocket-ic-x86_64-darwin.gz
+      #     gzip -d pocket-ic-x86_64-darwin.gz
+      #     mv pocket-ic-x86_64-darwin pocket-ic
+      #     chmod +x pocket-ic
+      #     mv pocket-ic ./canister/
 
-      - name: Install PocketIC (linux)
-        if: runner.os == 'Linux'
-        run: |
-          wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_SERVER_VERSION/pocket-ic-x86_64-linux.gz
-          gzip -d pocket-ic-x86_64-linux.gz
-          mv pocket-ic-x86_64-linux pocket-ic
-          chmod +x pocket-ic
-          mv pocket-ic ./canister/
+      # - name: Install PocketIC (linux)
+      #   if: runner.os == 'Linux'
+      #   run: |
+      #     wget https://github.com/dfinity/pocketic/releases/download/$POCKET_IC_SERVER_VERSION/pocket-ic-x86_64-linux.gz
+      #     gzip -d pocket-ic-x86_64-linux.gz
+      #     mv pocket-ic-x86_64-linux pocket-ic
+      #     chmod +x pocket-ic
+      #     mv pocket-ic ./canister/
 
       - name: Install brew packages (mac)
         if: runner.os == 'macOS'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,15 +1115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "erased-serde"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,7 +1630,7 @@ dependencies = [
  "http",
  "http-body",
  "ic-certification",
- "ic-transport-types 0.36.0",
+ "ic-transport-types",
  "ic-verify-bls-signature",
  "k256",
  "leb128",
@@ -1766,6 +1757,19 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b1da6a25b045f9da3c9459c0cb2b0700ac368ee16382975a17185a23b9c18ab"
+dependencies = [
+ "candid 0.10.10",
+ "ic-cdk-macros 0.13.2",
+ "ic0 0.21.1",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "ic-cdk"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "038ff230bf0fc8630943e3c52e989d248a7c89834ccb65da408fabc5817a475b"
@@ -1796,6 +1800,20 @@ name = "ic-cdk-macros"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5a618e4020cea88e933d8d2f8c7f86d570ec06213506a80d4f2c520a9bba512"
+dependencies = [
+ "candid 0.10.10",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream 0.1.7",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ic-cdk-macros"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45800053d80a6df839a71aaea5797e723188c0b992618208ca3b941350c7355"
 dependencies = [
  "candid 0.10.10",
  "proc-macro2",
@@ -1877,23 +1895,6 @@ name = "ic-transport-types"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce14c068bd053c0f5ab525326f3f358f265cdfcae279fbf6461fb529e9682acd"
-dependencies = [
- "candid 0.10.10",
- "hex",
- "ic-certification",
- "leb128",
- "serde",
- "serde_bytes",
- "serde_repr",
- "sha2 0.10.8",
- "thiserror",
-]
-
-[[package]]
-name = "ic-transport-types"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
 dependencies = [
  "candid 0.10.10",
  "hex",
@@ -2285,16 +2286,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,31 +2573,23 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic"
-version = "6.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124a2380ca6f557adf8b02517cbfd2f564113230e14cda6f6aadd3dfe156293c"
+checksum = "f9765eeff77b8750cf6258eaeea237b96607cd770aa3d4003f021924192b7e4e"
 dependencies = [
+ "async-trait",
  "base64 0.13.1",
  "candid 0.10.10",
  "hex",
- "ic-certification",
- "ic-transport-types 0.37.1",
+ "ic-cdk 0.13.5",
  "reqwest",
  "schemars",
  "serde",
  "serde_bytes",
- "serde_cbor",
  "serde_json",
- "sha2 0.10.8",
- "slog",
- "strum",
- "strum_macros",
- "thiserror",
- "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "wslpath",
 ]
 
 [[package]]
@@ -3109,7 +3092,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3674,15 +3656,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slog"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
-dependencies = [
- "erased-serde",
-]
-
-[[package]]
 name = "slotmap"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3812,28 +3785,6 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
-]
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
  "syn 2.0.75",
 ]
 
@@ -4228,15 +4179,6 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
-name = "unicase"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -4719,12 +4661,6 @@ checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "wslpath"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04a2ecdf2cc4d33a6a93d71bcfbc00bb1f635cdb8029a2cc0709204a045ec7a3"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53574f268dbe23dc83f891a4751b118a6ba927c8bc92e839ff108f3aaf151aa9"
+checksum = "497d900e11ab1891dd9743dd45dbeaada540ce323aa1adc7fc0ce1da2c6e86ff"
 dependencies = [
  "canbench-rs-macros",
  "candid 0.10.10",
@@ -573,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs-macros"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d454906c77138a3802a7a680259cca7c006e9b268ba6905f7f4f2b8b74293fa4"
+checksum = "5a5509bcfe6eeb86f057d46fbf20a2ba6b6bf9a1099b053a8f491cd7a909dfa6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,6 +1115,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,7 +1639,7 @@ dependencies = [
  "http",
  "http-body",
  "ic-certification",
- "ic-transport-types",
+ "ic-transport-types 0.36.0",
  "ic-verify-bls-signature",
  "k256",
  "leb128",
@@ -1757,19 +1766,6 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1da6a25b045f9da3c9459c0cb2b0700ac368ee16382975a17185a23b9c18ab"
-dependencies = [
- "candid 0.10.10",
- "ic-cdk-macros 0.13.2",
- "ic0 0.21.1",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "ic-cdk"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "038ff230bf0fc8630943e3c52e989d248a7c89834ccb65da408fabc5817a475b"
@@ -1800,20 +1796,6 @@ name = "ic-cdk-macros"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5a618e4020cea88e933d8d2f8c7f86d570ec06213506a80d4f2c520a9bba512"
-dependencies = [
- "candid 0.10.10",
- "proc-macro2",
- "quote",
- "serde",
- "serde_tokenstream 0.1.7",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ic-cdk-macros"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45800053d80a6df839a71aaea5797e723188c0b992618208ca3b941350c7355"
 dependencies = [
  "candid 0.10.10",
  "proc-macro2",
@@ -1895,6 +1877,23 @@ name = "ic-transport-types"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce14c068bd053c0f5ab525326f3f358f265cdfcae279fbf6461fb529e9682acd"
+dependencies = [
+ "candid 0.10.10",
+ "hex",
+ "ic-certification",
+ "leb128",
+ "serde",
+ "serde_bytes",
+ "serde_repr",
+ "sha2 0.10.8",
+ "thiserror",
+]
+
+[[package]]
+name = "ic-transport-types"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
 dependencies = [
  "candid 0.10.10",
  "hex",
@@ -2286,6 +2285,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2573,23 +2582,31 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic"
-version = "3.1.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9765eeff77b8750cf6258eaeea237b96607cd770aa3d4003f021924192b7e4e"
+checksum = "124a2380ca6f557adf8b02517cbfd2f564113230e14cda6f6aadd3dfe156293c"
 dependencies = [
- "async-trait",
  "base64 0.13.1",
  "candid 0.10.10",
  "hex",
- "ic-cdk 0.13.5",
+ "ic-certification",
+ "ic-transport-types 0.37.1",
  "reqwest",
  "schemars",
  "serde",
  "serde_bytes",
+ "serde_cbor",
  "serde_json",
+ "sha2 0.10.8",
+ "slog",
+ "strum",
+ "strum_macros",
+ "thiserror",
+ "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "wslpath",
 ]
 
 [[package]]
@@ -3092,6 +3109,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3656,6 +3674,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+dependencies = [
+ "erased-serde",
+]
+
+[[package]]
 name = "slotmap"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3785,6 +3812,28 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.75",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn 2.0.75",
 ]
 
@@ -4179,6 +4228,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"
@@ -4661,6 +4716,12 @@ checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wslpath"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a2ecdf2cc4d33a6a93d71bcfbc00bb1f635cdb8029a2cc0709204a045ec7a3"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,6 +833,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,6 +1113,15 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "errno"
@@ -1576,7 +1595,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.2",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1620,7 +1639,7 @@ dependencies = [
  "http",
  "http-body",
  "ic-certification",
- "ic-transport-types",
+ "ic-transport-types 0.36.0",
  "ic-verify-bls-signature",
  "k256",
  "leb128",
@@ -1747,19 +1766,6 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1da6a25b045f9da3c9459c0cb2b0700ac368ee16382975a17185a23b9c18ab"
-dependencies = [
- "candid 0.10.10",
- "ic-cdk-macros 0.13.2",
- "ic0 0.21.1",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "ic-cdk"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "038ff230bf0fc8630943e3c52e989d248a7c89834ccb65da408fabc5817a475b"
@@ -1790,20 +1796,6 @@ name = "ic-cdk-macros"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5a618e4020cea88e933d8d2f8c7f86d570ec06213506a80d4f2c520a9bba512"
-dependencies = [
- "candid 0.10.10",
- "proc-macro2",
- "quote",
- "serde",
- "serde_tokenstream 0.1.7",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ic-cdk-macros"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45800053d80a6df839a71aaea5797e723188c0b992618208ca3b941350c7355"
 dependencies = [
  "candid 0.10.10",
  "proc-macro2",
@@ -1885,6 +1877,23 @@ name = "ic-transport-types"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce14c068bd053c0f5ab525326f3f358f265cdfcae279fbf6461fb529e9682acd"
+dependencies = [
+ "candid 0.10.10",
+ "hex",
+ "ic-certification",
+ "leb128",
+ "serde",
+ "serde_bytes",
+ "serde_repr",
+ "sha2 0.10.8",
+ "thiserror",
+]
+
+[[package]]
+name = "ic-transport-types"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
 dependencies = [
  "candid 0.10.10",
  "hex",
@@ -2573,24 +2582,31 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic"
-version = "4.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629f46b7ab8a8d2fee02220ef8e99ae552c7e220117efa1ce0882ff09c8fb038"
+checksum = "124a2380ca6f557adf8b02517cbfd2f564113230e14cda6f6aadd3dfe156293c"
 dependencies = [
  "base64 0.13.1",
  "candid 0.10.10",
  "hex",
- "ic-cdk 0.13.5",
+ "ic-certification",
+ "ic-transport-types 0.37.1",
  "reqwest",
  "schemars",
  "serde",
  "serde_bytes",
+ "serde_cbor",
  "serde_json",
  "sha2 0.10.8",
+ "slog",
+ "strum",
+ "strum_macros",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "wslpath",
 ]
 
 [[package]]
@@ -3073,9 +3089,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.12.7"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3099,7 +3115,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -3208,7 +3224,19 @@ dependencies = [
  "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.0.1",
 ]
 
 [[package]]
@@ -3223,9 +3251,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"
@@ -3423,7 +3451,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3431,9 +3472,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3633,6 +3674,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+dependencies = [
+ "erased-serde",
+]
+
+[[package]]
 name = "slotmap"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3762,6 +3812,28 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.75",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn 2.0.75",
 ]
 
@@ -3940,9 +4012,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.3"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4647,6 +4719,12 @@ checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wslpath"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a2ecdf2cc4d33a6a93d71bcfbc00bb1f635cdb8029a2cc0709204a045ec7a3"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ resolver = "2"
 assert_matches = "1.5.0"
 bitcoin = "0.28.1"
 byteorder = "1.4.3"
-canbench-rs = { version = "0.1.8" }
+canbench-rs = "0.1.8"
 candid = "0.10.6"
-candid_parser = { version = "0.1.4" }
+candid_parser = "0.1.4"
 ciborium = "0.2.1"
 clap = { version = "4.0.11", features = ["derive"] }
 futures = "0.3.28"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 assert_matches = "1.5.0"
 bitcoin = "0.28.1"
 byteorder = "1.4.3"
-canbench-rs = { version = "0.1.8" }
+canbench-rs = { version = "0.1.4" }
 candid = "0.10.6"
 candid_parser = { version = "0.1.4" }
 ciborium = "0.2.1"
@@ -47,7 +47,7 @@ ic-http = { path = "./ic-http" }
 ic-metrics-encoder = "1.0.0"
 ic-stable-structures = "0.6.7"
 lazy_static = "1.4.0"
-pocket-ic = "6.0.0"
+pocket-ic = "3.1.0"
 serde = "1.0.171"
 serde_bytes = "0.11"
 serde_json = "1.0.94"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 assert_matches = "1.5.0"
 bitcoin = "0.28.1"
 byteorder = "1.4.3"
-canbench-rs = { version = "0.1.1" }
+canbench-rs = { version = "0.1.8" }
 candid = "0.10.6"
 candid_parser = { version = "0.1.4" }
 ciborium = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ ic-http = { path = "./ic-http" }
 ic-metrics-encoder = "1.0.0"
 ic-stable-structures = "0.6.7"
 lazy_static = "1.4.0"
-pocket-ic = "4.0.0"
+pocket-ic = "6.0.0"
 serde = "1.0.171"
 serde_bytes = "0.11"
 serde_json = "1.0.94"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 assert_matches = "1.5.0"
 bitcoin = "0.28.1"
 byteorder = "1.4.3"
-canbench-rs = { version = "0.1.4" }
+canbench-rs = { version = "0.1.8" }
 candid = "0.10.6"
 candid_parser = { version = "0.1.4" }
 ciborium = "0.2.1"
@@ -47,7 +47,7 @@ ic-http = { path = "./ic-http" }
 ic-metrics-encoder = "1.0.0"
 ic-stable-structures = "0.6.7"
 lazy_static = "1.4.0"
-pocket-ic = "3.1.0"
+pocket-ic = "6.0.0"
 serde = "1.0.171"
 serde_bytes = "0.11"
 serde_json = "1.0.94"

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -1,3 +1,4 @@
+version: 0.1.8
 benches:
   get_metrics:
     total:
@@ -41,4 +42,3 @@ benches:
         instructions: 2381902913
         heap_increase: 2048
         stable_memory_increase: 0
-version: 0.1.8

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -41,4 +41,4 @@ benches:
         instructions: 2381902913
         heap_increase: 2048
         stable_memory_increase: 0
-version: 0.1.8
+version: 0.1.4

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -41,4 +41,4 @@ benches:
         instructions: 2381902913
         heap_increase: 2048
         stable_memory_increase: 0
-version: 0.1.1
+version: 0.1.8

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -1,36 +1,36 @@
 benches:
   get_metrics:
     total:
-      instructions: 86997214
+      instructions: 87003622
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   insert_300_blocks:
     total:
-      instructions: 561767622
+      instructions: 563254667
       heap_increase: 6
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers:
     total:
-      instructions: 3895777071
+      instructions: 3899095256
       heap_increase: 2
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers_multiple_times:
     total:
-      instructions: 13898426217
+      instructions: 13916672106
       heap_increase: 7
       stable_memory_increase: 0
     scopes: {}
   pre_upgrade_with_many_unstable_blocks:
     total:
-      instructions: 5809876449
+      instructions: 5966461880
       heap_increase: 4097
       stable_memory_increase: 1792
     scopes:
       serialize_blocktree:
-        instructions: 2382106854
+        instructions: 2392720389
         heap_increase: 2048
         stable_memory_increase: 0
       serialize_blocktree_flatten:
@@ -38,7 +38,7 @@ benches:
         heap_increase: 0
         stable_memory_increase: 0
       serialize_blocktree_serialize_seq:
-        instructions: 2381902913
+        instructions: 2392516448
         heap_increase: 2048
         stable_memory_increase: 0
-version: 0.1.4
+version: 0.1.8

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -1,4 +1,3 @@
-version: 0.1.8
 benches:
   get_metrics:
     total:
@@ -42,3 +41,4 @@ benches:
         instructions: 2381902913
         heap_increase: 2048
         stable_memory_increase: 0
+version: 0.1.8

--- a/scripts/canbench_ci_run_benchmark.sh
+++ b/scripts/canbench_ci_run_benchmark.sh
@@ -22,7 +22,7 @@ CANBENCH_RESULTS_FILE="$CANISTER_PATH/canbench_results.yml"
 MAIN_BRANCH_RESULTS_FILE="$MAIN_BRANCH_DIR/$CANBENCH_RESULTS_FILE"
 
 # Install canbench
-cargo install canbench --version 0.1.8
+cargo install canbench --version 0.1.4
 
 # Verify that canbench results are available.
 if [ ! -f "$CANBENCH_RESULTS_FILE" ]; then

--- a/scripts/canbench_ci_run_benchmark.sh
+++ b/scripts/canbench_ci_run_benchmark.sh
@@ -22,7 +22,7 @@ CANBENCH_RESULTS_FILE="$CANISTER_PATH/canbench_results.yml"
 MAIN_BRANCH_RESULTS_FILE="$MAIN_BRANCH_DIR/$CANBENCH_RESULTS_FILE"
 
 # Install canbench
-cargo install canbench --version 0.1.4
+cargo install canbench --version 0.1.8
 
 # Verify that canbench results are available.
 if [ ! -f "$CANBENCH_RESULTS_FILE" ]; then

--- a/scripts/canbench_ci_run_benchmark.sh
+++ b/scripts/canbench_ci_run_benchmark.sh
@@ -22,7 +22,7 @@ CANBENCH_RESULTS_FILE="$CANISTER_PATH/canbench_results.yml"
 MAIN_BRANCH_RESULTS_FILE="$MAIN_BRANCH_DIR/$CANBENCH_RESULTS_FILE"
 
 # Install canbench
-cargo install canbench --version 0.1.1
+cargo install canbench --version 0.1.8
 
 # Verify that canbench results are available.
 if [ ! -f "$CANBENCH_RESULTS_FILE" ]; then


### PR DESCRIPTION
This PR upgrades `canbench` crate to v.0.1.8 and `pocket-ic` to 6.0.0.

Canbench tests for this PR showed a regression for `pre_upgrade_with_many_unstable_blocks`, but that is expected since in `canbench` v.0.1.5 there was a fix for correctly accounting the instructions when writing stable memory ([release](https://github.com/dfinity/canbench/releases/tag/v0.1.5)), which is exactly what is happening in bitcoin canister pre_upgrade.