### PR TITLE
chore: add instructions for generating testnet_blocks.txt

### DIFF
--- a/benchmarks/src/README.md
+++ b/benchmarks/src/README.md
@@ -1,12 +1,7 @@
 # How to Generate `testnet_blocks.txt`
 
-To generate the `testnet_blocks.txt` file from `./canister/test-data/testnet4_10k_blocks.dat`:
-
-1. Set `SAVE_CHAIN_AS_HEX_FILE = true` in `./canister/src/tests.rs`.
-2. Run the `testnet_10k_blocks` test from the `ic-btc-canister` package.
-
-Run the following command:
+To generate the `testnet_blocks.txt` file from `./canister/test-data/testnet4_10k_blocks.dat`, run the `testnet_10k_blocks` test in the `ic-btc-canister` package with the `save_chain_as_hex` feature enabled:
 
 ```shell
-cargo test --release -p ic-btc-canister testnet_10k_blocks
+cargo test --release -p ic-btc-canister --features save_chain_as_hex testnet_10k_blocks
 ```

--- a/benchmarks/src/README.md
+++ b/benchmarks/src/README.md
@@ -1,0 +1,12 @@
+# How to Generate `testnet_blocks.txt`
+
+To generate the `testnet_blocks.txt` file from `./canister/test-data/testnet4_10k_blocks.dat`:
+
+1. Uncomment the call to `save_chain_as_hex_file()` in `process_chain()` located in `./canister/src/tests.rs`.
+2. Run the `testnet_10k_blocks` test from the `ic-btc-canister` package.
+
+Run the following command:
+
+```shell
+cargo test --release -p ic-btc-canister testnet_10k_blocks
+```

--- a/benchmarks/src/README.md
+++ b/benchmarks/src/README.md
@@ -2,7 +2,7 @@
 
 To generate the `testnet_blocks.txt` file from `./canister/test-data/testnet4_10k_blocks.dat`:
 
-1. Uncomment the call to `save_chain_as_hex_file()` in `process_chain()` located in `./canister/src/tests.rs`.
+1. Set `SAVE_CHAIN_AS_HEX_FILE = true` in `./canister/src/tests.rs`.
 2. Run the `testnet_10k_blocks` test from the `ic-btc-canister` package.
 
 Run the following command:

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -47,3 +47,4 @@ test-strategy = "0.3.1"
 
 [features]
 file_memory = []
+save_chain_as_hex = []

--- a/canister/src/tests.rs
+++ b/canister/src/tests.rs
@@ -29,6 +29,22 @@ use std::{fs::File, panic::catch_unwind};
 
 mod confirmation_counts;
 
+// Helper function to save a chain to a file in hex format.
+#[allow(dead_code)]
+fn save_chain_as_hex_file(chain: &[BitcoinBlock], file_name: &str) -> std::io::Result<()> {
+    use std::io::{BufWriter, Write};
+    let file = File::create(file_name)?;
+    let mut writer = BufWriter::new(file);
+
+    chain.iter().try_for_each(|block| {
+        let mut bytes = Vec::new();
+        block.consensus_encode(&mut bytes)?;
+        writeln!(writer, "{}", hex::encode(bytes))
+    })?;
+
+    Ok(())
+}
+
 async fn process_chain(network: Network, blocks_file: &str, num_blocks: u32) {
     let mut chain: Vec<BitcoinBlock> = vec![];
 
@@ -80,6 +96,15 @@ async fn process_chain(network: Network, blocks_file: &str, num_blocks: u32) {
     }
 
     println!("Built chain with length: {}", chain.len());
+
+    // Uncomment to save the chain to a file.
+    // if network == Network::Testnet {
+    //     save_chain_as_hex_file(
+    //         &chain[..4000.min(chain.len())],
+    //         "../benchmarks/src/testnet_blocks.txt",
+    //     )
+    //     .unwrap();
+    // }
 
     // Map the blocks into responses that are given to the hearbeat.
     let responses: Vec<_> = chain

--- a/canister/src/tests.rs
+++ b/canister/src/tests.rs
@@ -29,8 +29,9 @@ use std::{fs::File, panic::catch_unwind};
 
 mod confirmation_counts;
 
+const SAVE_CHAIN_AS_HEX_FILE: bool = false;
+
 /// Helper function to save a chain to a file in hex format.
-#[allow(dead_code)]
 fn save_chain_as_hex_file(chain: &[BitcoinBlock], file_name: &str) -> std::io::Result<()> {
     use std::io::{BufWriter, Write};
     let file = File::create(file_name)?;
@@ -97,14 +98,13 @@ async fn process_chain(network: Network, blocks_file: &str, num_blocks: u32) {
 
     println!("Built chain with length: {}", chain.len());
 
-    // Uncomment to save the chain to a file.
-    // if network == Network::Testnet {
-    //     save_chain_as_hex_file(
-    //         &chain[..4000.min(chain.len())],
-    //         "../benchmarks/src/testnet_blocks.txt",
-    //     )
-    //     .unwrap();
-    // }
+    if SAVE_CHAIN_AS_HEX_FILE && network == Network::Testnet {
+        save_chain_as_hex_file(
+            &chain[..4000.min(chain.len())],
+            "../benchmarks/src/testnet_blocks.txt",
+        )
+        .unwrap();
+    }
 
     // Map the blocks into responses that are given to the hearbeat.
     let responses: Vec<_> = chain

--- a/canister/src/tests.rs
+++ b/canister/src/tests.rs
@@ -29,7 +29,7 @@ use std::{fs::File, panic::catch_unwind};
 
 mod confirmation_counts;
 
-// Helper function to save a chain to a file in hex format.
+/// Helper function to save a chain to a file in hex format.
 #[allow(dead_code)]
 fn save_chain_as_hex_file(chain: &[BitcoinBlock], file_name: &str) -> std::io::Result<()> {
     use std::io::{BufWriter, Write};

--- a/canister/src/tests.rs
+++ b/canister/src/tests.rs
@@ -29,9 +29,8 @@ use std::{fs::File, panic::catch_unwind};
 
 mod confirmation_counts;
 
-const SAVE_CHAIN_AS_HEX_FILE: bool = false;
-
 /// Helper function to save a chain to a file in hex format.
+#[cfg(feature = "save_chain_as_hex")]
 fn save_chain_as_hex_file(chain: &[BitcoinBlock], file_name: &str) -> std::io::Result<()> {
     use std::io::{BufWriter, Write};
     let file = File::create(file_name)?;
@@ -98,7 +97,8 @@ async fn process_chain(network: Network, blocks_file: &str, num_blocks: u32) {
 
     println!("Built chain with length: {}", chain.len());
 
-    if SAVE_CHAIN_AS_HEX_FILE && network == Network::Testnet {
+    #[cfg(feature = "save_chain_as_hex")]
+    if network == Network::Testnet {
         save_chain_as_hex_file(
             &chain[..4000.min(chain.len())],
             "../benchmarks/src/testnet_blocks.txt",


### PR DESCRIPTION
This PR adds instructions for generating `testnet_blocks.txt` hex file.

EXC-1813