### PR TITLE
chore: bump up bitcoin version to 0.32.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 
 [workspace.dependencies]
 assert_matches = "1.5.0"
-bitcoin = "0.32.4"
+bitcoin = "0.32.5"
 byteorder = "1.4.3"
 canbench-rs = "0.1.8"
 candid = "0.10.6"


### PR DESCRIPTION
This PR updates the `bitcoin` crate from `0.32.4` to `0.32.5` to be the same as in the IC-repo (for bitcoin adapter).