### PR TITLE
feat: migrate watchdog canister to Testnet4

### DIFF
--- a/watchdog/candid.did
+++ b/watchdog/candid.did
@@ -29,6 +29,8 @@ type bitcoin_block_api = variant {
     blockstream_info_mainnet;
     blockstream_info_testnet;
     chain_api_btc_com_mainnet;
+    mempool_mainnet;
+    mempool_testnet;
 };
 
 /// Information about a Bitcoin block from a specific API provider.

--- a/watchdog/candid.did
+++ b/watchdog/candid.did
@@ -18,16 +18,12 @@ type height_status = variant {
 /// Bitcoin block API providers.
 type bitcoin_block_api = variant {
     api_bitaps_com_mainnet;
-    api_bitaps_com_testnet;
     api_blockchair_com_mainnet;
-    api_blockchair_com_testnet;
     api_blockcypher_com_mainnet;
-    api_blockcypher_com_testnet;
     bitcoin_canister;
     bitcoinexplorer_org_mainnet;
     blockchain_info_mainnet;
     blockstream_info_mainnet;
-    blockstream_info_testnet;
     chain_api_btc_com_mainnet;
     mempool_mainnet;
     mempool_testnet;

--- a/watchdog/src/bitcoin_block_apis.rs
+++ b/watchdog/src/bitcoin_block_apis.rs
@@ -11,20 +11,11 @@ pub enum BitcoinBlockApi {
     #[serde(rename = "api_bitaps_com_mainnet")]
     ApiBitapsComMainnet,
 
-    #[serde(rename = "api_bitaps_com_testnet")]
-    ApiBitapsComTestnet,
-
     #[serde(rename = "api_blockchair_com_mainnet")]
     ApiBlockchairComMainnet,
 
-    #[serde(rename = "api_blockchair_com_testnet")]
-    ApiBlockchairComTestnet,
-
     #[serde(rename = "api_blockcypher_com_mainnet")]
     ApiBlockcypherComMainnet,
-
-    #[serde(rename = "api_blockcypher_com_testnet")]
-    ApiBlockcypherComTestnet,
 
     #[serde(rename = "bitcoin_canister")]
     BitcoinCanister, // Not an explorer.
@@ -37,9 +28,6 @@ pub enum BitcoinBlockApi {
 
     #[serde(rename = "blockstream_info_mainnet")]
     BlockstreamInfoMainnet,
-
-    #[serde(rename = "blockstream_info_testnet")]
-    BlockstreamInfoTestnet,
 
     #[serde(rename = "chain_api_btc_com_mainnet")]
     ChainApiBtcComMainnet,
@@ -120,13 +108,7 @@ impl BitcoinBlockApi {
 
     /// Returns the list of testnet explorers only.
     fn explorers_testnet() -> Vec<Self> {
-        let mut explorers = vec![
-            BitcoinBlockApi::ApiBitapsComTestnet,
-            BitcoinBlockApi::ApiBlockchairComTestnet,
-            BitcoinBlockApi::ApiBlockcypherComTestnet,
-            BitcoinBlockApi::BlockstreamInfoTestnet,
-            BitcoinBlockApi::MempoolTestnet,
-        ];
+        let mut explorers = vec![BitcoinBlockApi::MempoolTestnet];
         // Remove the explorers that are not configured.
         let configured: HashSet<_> = crate::storage::get_config().explorers.into_iter().collect();
         explorers.retain(|x| configured.contains(x));
@@ -140,20 +122,11 @@ impl BitcoinBlockApi {
             BitcoinBlockApi::ApiBitapsComMainnet => {
                 http_request(endpoint_api_bitaps_com_block_mainnet()).await
             }
-            BitcoinBlockApi::ApiBitapsComTestnet => {
-                http_request(endpoint_api_bitaps_com_block_testnet()).await
-            }
             BitcoinBlockApi::ApiBlockchairComMainnet => {
                 http_request(endpoint_api_blockchair_com_block_mainnet()).await
             }
-            BitcoinBlockApi::ApiBlockchairComTestnet => {
-                http_request(endpoint_api_blockchair_com_block_testnet()).await
-            }
             BitcoinBlockApi::ApiBlockcypherComMainnet => {
                 http_request(endpoint_api_blockcypher_com_block_mainnet()).await
-            }
-            BitcoinBlockApi::ApiBlockcypherComTestnet => {
-                http_request(endpoint_api_blockcypher_com_block_testnet()).await
             }
             BitcoinBlockApi::BitcoinCanister => http_request(endpoint_bitcoin_canister()).await,
             BitcoinBlockApi::BitcoinExplorerOrgMainnet => {
@@ -179,22 +152,6 @@ impl BitcoinBlockApi {
                 let futures = vec![
                     http_request(endpoint_blockstream_info_height_mainnet()),
                     http_request(endpoint_blockstream_info_hash_mainnet()),
-                ];
-                let results = futures::future::join_all(futures).await;
-                match (results[0]["height"].as_u64(), results[1]["hash"].as_str()) {
-                    (Some(height), Some(hash)) => {
-                        json!({
-                            "height": height,
-                            "hash": hash,
-                        })
-                    }
-                    _ => json!({}),
-                }
-            }
-            BitcoinBlockApi::BlockstreamInfoTestnet => {
-                let futures = vec![
-                    http_request(endpoint_blockstream_info_height_testnet()),
-                    http_request(endpoint_blockstream_info_hash_testnet()),
                 ];
                 let results = futures::future::join_all(futures).await;
                 match (results[0]["height"].as_u64(), results[1]["hash"].as_str()) {
@@ -290,20 +247,6 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_api_bitaps_com_testnet() {
-        test_utils::mock_testnet_outcalls();
-        run_test(
-            BitcoinBlockApi::ApiBitapsComTestnet,
-            vec![(endpoint_api_bitaps_com_block_testnet(), 1)],
-            json!({
-                "height": 2000001,
-                "hash": "0000000000000000000fff111111111111111111111111111111111111111111",
-            }),
-        )
-        .await;
-    }
-
-    #[tokio::test]
     async fn test_bitcoinexplorer_org_mainnet() {
         test_utils::mock_mainnet_outcalls();
         run_test(
@@ -332,20 +275,6 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_api_blockchair_com_testnet() {
-        test_utils::mock_testnet_outcalls();
-        run_test(
-            BitcoinBlockApi::ApiBlockchairComTestnet,
-            vec![(endpoint_api_blockchair_com_block_testnet(), 1)],
-            json!({
-                "height": 2000002,
-                "hash": "0000000000000000000fff222222222222222222222222222222222222222222",
-            }),
-        )
-        .await;
-    }
-
-    #[tokio::test]
     async fn test_api_blockcypher_com_mainnet() {
         test_utils::mock_mainnet_outcalls();
         run_test(
@@ -355,21 +284,6 @@ mod test {
                 "height": 700003,
                 "hash": "0000000000000000000aaa333333333333333333333333333333333333333333",
                 "previous_hash": "0000000000000000000aaa222222222222222222222222222222222222222222",
-            }),
-        )
-        .await;
-    }
-
-    #[tokio::test]
-    async fn test_api_blockcypher_com_testnet() {
-        test_utils::mock_testnet_outcalls();
-        run_test(
-            BitcoinBlockApi::ApiBlockcypherComTestnet,
-            vec![(endpoint_api_blockcypher_com_block_testnet(), 1)],
-            json!({
-                "height": 2000003,
-                "hash": "0000000000000000000fff333333333333333333333333333333333333333333",
-                "previous_hash": "0000000000000000000fff222222222222222222222222222222222222222222",
             }),
         )
         .await;
@@ -423,23 +337,6 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_blockstream_info_testnet() {
-        test_utils::mock_testnet_outcalls();
-        run_test(
-            BitcoinBlockApi::BlockstreamInfoTestnet,
-            vec![
-                (endpoint_blockstream_info_hash_testnet(), 1),
-                (endpoint_blockstream_info_height_testnet(), 1),
-            ],
-            json!({
-                "height": 2000004,
-                "hash": "0000000000000000000fff555555555555555555555555555555555555555555",
-            }),
-        )
-        .await;
-    }
-
-    #[tokio::test]
     async fn test_chain_api_btc_com_mainnet() {
         test_utils::mock_mainnet_outcalls();
         run_test(
@@ -486,24 +383,12 @@ mod test {
                 "api_bitaps_com_mainnet",
             ),
             (
-                BitcoinBlockApi::ApiBitapsComTestnet,
-                "api_bitaps_com_testnet",
-            ),
-            (
                 BitcoinBlockApi::ApiBlockchairComMainnet,
                 "api_blockchair_com_mainnet",
             ),
             (
-                BitcoinBlockApi::ApiBlockchairComTestnet,
-                "api_blockchair_com_testnet",
-            ),
-            (
                 BitcoinBlockApi::ApiBlockcypherComMainnet,
                 "api_blockcypher_com_mainnet",
-            ),
-            (
-                BitcoinBlockApi::ApiBlockcypherComTestnet,
-                "api_blockcypher_com_testnet",
             ),
             (BitcoinBlockApi::BitcoinCanister, "bitcoin_canister"),
             (
@@ -519,13 +404,11 @@ mod test {
                 "blockstream_info_mainnet",
             ),
             (
-                BitcoinBlockApi::BlockstreamInfoTestnet,
-                "blockstream_info_testnet",
-            ),
-            (
                 BitcoinBlockApi::ChainApiBtcComMainnet,
                 "chain_api_btc_com_mainnet",
             ),
+            (BitcoinBlockApi::MempoolMainnet, "mempool_mainnet"),
+            (BitcoinBlockApi::MempoolTestnet, "mempool_testnet"),
         ]
         .iter()
         .cloned()

--- a/watchdog/src/bitcoin_block_apis.rs
+++ b/watchdog/src/bitcoin_block_apis.rs
@@ -43,6 +43,12 @@ pub enum BitcoinBlockApi {
 
     #[serde(rename = "chain_api_btc_com_mainnet")]
     ChainApiBtcComMainnet,
+
+    #[serde(rename = "mempool_mainnet")]
+    MempoolMainnet,
+
+    #[serde(rename = "mempool_testnet")]
+    MempoolTestnet,
 }
 
 impl std::fmt::Display for BitcoinBlockApi {
@@ -103,6 +109,7 @@ impl BitcoinBlockApi {
             BitcoinBlockApi::BlockchainInfoMainnet,
             BitcoinBlockApi::BlockstreamInfoMainnet,
             BitcoinBlockApi::ChainApiBtcComMainnet,
+            BitcoinBlockApi::MempoolMainnet,
         ];
         // Remove the explorers that are not configured.
         let configured: HashSet<_> = crate::storage::get_config().explorers.into_iter().collect();
@@ -118,6 +125,7 @@ impl BitcoinBlockApi {
             BitcoinBlockApi::ApiBlockchairComTestnet,
             BitcoinBlockApi::ApiBlockcypherComTestnet,
             BitcoinBlockApi::BlockstreamInfoTestnet,
+            BitcoinBlockApi::MempoolTestnet,
         ];
         // Remove the explorers that are not configured.
         let configured: HashSet<_> = crate::storage::get_config().explorers.into_iter().collect();
@@ -201,6 +209,12 @@ impl BitcoinBlockApi {
             }
             BitcoinBlockApi::ChainApiBtcComMainnet => {
                 http_request(endpoint_chain_api_btc_com_block_mainnet()).await
+            }
+            BitcoinBlockApi::MempoolMainnet => {
+                http_request(endpoint_mempool_height_mainnet()).await
+            }
+            BitcoinBlockApi::MempoolTestnet => {
+                http_request(endpoint_mempool_height_testnet()).await
             }
         }
     }

--- a/watchdog/src/bitcoin_block_apis.rs
+++ b/watchdog/src/bitcoin_block_apis.rs
@@ -352,6 +352,32 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_mempool_mainnet() {
+        test_utils::mock_mainnet_outcalls();
+        run_test(
+            BitcoinBlockApi::MempoolMainnet,
+            vec![(endpoint_mempool_height_mainnet(), 1)],
+            json!({
+                "height": 700008,
+            }),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_mempool_testnet() {
+        test_utils::mock_testnet_outcalls();
+        run_test(
+            BitcoinBlockApi::MempoolTestnet,
+            vec![(endpoint_mempool_height_testnet(), 1)],
+            json!({
+                "height": 55002,
+            }),
+        )
+        .await;
+    }
+
+    #[tokio::test]
     async fn test_http_request_failed_with_404() {
         test_utils::mock_all_outcalls_404();
         let all_providers = BitcoinBlockApi::providers_mainnet()

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -73,6 +73,7 @@ impl Config {
                 BitcoinBlockApi::BlockchainInfoMainnet,
                 BitcoinBlockApi::BlockstreamInfoMainnet,
                 BitcoinBlockApi::ChainApiBtcComMainnet,
+                BitcoinBlockApi::MempoolMainnet,
             ],
         }
     }
@@ -88,12 +89,7 @@ impl Config {
                 .unwrap(),
             delay_before_first_fetch_sec: DELAY_BEFORE_FIRST_FETCH_SEC,
             interval_between_fetches_sec: INTERVAL_BETWEEN_FETCHES_SEC,
-            explorers: vec![
-                BitcoinBlockApi::ApiBitapsComTestnet,
-                BitcoinBlockApi::ApiBlockchairComTestnet,
-                BitcoinBlockApi::ApiBlockcypherComTestnet,
-                BitcoinBlockApi::BlockstreamInfoTestnet,
-            ],
+            explorers: vec![BitcoinBlockApi::MempoolTestnet],
         }
     }
 

--- a/watchdog/src/endpoints.rs
+++ b/watchdog/src/endpoints.rs
@@ -13,22 +13,8 @@ use serde_json::json;
 
 /// Creates a config for fetching mainnet block data from api.bitaps.com.
 pub fn endpoint_api_bitaps_com_block_mainnet() -> HttpRequestConfig {
-    endpoint_api_bitaps_com_block(BitcoinNetwork::Mainnet)
-}
-
-/// Creates a config for fetching testnet block data from api.bitaps.com.
-pub fn endpoint_api_bitaps_com_block_testnet() -> HttpRequestConfig {
-    endpoint_api_bitaps_com_block(BitcoinNetwork::Testnet)
-}
-
-/// Creates a config for fetching block data from api.bitaps.com.
-fn endpoint_api_bitaps_com_block(bitcoin_network: BitcoinNetwork) -> HttpRequestConfig {
-    let url = match bitcoin_network {
-        BitcoinNetwork::Mainnet => "https://api.bitaps.com/btc/v1/blockchain/block/last",
-        BitcoinNetwork::Testnet => "https://api.bitaps.com/btc/testnet/v1/blockchain/block/last",
-    };
     HttpRequestConfig::new(
-        url,
+        "https://api.bitaps.com/btc/v1/blockchain/block/last",
         Some(TransformFnWrapper {
             name: "transform_api_bitaps_com_block",
             func: transform_api_bitaps_com_block,
@@ -47,22 +33,8 @@ fn endpoint_api_bitaps_com_block(bitcoin_network: BitcoinNetwork) -> HttpRequest
 
 /// Creates a config for fetching mainnet block data from api.blockchair.com.
 pub fn endpoint_api_blockchair_com_block_mainnet() -> HttpRequestConfig {
-    endpoint_api_blockchair_com_block(BitcoinNetwork::Mainnet)
-}
-
-/// Creates a config for fetching testnet block data from api.blockchair.com.
-pub fn endpoint_api_blockchair_com_block_testnet() -> HttpRequestConfig {
-    endpoint_api_blockchair_com_block(BitcoinNetwork::Testnet)
-}
-
-/// Creates a config for fetching block data from api.blockchair.com.
-fn endpoint_api_blockchair_com_block(bitcoin_network: BitcoinNetwork) -> HttpRequestConfig {
-    let url = match bitcoin_network {
-        BitcoinNetwork::Mainnet => "https://api.blockchair.com/bitcoin/stats",
-        BitcoinNetwork::Testnet => "https://api.blockchair.com/bitcoin/testnet/stats",
-    };
     HttpRequestConfig::new(
-        url,
+        "https://api.blockchair.com/bitcoin/stats",
         Some(TransformFnWrapper {
             name: "transform_api_blockchair_com_block",
             func: transform_api_blockchair_com_block,
@@ -81,22 +53,8 @@ fn endpoint_api_blockchair_com_block(bitcoin_network: BitcoinNetwork) -> HttpReq
 
 /// Creates a config for fetching mainnet block data from api.blockcypher.com.
 pub fn endpoint_api_blockcypher_com_block_mainnet() -> HttpRequestConfig {
-    endpoint_api_blockcypher_com_block(BitcoinNetwork::Mainnet)
-}
-
-/// Creates a config for fetching testnet block data from api.blockcypher.com.
-pub fn endpoint_api_blockcypher_com_block_testnet() -> HttpRequestConfig {
-    endpoint_api_blockcypher_com_block(BitcoinNetwork::Testnet)
-}
-
-/// Creates a config for fetching block data from api.blockcypher.com.
-fn endpoint_api_blockcypher_com_block(bitcoin_network: BitcoinNetwork) -> HttpRequestConfig {
-    let url = match bitcoin_network {
-        BitcoinNetwork::Mainnet => "https://api.blockcypher.com/v1/btc/main",
-        BitcoinNetwork::Testnet => "https://api.blockcypher.com/v1/btc/test3",
-    };
     HttpRequestConfig::new(
-        url,
+        "https://api.blockcypher.com/v1/btc/main",
         Some(TransformFnWrapper {
             name: "transform_api_blockcypher_com_block",
             func: transform_api_blockcypher_com_block,
@@ -223,22 +181,8 @@ pub fn endpoint_blockchain_info_height_mainnet() -> HttpRequestConfig {
 
 /// Creates a config for fetching mainnet hash data from blockstream.info.
 pub fn endpoint_blockstream_info_hash_mainnet() -> HttpRequestConfig {
-    endpoint_blockstream_info_hash(BitcoinNetwork::Mainnet)
-}
-
-/// Creates a config for fetching testnet hash data from blockstream.info.
-pub fn endpoint_blockstream_info_hash_testnet() -> HttpRequestConfig {
-    endpoint_blockstream_info_hash(BitcoinNetwork::Testnet)
-}
-
-/// Creates a config for fetching hash data from blockstream.info.
-fn endpoint_blockstream_info_hash(bitcoin_network: BitcoinNetwork) -> HttpRequestConfig {
-    let url = match bitcoin_network {
-        BitcoinNetwork::Mainnet => "https://blockstream.info/api/blocks/tip/hash",
-        BitcoinNetwork::Testnet => "https://blockstream.info/testnet/api/blocks/tip/hash",
-    };
     HttpRequestConfig::new(
-        url,
+        "https://blockstream.info/api/blocks/tip/hash",
         Some(TransformFnWrapper {
             name: "transform_blockstream_info_hash",
             func: transform_blockstream_info_hash,
@@ -256,22 +200,8 @@ fn endpoint_blockstream_info_hash(bitcoin_network: BitcoinNetwork) -> HttpReques
 
 /// Creates a config for fetching mainnet height data from blockstream.info.
 pub fn endpoint_blockstream_info_height_mainnet() -> HttpRequestConfig {
-    endpoint_blockstream_info_height(BitcoinNetwork::Mainnet)
-}
-
-/// Creates a config for fetching testnet height data from blockstream.info.
-pub fn endpoint_blockstream_info_height_testnet() -> HttpRequestConfig {
-    endpoint_blockstream_info_height(BitcoinNetwork::Testnet)
-}
-
-/// Creates a config for fetching height data from blockstream.info.
-fn endpoint_blockstream_info_height(bitcoin_network: BitcoinNetwork) -> HttpRequestConfig {
-    let url = match bitcoin_network {
-        BitcoinNetwork::Mainnet => "https://blockstream.info/api/blocks/tip/height",
-        BitcoinNetwork::Testnet => "https://blockstream.info/testnet/api/blocks/tip/height",
-    };
     HttpRequestConfig::new(
-        url,
+        "https://blockstream.info/api/blocks/tip/height",
         Some(TransformFnWrapper {
             name: "transform_blockstream_info_height",
             func: transform_blockstream_info_height,
@@ -441,20 +371,6 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_api_bitaps_com_block_testnet() {
-        run_http_request_test(
-            endpoint_api_bitaps_com_block_testnet(),
-            "https://api.bitaps.com/btc/testnet/v1/blockchain/block/last",
-            test_utils::API_BITAPS_COM_TESTNET_RESPONSE,
-            json!({
-                "height": 2000001,
-                "hash": "0000000000000000000fff111111111111111111111111111111111111111111",
-            }),
-        )
-        .await;
-    }
-
-    #[tokio::test]
     async fn test_api_blockchair_com_block() {
         run_http_request_test(
             endpoint_api_blockchair_com_block_mainnet(),
@@ -505,7 +421,7 @@ mod test {
             "https://g4xu7-jiaaa-aaaan-aaaaq-cai.raw.ic0.app/metrics",
             test_utils::BITCOIN_CANISTER_TESTNET_RESPONSE,
             json!({
-                "height": 2000007,
+                "height": 55001,
             }),
         )
         .await;
@@ -641,17 +557,14 @@ mod test {
         let expected_status = candid::Nat::from(404u16);
         let test_cases = [
             endpoint_api_blockchair_com_block_mainnet(),
-            endpoint_api_blockchair_com_block_testnet(),
             endpoint_api_blockcypher_com_block_mainnet(),
-            endpoint_api_blockcypher_com_block_testnet(),
             endpoint_bitcoin_canister(),
             endpoint_blockchain_info_hash_mainnet(),
             endpoint_blockchain_info_height_mainnet(),
             endpoint_blockstream_info_hash_mainnet(),
-            endpoint_blockstream_info_hash_testnet(),
             endpoint_blockstream_info_height_mainnet(),
-            endpoint_blockstream_info_height_testnet(),
             endpoint_chain_api_btc_com_block_mainnet(),
+            endpoint_mempool_height_testnet(),
         ];
         for config in test_cases {
             // Arrange

--- a/watchdog/src/endpoints.rs
+++ b/watchdog/src/endpoints.rs
@@ -494,6 +494,32 @@ mod test {
         .await;
     }
 
+    #[tokio::test]
+    async fn test_mempool_height_mainnet() {
+        run_http_request_test(
+            endpoint_mempool_height_mainnet(),
+            "https://mempool.space/api/blocks/tip/height",
+            test_utils::MEMPOOL_HEIGHT_MAINNET_RESPONSE,
+            json!({
+                "height": 700008,
+            }),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_mempool_height_testnet() {
+        run_http_request_test(
+            endpoint_mempool_height_testnet(),
+            "https://mempool.space/testnet4/api/blocks/tip/height",
+            test_utils::MEMPOOL_HEIGHT_TESTNET_RESPONSE,
+            json!({
+                "height": 55002,
+            }),
+        )
+        .await;
+    }
+
     #[test]
     fn test_transform_function_names() {
         test_utils::mock_mainnet_outcalls();

--- a/watchdog/src/fetch.rs
+++ b/watchdog/src/fetch.rs
@@ -87,6 +87,10 @@ mod test {
                     height: Some(700006),
                 },
                 BlockInfo {
+                    provider: BitcoinBlockApi::MempoolMainnet,
+                    height: Some(700008),
+                },
+                BlockInfo {
                     provider: BitcoinBlockApi::BitcoinCanister,
                     height: Some(700007),
                 },
@@ -104,24 +108,12 @@ mod test {
             result,
             vec![
                 BlockInfo {
-                    provider: BitcoinBlockApi::ApiBitapsComTestnet,
-                    height: Some(2000001),
-                },
-                BlockInfo {
-                    provider: BitcoinBlockApi::ApiBlockchairComTestnet,
-                    height: Some(2000002),
-                },
-                BlockInfo {
-                    provider: BitcoinBlockApi::ApiBlockcypherComTestnet,
-                    height: Some(2000003),
-                },
-                BlockInfo {
-                    provider: BitcoinBlockApi::BlockstreamInfoTestnet,
-                    height: Some(2000004),
+                    provider: BitcoinBlockApi::MempoolTestnet,
+                    height: Some(55002),
                 },
                 BlockInfo {
                     provider: BitcoinBlockApi::BitcoinCanister,
-                    height: Some(2000007),
+                    height: Some(55001),
                 },
             ]
         );
@@ -165,6 +157,10 @@ mod test {
                     height: None,
                 },
                 BlockInfo {
+                    provider: BitcoinBlockApi::MempoolMainnet,
+                    height: None,
+                },
+                BlockInfo {
                     provider: BitcoinBlockApi::BitcoinCanister,
                     height: None,
                 },
@@ -182,19 +178,7 @@ mod test {
             result,
             vec![
                 BlockInfo {
-                    provider: BitcoinBlockApi::ApiBitapsComTestnet,
-                    height: None,
-                },
-                BlockInfo {
-                    provider: BitcoinBlockApi::ApiBlockchairComTestnet,
-                    height: None,
-                },
-                BlockInfo {
-                    provider: BitcoinBlockApi::ApiBlockcypherComTestnet,
-                    height: None,
-                },
-                BlockInfo {
-                    provider: BitcoinBlockApi::BlockstreamInfoTestnet,
+                    provider: BitcoinBlockApi::MempoolTestnet,
                     height: None,
                 },
                 BlockInfo {

--- a/watchdog/src/lib.rs
+++ b/watchdog/src/lib.rs
@@ -185,6 +185,11 @@ fn transform_chain_api_btc_com_block(raw: TransformArgs) -> HttpResponse {
     endpoint_chain_api_btc_com_block_mainnet().transform(raw)
 }
 
+#[query]
+fn transform_mempool_height(raw: TransformArgs) -> HttpResponse {
+    endpoint_mempool_height_mainnet().transform(raw)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/watchdog/src/test_utils.rs
+++ b/watchdog/src/test_utils.rs
@@ -43,6 +43,10 @@ pub fn mock_mainnet_outcalls() {
             endpoint_chain_api_btc_com_block_mainnet(),
             CHAIN_API_BTC_COM_MAINNET_RESPONSE,
         ),
+        (
+            endpoint_mempool_height_mainnet(),
+            MEMPOOL_HEIGHT_MAINNET_RESPONSE,
+        ),
     ];
     for (config, response_body) in mocks {
         let request = config.request();
@@ -81,6 +85,10 @@ pub fn mock_testnet_outcalls() {
             endpoint_blockstream_info_height_testnet(),
             BLOCKSTREAM_INFO_HEIGHT_TESTNET_RESPONSE,
         ),
+        (
+            endpoint_mempool_height_testnet(),
+            MEMPOOL_HEIGHT_TESTNET_RESPONSE,
+        ),
     ];
     for (config, response_body) in mocks {
         let request = config.request();
@@ -108,6 +116,8 @@ pub fn mock_all_outcalls_404() {
         endpoint_blockstream_info_height_mainnet(),
         endpoint_blockstream_info_height_testnet(),
         endpoint_chain_api_btc_com_block_mainnet(),
+        endpoint_mempool_height_mainnet(),
+        endpoint_mempool_height_testnet(),
     ];
     for config in mocks {
         let request = config.request();
@@ -132,6 +142,8 @@ pub fn mock_all_outcalls_abusing_api() {
         endpoint_blockstream_info_height_mainnet(),
         endpoint_blockstream_info_height_testnet(),
         endpoint_chain_api_btc_com_block_mainnet(),
+        endpoint_mempool_height_mainnet(),
+        endpoint_mempool_height_testnet(),
     ];
     for config in mocks {
         let request = config.request();
@@ -420,3 +432,9 @@ pub const CHAIN_API_BTC_COM_MAINNET_RESPONSE: &str = r#"{
     "message":"success",
     "status":"success"
 }"#;
+
+// https://mempool.space/api/blocks/tip/height
+pub const MEMPOOL_HEIGHT_MAINNET_RESPONSE: &str = r#"700007"#;
+
+// https://mempool.space/testnet4/api/blocks/tip/height
+pub const MEMPOOL_HEIGHT_TESTNET_RESPONSE: &str = r#"700008"#;

--- a/watchdog/src/test_utils.rs
+++ b/watchdog/src/test_utils.rs
@@ -1,4 +1,5 @@
 use crate::endpoints::*;
+use crate::http::HttpRequestConfig;
 
 /// Mocks all the mainnet outcalls to be successful.
 pub fn mock_mainnet_outcalls() {
@@ -62,28 +63,8 @@ pub fn mock_mainnet_outcalls() {
 pub fn mock_testnet_outcalls() {
     let mocks = [
         (
-            endpoint_api_bitaps_com_block_testnet(),
-            API_BITAPS_COM_TESTNET_RESPONSE,
-        ),
-        (
-            endpoint_api_blockchair_com_block_testnet(),
-            API_BLOCKCHAIR_COM_TESTNET_RESPONSE,
-        ),
-        (
-            endpoint_api_blockcypher_com_block_testnet(),
-            API_BLOCKCYPHER_COM_TESTNET_RESPONSE,
-        ),
-        (
             endpoint_bitcoin_canister(),
             BITCOIN_CANISTER_TESTNET_RESPONSE,
-        ),
-        (
-            endpoint_blockstream_info_hash_testnet(),
-            BLOCKSTREAM_INFO_HASH_TESTNET_RESPONSE,
-        ),
-        (
-            endpoint_blockstream_info_height_testnet(),
-            BLOCKSTREAM_INFO_HEIGHT_TESTNET_RESPONSE,
         ),
         (
             endpoint_mempool_height_testnet(),
@@ -100,26 +81,25 @@ pub fn mock_testnet_outcalls() {
     }
 }
 
-/// Mocks all the outcalls to fail with status code 404.
-pub fn mock_all_outcalls_404() {
-    let mocks = [
+fn all_mock_outcalls() -> Vec<HttpRequestConfig> {
+    vec![
         endpoint_api_blockchair_com_block_mainnet(),
-        endpoint_api_blockchair_com_block_testnet(),
         endpoint_api_blockcypher_com_block_mainnet(),
-        endpoint_api_blockcypher_com_block_testnet(),
         endpoint_bitcoin_canister(),
         endpoint_bitcoinexplorer_org_block_mainnet(),
         endpoint_blockchain_info_hash_mainnet(),
         endpoint_blockchain_info_height_mainnet(),
         endpoint_blockstream_info_hash_mainnet(),
-        endpoint_blockstream_info_hash_testnet(),
         endpoint_blockstream_info_height_mainnet(),
-        endpoint_blockstream_info_height_testnet(),
         endpoint_chain_api_btc_com_block_mainnet(),
         endpoint_mempool_height_mainnet(),
         endpoint_mempool_height_testnet(),
-    ];
-    for config in mocks {
+    ]
+}
+
+/// Mocks all the outcalls to fail with status code 404.
+pub fn mock_all_outcalls_404() {
+    for config in all_mock_outcalls() {
         let request = config.request();
         let mock_response = ic_http::create_response().status(404).build();
         ic_http::mock::mock(request, mock_response);
@@ -128,24 +108,7 @@ pub fn mock_all_outcalls_404() {
 
 /// Mocks all the outcalls to abuse the API.
 pub fn mock_all_outcalls_abusing_api() {
-    let mocks = [
-        endpoint_api_blockchair_com_block_mainnet(),
-        endpoint_api_blockchair_com_block_testnet(),
-        endpoint_api_blockcypher_com_block_mainnet(),
-        endpoint_api_blockcypher_com_block_testnet(),
-        endpoint_bitcoin_canister(),
-        endpoint_bitcoinexplorer_org_block_mainnet(),
-        endpoint_blockchain_info_hash_mainnet(),
-        endpoint_blockchain_info_height_mainnet(),
-        endpoint_blockstream_info_hash_mainnet(),
-        endpoint_blockstream_info_hash_testnet(),
-        endpoint_blockstream_info_height_mainnet(),
-        endpoint_blockstream_info_height_testnet(),
-        endpoint_chain_api_btc_com_block_mainnet(),
-        endpoint_mempool_height_mainnet(),
-        endpoint_mempool_height_testnet(),
-    ];
-    for config in mocks {
+    for config in all_mock_outcalls() {
         let request = config.request();
         let mock_response = ic_http::create_response()
             .status(200)
@@ -162,17 +125,6 @@ pub const API_BITAPS_COM_MAINNET_RESPONSE: &str = r#"{
     "data": {
         "height": 700001,
         "hash": "0000000000000000000aaa111111111111111111111111111111111111111111",
-        "header": "AGAAILqkI+SFlsu4FRCwVNiwU3Eku+N/g9sEAAAAAAAAAAAAH1tWFGtObfxfaOeXVwH9txRFHWS4V+N24n9AyliR1S4Yvghko4kGFwdzNef9XA4=",
-        "adjustedTimestamp": 1678294552
-    },
-    "time": 0.0018
-}"#;
-
-// https://api.bitaps.com/btc/testnet/v1/blockchain/block/last
-pub const API_BITAPS_COM_TESTNET_RESPONSE: &str = r#"{
-    "data": {
-        "height": 2000001,
-        "hash": "0000000000000000000fff111111111111111111111111111111111111111111",
         "header": "AGAAILqkI+SFlsu4FRCwVNiwU3Eku+N/g9sEAAAAAAAAAAAAH1tWFGtObfxfaOeXVwH9txRFHWS4V+N24n9AyliR1S4Yvghko4kGFwdzNef9XA4=",
         "adjustedTimestamp": 1678294552
     },
@@ -227,80 +179,6 @@ pub const API_BLOCKCHAIR_COM_MAINNET_RESPONSE: &str = r#"{
     }    
 }"#;
 
-// https://api.blockchair.com/bitcoin/testnet/stats
-pub const API_BLOCKCHAIR_COM_TESTNET_RESPONSE: &str = r#"{
-    "data":
-    {
-        "blocks":2431136,
-        "transactions":65448595,
-        "outputs":173565382,
-        "circulation":2099216984092285,
-        "blocks_24h":96,
-        "transactions_24h":9427,
-        "difficulty":1,
-        "volume_24h":5268257522789,
-        "mempool_transactions":112,
-        "mempool_size":39045,
-        "mempool_tps":0.06666666666666667,
-        "mempool_total_fee_usd":0,
-        "best_block_height":2000002,
-        "best_block_hash":"0000000000000000000fff222222222222222222222222222222222222222222",
-        "best_block_time":"2023-04-26 17:12:02",
-        "blockchain_size":28774784525,
-        "average_transaction_fee_24h":4780,
-        "inflation_24h":234374976,
-        "median_transaction_fee_24h":247,
-        "cdd_24h":132168.45577533677,
-        "mempool_outputs":453,
-        "largest_transaction_24h":
-        {
-            "hash":"6b50cb5842a049a8aa148f40acad0d20970e5100ed7659938f5f0f95ca2c5d4f",
-            "value_usd":0
-        },
-        "hashrate_24h":"4772185",
-        "inflation_usd_24h":0,
-        "average_transaction_fee_usd_24h":0,
-        "median_transaction_fee_usd_24h":0,
-        "market_price_usd":0,
-        "market_price_btc":0,
-        "market_price_usd_change_24h_percentage":0,
-        "market_cap_usd":0,
-        "market_dominance_percentage":0,
-        "next_retarget_time_estimate":"2023-04-27 12:46:52",
-        "next_difficulty_estimate":139532120,
-        "suggested_transaction_fee_per_byte_sat":1,
-        "hodling_addresses":10038668
-    },
-    "context":
-    {
-        "code":200,
-        "source":"A",
-        "state":2431135,
-        "market_price_usd":29794,
-        "cache":
-        {
-            "live":false,
-            "duration":"Ignore",
-            "since":"2023-04-26 17:24:41",
-            "until":"2023-04-26 17:25:52",
-            "time":1.9073486328125e-6
-        },
-        "api":
-        {
-            "version":"2.0.95-ie",
-            "last_major_update":"2022-11-07 02:00:00",
-            "next_major_update":null,
-            "documentation":"https:\/\/blockchair.com\/api\/docs",
-            "notice":"Please note that on November 7th, 2022 public support for the following blockchains was dropped: EOS, Bitcoin SV"
-        },
-        "servers":"API4,TBTC0",
-        "time":1.7573418617248535,
-        "render_time":0.0011322498321533203,
-        "full_time":0.0011341571807861328,
-        "request_cost":1
-    }
-}"#;
-
 // https://api.blockcypher.com/v1/btc/main
 pub const API_BLOCKCYPHER_COM_MAINNET_RESPONSE: &str = r#"{
     "name": "BTC.main",
@@ -317,24 +195,6 @@ pub const API_BLOCKCYPHER_COM_MAINNET_RESPONSE: &str = r#"{
     "low_fee_per_kb": 12258,
     "last_fork_height": 781277,
     "last_fork_hash": "0000000000000000000388f42000fa901c01f2bfae36042bbae133ee430e6485"
-}"#;
-
-// https://api.blockcypher.com/v1/btc/test3
-pub const API_BLOCKCYPHER_COM_TESTNET_RESPONSE: &str = r#"{
-    "name": "BTC.test3",
-    "height": 2000003,
-    "hash": "0000000000000000000fff333333333333333333333333333333333333333333",
-    "time": "2023-04-26T17:12:11.044585287Z",
-    "latest_url": "https://api.blockcypher.com/v1/btc/test3/blocks/0000000000008d9497a398933d6618c6a39a6c818c22e82ef864f0a53c7bc4c1",
-    "previous_hash": "0000000000000000000fff222222222222222222222222222222222222222222",
-    "previous_url": "https://api.blockcypher.com/v1/btc/test3/blocks/00000000000000150d0869032cacc4af7b72a70a60e6d41805543a471e17050e",
-    "peer_count": 284,
-    "unconfirmed_count": 62,
-    "high_fee_per_kb": 44424,
-    "medium_fee_per_kb": 29773,
-    "low_fee_per_kb": 16199,
-    "last_fork_height": 2428426,
-    "last_fork_hash": "00000000000011f558264dc907379ec11e62420f6224f0b081dc6155e9a6e239"
 }"#;
 
 // https://ghsi2-tqaaa-aaaan-aaaca-cai.raw.ic0.app/metrics
@@ -357,7 +217,7 @@ pub const BITCOIN_CANISTER_MAINNET_RESPONSE: &str = r#"{
 pub const BITCOIN_CANISTER_TESTNET_RESPONSE: &str = r#"{
     # HELP main_chain_height Height of the main chain.
     # TYPE main_chain_height gauge
-    main_chain_height 2000007 1682533330541
+    main_chain_height 55001 1682533330541
     # HELP stable_height The height of the latest stable block.
     # TYPE stable_height gauge
     stable_height 2430866 1682533330541
@@ -388,13 +248,6 @@ pub const BLOCKSTREAM_INFO_HASH_MAINNET_RESPONSE: &str =
 
 // https://blockstream.info/api/blocks/tip/height
 pub const BLOCKSTREAM_INFO_HEIGHT_MAINNET_RESPONSE: &str = r#"700005"#;
-
-// https://blockstream.info/testnet/api/blocks/tip/hash
-pub const BLOCKSTREAM_INFO_HASH_TESTNET_RESPONSE: &str =
-    r#"0000000000000000000fff555555555555555555555555555555555555555555"#;
-
-// https://blockstream.info/testnet/api/blocks/tip/height
-pub const BLOCKSTREAM_INFO_HEIGHT_TESTNET_RESPONSE: &str = r#"2000004"#;
 
 // https://chain.api.btc.com/v3/block/latest
 pub const CHAIN_API_BTC_COM_MAINNET_RESPONSE: &str = r#"{
@@ -434,7 +287,7 @@ pub const CHAIN_API_BTC_COM_MAINNET_RESPONSE: &str = r#"{
 }"#;
 
 // https://mempool.space/api/blocks/tip/height
-pub const MEMPOOL_HEIGHT_MAINNET_RESPONSE: &str = r#"700007"#;
+pub const MEMPOOL_HEIGHT_MAINNET_RESPONSE: &str = r#"700008"#;
 
 // https://mempool.space/testnet4/api/blocks/tip/height
-pub const MEMPOOL_HEIGHT_TESTNET_RESPONSE: &str = r#"700008"#;
+pub const MEMPOOL_HEIGHT_TESTNET_RESPONSE: &str = r#"55002"#;


### PR DESCRIPTION
This PR updates the watchdog canister to support Testnet4 explorers.

Changes
- Removed all Testnet3 explorers, as they are no longer needed.
- Added support for **Mempool** as the sole Testnet4 explorer.
- Added **Mempool** as a Mainnet explorer as well.

EXC-1813