### PR TITLE
feat: add get_successors request / response metrics for bitcoin canister

### DIFF
--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -169,6 +169,36 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         .value(&[("flag", "enabled")], enabled)?
         .value(&[("flag", "disabled")], disabled)?;
 
+        if let Some(stats) = &state.syncing_state.get_successors_request_stats {
+            encode_labeled_gauge(
+                w,
+                "get_successors_tx_count",
+                "The number of get_successors requests.",
+                &stats.get_count_metrics(),
+            )?;
+        }
+
+        if let Some(stats) = &state.syncing_state.get_successors_response_stats {
+            encode_labeled_gauge(
+                w,
+                "get_successors_rx_count",
+                "The number of get_successors responses.",
+                &stats.get_count_metrics(),
+            )?;
+            encode_labeled_gauge(
+                w,
+                "get_successors_rx_block_count",
+                "The number of blocks in get_successors responses.",
+                &stats.get_block_count_metrics(),
+            )?;
+            encode_labeled_gauge(
+                w,
+                "get_successors_rx_block_size",
+                "The total size of the blocks in get_successors responses.",
+                &stats.get_block_size_metrics(),
+            )?;
+        }
+
         Ok(())
     })
 }

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -149,7 +149,16 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             w,
             "block_ingestion_stats",
             "The stats of the most recent block ingested into the stable UTXO set.",
-            &state.metrics.block_ingestion_stats.get_labels_and_values(),
+            &state
+                .metrics
+                .block_ingestion_stats
+                .get_instruction_labels_and_values(),
+        )?;
+
+        w.encode_gauge(
+            "block_ingestion_num_rounds",
+            state.metrics.block_ingestion_stats.get_num_rounds() as f64,
+            "The number of rounds it took the most recent block to get ingested into the stable UTXO set.",
         )?;
 
         w.encode_gauge(
@@ -183,19 +192,28 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             w,
             "get_successors_response_count",
             "The number of get_successors responses.",
-            &state.syncing_state.get_successors_response_stats.get_count_metrics(),
+            &state
+                .syncing_state
+                .get_successors_response_stats
+                .get_count_metrics(),
         )?;
         encode_labeled_gauge(
             w,
             "get_successors_response_block_count",
             "The number of blocks in get_successors responses.",
-            &state.syncing_state.get_successors_response_stats.get_block_count_metrics(),
+            &state
+                .syncing_state
+                .get_successors_response_stats
+                .get_block_count_metrics(),
         )?;
         encode_labeled_gauge(
             w,
             "get_successors_response_block_size",
             "The total size of the blocks in get_successors responses.",
-            &state.syncing_state.get_successors_response_stats.get_block_size_metrics(),
+            &state
+                .syncing_state
+                .get_successors_response_stats
+                .get_block_size_metrics(),
         )?;
 
         Ok(())

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -172,7 +172,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         if let Some(tx_stats) = &state.syncing_state.get_successors_request_stats {
             encode_labeled_gauge(
                 w,
-                "get_successors_tx_count",
+                "get_successors_request_count",
                 "The number of get_successors requests.",
                 &tx_stats.get_count_metrics(),
             )?;
@@ -181,19 +181,19 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         if let Some(rx_stats) = &state.syncing_state.get_successors_response_stats {
             encode_labeled_gauge(
                 w,
-                "get_successors_rx_count",
+                "get_successors_response_count",
                 "The number of get_successors responses.",
                 &rx_stats.get_count_metrics(),
             )?;
             encode_labeled_gauge(
                 w,
-                "get_successors_rx_block_count",
+                "get_successors_response_block_count",
                 "The number of blocks in get_successors responses.",
                 &rx_stats.get_block_count_metrics(),
             )?;
             encode_labeled_gauge(
                 w,
-                "get_successors_rx_block_size",
+                "get_successors_response_block_size",
                 "The total size of the blocks in get_successors responses.",
                 &rx_stats.get_block_size_metrics(),
             )?;

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -169,35 +169,34 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         .value(&[("flag", "enabled")], enabled)?
         .value(&[("flag", "disabled")], disabled)?;
 
-        if let Some(stats) = &state.syncing_state.get_successors_request_stats {
-            encode_labeled_gauge(
-                w,
-                "get_successors_request_count",
-                "The number of get_successors requests.",
-                &stats.get_count_metrics(),
-            )?;
-        }
+        encode_labeled_gauge(
+            w,
+            "get_successors_request_count",
+            "The number of get_successors requests.",
+            &state
+                .syncing_state
+                .get_successors_request_stats
+                .get_count_metrics(),
+        )?;
 
-        if let Some(stats) = &state.syncing_state.get_successors_response_stats {
-            encode_labeled_gauge(
-                w,
-                "get_successors_response_count",
-                "The number of get_successors responses.",
-                &stats.get_count_metrics(),
-            )?;
-            encode_labeled_gauge(
-                w,
-                "get_successors_response_block_count",
-                "The number of blocks in get_successors responses.",
-                &stats.get_block_count_metrics(),
-            )?;
-            encode_labeled_gauge(
-                w,
-                "get_successors_response_block_size",
-                "The total size of the blocks in get_successors responses.",
-                &stats.get_block_size_metrics(),
-            )?;
-        }
+        encode_labeled_gauge(
+            w,
+            "get_successors_response_count",
+            "The number of get_successors responses.",
+            &state.syncing_state.get_successors_response_stats.get_count_metrics(),
+        )?;
+        encode_labeled_gauge(
+            w,
+            "get_successors_response_block_count",
+            "The number of blocks in get_successors responses.",
+            &state.syncing_state.get_successors_response_stats.get_block_count_metrics(),
+        )?;
+        encode_labeled_gauge(
+            w,
+            "get_successors_response_block_size",
+            "The total size of the blocks in get_successors responses.",
+            &state.syncing_state.get_successors_response_stats.get_block_size_metrics(),
+        )?;
 
         Ok(())
     })

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -169,33 +169,33 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         .value(&[("flag", "enabled")], enabled)?
         .value(&[("flag", "disabled")], disabled)?;
 
-        if let Some(stats) = &state.syncing_state.get_successors_request_stats {
+        if let Some(tx_stats) = &state.syncing_state.get_successors_request_stats {
             encode_labeled_gauge(
                 w,
                 "get_successors_tx_count",
                 "The number of get_successors requests.",
-                &stats.get_count_metrics(),
+                &tx_stats.get_count_metrics(),
             )?;
         }
 
-        if let Some(stats) = &state.syncing_state.get_successors_response_stats {
+        if let Some(rx_stats) = &state.syncing_state.get_successors_response_stats {
             encode_labeled_gauge(
                 w,
                 "get_successors_rx_count",
                 "The number of get_successors responses.",
-                &stats.get_count_metrics(),
+                &rx_stats.get_count_metrics(),
             )?;
             encode_labeled_gauge(
                 w,
                 "get_successors_rx_block_count",
                 "The number of blocks in get_successors responses.",
-                &stats.get_block_count_metrics(),
+                &rx_stats.get_block_count_metrics(),
             )?;
             encode_labeled_gauge(
                 w,
                 "get_successors_rx_block_size",
                 "The total size of the blocks in get_successors responses.",
-                &stats.get_block_size_metrics(),
+                &rx_stats.get_block_size_metrics(),
             )?;
         }
 

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -169,33 +169,33 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         .value(&[("flag", "enabled")], enabled)?
         .value(&[("flag", "disabled")], disabled)?;
 
-        if let Some(tx_stats) = &state.syncing_state.get_successors_request_stats {
+        if let Some(stats) = &state.syncing_state.get_successors_request_stats {
             encode_labeled_gauge(
                 w,
                 "get_successors_request_count",
                 "The number of get_successors requests.",
-                &tx_stats.get_count_metrics(),
+                &stats.get_count_metrics(),
             )?;
         }
 
-        if let Some(rx_stats) = &state.syncing_state.get_successors_response_stats {
+        if let Some(stats) = &state.syncing_state.get_successors_response_stats {
             encode_labeled_gauge(
                 w,
                 "get_successors_response_count",
                 "The number of get_successors responses.",
-                &rx_stats.get_count_metrics(),
+                &stats.get_count_metrics(),
             )?;
             encode_labeled_gauge(
                 w,
                 "get_successors_response_block_count",
                 "The number of blocks in get_successors responses.",
-                &rx_stats.get_block_count_metrics(),
+                &stats.get_block_count_metrics(),
             )?;
             encode_labeled_gauge(
                 w,
                 "get_successors_response_block_size",
                 "The total size of the blocks in get_successors responses.",
-                &rx_stats.get_block_size_metrics(),
+                &stats.get_block_size_metrics(),
             )?;
         }
 

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -64,10 +64,7 @@ async fn maybe_fetch_blocks() -> bool {
     };
 
     with_state_mut(|s| {
-        let stats = s
-            .syncing_state
-            .get_successors_request_stats
-            .get_or_insert_with(SuccessorsRequestStats::default);
+        let stats = &mut s.syncing_state.get_successors_request_stats;
         stats.total_count += 1;
         match request {
             GetSuccessorsRequest::Initial(_) => stats.initial_count += 1,
@@ -92,10 +89,6 @@ async fn maybe_fetch_blocks() -> bool {
             }
         };
 
-        s.syncing_state
-            .get_successors_response_stats
-            .get_or_insert_with(SuccessorsResponseStats::default);
-
         match response {
             GetSuccessorsResponse::Complete(response) => {
                 // Received complete response.
@@ -109,14 +102,13 @@ async fn maybe_fetch_blocks() -> bool {
                     "Received complete response: {} blocks, total {} bytes.",
                     count, bytes,
                 ));
-                if let Some(stats) = s.syncing_state.get_successors_response_stats.as_mut() {
-                    stats.complete_count += 1;
-                    stats.complete_block_count += count;
-                    stats.complete_block_size += bytes;
-                    stats.total_count += 1;
-                    stats.total_block_count += count;
-                    stats.total_block_size += bytes;
-                }
+                let stats = &mut s.syncing_state.get_successors_response_stats;
+                stats.complete_count += 1;
+                stats.complete_block_count += count;
+                stats.complete_block_size += bytes;
+                stats.total_count += 1;
+                stats.total_block_count += count;
+                stats.total_block_size += bytes;
                 s.syncing_state.response_to_process = Some(ResponseToProcess::Complete(response));
             }
             GetSuccessorsResponse::Partial(partial_response) => {
@@ -131,14 +123,13 @@ async fn maybe_fetch_blocks() -> bool {
                     "Received partial response: {} bytes, {} follow-ups remaining.",
                     bytes, remaining,
                 ));
-                if let Some(stats) = s.syncing_state.get_successors_response_stats.as_mut() {
-                    stats.partial_count += 1;
-                    stats.partial_block_count += 1;
-                    stats.partial_block_size += bytes;
-                    stats.total_count += 1;
-                    stats.total_block_count += 1;
-                    stats.total_block_size += bytes;
-                }
+                let stats = &mut s.syncing_state.get_successors_response_stats;
+                stats.partial_count += 1;
+                stats.partial_block_count += 1;
+                stats.partial_block_size += bytes;
+                stats.total_count += 1;
+                stats.total_block_count += 1;
+                stats.total_block_size += bytes;
                 s.syncing_state.response_to_process =
                     Some(ResponseToProcess::Partial(partial_response, 0));
             }
@@ -152,14 +143,13 @@ async fn maybe_fetch_blocks() -> bool {
                     Some(ResponseToProcess::Partial(res, pages)) => (res, pages),
                     other => unreachable!("Cannot receive follow-up response without a previous partial response. Previous response found: {:?}", other)
                 };
-                if let Some(stats) = s.syncing_state.get_successors_response_stats.as_mut() {
-                    stats.follow_up_count += 1;
-                    stats.follow_up_block_count += 1;
-                    stats.follow_up_block_size += bytes;
-                    stats.total_count += 1;
-                    stats.total_block_count += 1;
-                    stats.total_block_size += bytes;
-                }
+                let stats = &mut s.syncing_state.get_successors_response_stats;
+                stats.follow_up_count += 1;
+                stats.follow_up_block_count += 1;
+                stats.follow_up_block_size += bytes;
+                stats.total_count += 1;
+                stats.total_block_count += 1;
+                stats.total_block_size += bytes;
 
                 // Append block to partial response and increment # pages processed.
                 partial_response.partial_block.append(&mut block_bytes);

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -1,7 +1,7 @@
 use crate::{
     api::get_current_fee_percentiles_impl,
     runtime::{call_get_successors, cycles_burn, print},
-    state::{self, ResponseToProcess, SuccessorsRequestStats, SuccessorsResponseStats},
+    state::{self, ResponseToProcess},
     types::{
         GetSuccessorsCompleteResponse, GetSuccessorsRequest, GetSuccessorsRequestInitial,
         GetSuccessorsResponse,

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -64,14 +64,14 @@ async fn maybe_fetch_blocks() -> bool {
     };
 
     with_state_mut(|s| {
-        let tx_stats = s
+        let stats = s
             .syncing_state
             .get_successors_request_stats
             .get_or_insert_with(SuccessorsRequestStats::default);
-        tx_stats.total_count += 1;
+        stats.total_count += 1;
         match request {
-            GetSuccessorsRequest::Initial(_) => tx_stats.initial_count += 1,
-            GetSuccessorsRequest::FollowUp(_) => tx_stats.follow_up_count += 1,
+            GetSuccessorsRequest::Initial(_) => stats.initial_count += 1,
+            GetSuccessorsRequest::FollowUp(_) => stats.follow_up_count += 1,
         }
     });
 
@@ -109,13 +109,13 @@ async fn maybe_fetch_blocks() -> bool {
                     "Received complete response: {} blocks, total {} bytes.",
                     count, bytes,
                 ));
-                if let Some(rx_stats) = s.syncing_state.get_successors_response_stats.as_mut() {
-                    rx_stats.complete_count += 1;
-                    rx_stats.complete_block_count += count;
-                    rx_stats.complete_block_size += bytes;
-                    rx_stats.total_count += 1;
-                    rx_stats.total_block_count += count;
-                    rx_stats.total_block_size += bytes;
+                if let Some(stats) = s.syncing_state.get_successors_response_stats.as_mut() {
+                    stats.complete_count += 1;
+                    stats.complete_block_count += count;
+                    stats.complete_block_size += bytes;
+                    stats.total_count += 1;
+                    stats.total_block_count += count;
+                    stats.total_block_size += bytes;
                 }
                 s.syncing_state.response_to_process = Some(ResponseToProcess::Complete(response));
             }
@@ -131,13 +131,13 @@ async fn maybe_fetch_blocks() -> bool {
                     "Received partial response: {} bytes, {} follow-ups remaining.",
                     bytes, remaining,
                 ));
-                if let Some(rx_stats) = s.syncing_state.get_successors_response_stats.as_mut() {
-                    rx_stats.partial_count += 1;
-                    rx_stats.partial_block_count += 1;
-                    rx_stats.partial_block_size += bytes;
-                    rx_stats.total_count += 1;
-                    rx_stats.total_block_count += 1;
-                    rx_stats.total_block_size += bytes;
+                if let Some(stats) = s.syncing_state.get_successors_response_stats.as_mut() {
+                    stats.partial_count += 1;
+                    stats.partial_block_count += 1;
+                    stats.partial_block_size += bytes;
+                    stats.total_count += 1;
+                    stats.total_block_count += 1;
+                    stats.total_block_size += bytes;
                 }
                 s.syncing_state.response_to_process =
                     Some(ResponseToProcess::Partial(partial_response, 0));
@@ -152,13 +152,13 @@ async fn maybe_fetch_blocks() -> bool {
                     Some(ResponseToProcess::Partial(res, pages)) => (res, pages),
                     other => unreachable!("Cannot receive follow-up response without a previous partial response. Previous response found: {:?}", other)
                 };
-                if let Some(rx_stats) = s.syncing_state.get_successors_response_stats.as_mut() {
-                    rx_stats.follow_up_count += 1;
-                    rx_stats.follow_up_block_count += 1;
-                    rx_stats.follow_up_block_size += bytes;
-                    rx_stats.total_count += 1;
-                    rx_stats.total_block_count += 1;
-                    rx_stats.total_block_size += bytes;
+                if let Some(stats) = s.syncing_state.get_successors_response_stats.as_mut() {
+                    stats.follow_up_count += 1;
+                    stats.follow_up_block_count += 1;
+                    stats.follow_up_block_size += bytes;
+                    stats.total_count += 1;
+                    stats.total_block_count += 1;
+                    stats.total_block_size += bytes;
                 }
 
                 // Append block to partial response and increment # pages processed.

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -360,9 +360,9 @@ pub struct SuccessorsRequestStats {
 impl SuccessorsRequestStats {
     pub fn get_count_metrics(&self) -> Vec<((&str, &str), u64)> {
         vec![
-            (("type", "tx_total"), self.total_count),
-            (("type", "tx_initial"), self.initial_count),
-            (("type", "tx_follow_up"), self.follow_up_count),
+            (("type", "total"), self.total_count),
+            (("type", "initial"), self.initial_count),
+            (("type", "follow_up"), self.follow_up_count),
         ]
     }
 }
@@ -389,28 +389,28 @@ pub struct SuccessorsResponseStats {
 impl SuccessorsResponseStats {
     pub fn get_count_metrics(&self) -> Vec<((&str, &str), u64)> {
         vec![
-            (("type", "rx_total"), self.total_count),
-            (("type", "rx_complete"), self.complete_count),
-            (("type", "rx_partial"), self.partial_count),
-            (("type", "rx_follow_up"), self.follow_up_count),
+            (("type", "total"), self.total_count),
+            (("type", "complete"), self.complete_count),
+            (("type", "partial"), self.partial_count),
+            (("type", "follow_up"), self.follow_up_count),
         ]
     }
 
     pub fn get_block_count_metrics(&self) -> Vec<((&str, &str), u64)> {
         vec![
-            (("type", "rx_total"), self.total_block_count),
-            (("type", "rx_complete"), self.complete_block_count),
-            (("type", "rx_partial"), self.partial_block_count),
-            (("type", "rx_follow_up"), self.follow_up_block_count),
+            (("type", "total"), self.total_block_count),
+            (("type", "complete"), self.complete_block_count),
+            (("type", "partial"), self.partial_block_count),
+            (("type", "follow_up"), self.follow_up_block_count),
         ]
     }
 
     pub fn get_block_size_metrics(&self) -> Vec<((&str, &str), u64)> {
         vec![
-            (("type", "rx_total"), self.total_block_size),
-            (("type", "rx_complete"), self.complete_block_size),
-            (("type", "rx_partial"), self.partial_block_size),
-            (("type", "rx_follow_up"), self.follow_up_block_size),
+            (("type", "total"), self.total_block_size),
+            (("type", "complete"), self.complete_block_size),
+            (("type", "partial"), self.partial_block_size),
+            (("type", "follow_up"), self.follow_up_block_size),
         ]
     }
 }

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -325,6 +325,14 @@ pub struct SyncingState {
 
     /// The number of errors occurred when inserting a block.
     pub num_insert_block_errors: u64,
+
+    /// Stats about the request sent to GetSuccessors.
+    #[serde(default)] // Ensures backward compatibility during deserialization
+    pub get_successors_request_stats: Option<SuccessorsRequestStats>,
+
+    /// Stats about the responses received from GetSuccessors.
+    #[serde(default)] // Ensures backward compatibility during deserialization
+    pub get_successors_response_stats: Option<SuccessorsResponseStats>,
 }
 
 impl Default for SyncingState {
@@ -336,7 +344,74 @@ impl Default for SyncingState {
             num_get_successors_rejects: 0,
             num_block_deserialize_errors: 0,
             num_insert_block_errors: 0,
+            get_successors_request_stats: None,
+            get_successors_response_stats: None,
         }
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default)]
+pub struct SuccessorsRequestStats {
+    pub total_count: u64,
+    pub initial_count: u64,
+    pub follow_up_count: u64,
+}
+
+impl SuccessorsRequestStats {
+    pub fn get_count_metrics(&self) -> Vec<((&str, &str), u64)> {
+        vec![
+            (("type", "total"), self.total_count),
+            (("type", "initial"), self.initial_count),
+            (("type", "follow_up"), self.follow_up_count),
+        ]
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default)]
+pub struct SuccessorsResponseStats {
+    pub total_count: u64,
+    pub total_block_count: u64,
+    pub total_block_size: u64,
+
+    pub complete_count: u64,
+    pub complete_block_count: u64,
+    pub complete_block_size: u64,
+
+    pub partial_count: u64,
+    pub partial_block_count: u64,
+    pub partial_block_size: u64,
+
+    pub follow_up_count: u64,
+    pub follow_up_block_count: u64,
+    pub follow_up_block_size: u64,
+}
+
+impl SuccessorsResponseStats {
+    pub fn get_count_metrics(&self) -> Vec<((&str, &str), u64)> {
+        vec![
+            (("type", "total"), self.total_count),
+            (("type", "complete"), self.complete_count),
+            (("type", "partial"), self.partial_count),
+            (("type", "follow_up"), self.follow_up_count),
+        ]
+    }
+
+    pub fn get_block_count_metrics(&self) -> Vec<((&str, &str), u64)> {
+        vec![
+            (("type", "total"), self.total_block_count),
+            (("type", "complete"), self.complete_block_count),
+            (("type", "partial"), self.partial_block_count),
+            (("type", "follow_up"), self.follow_up_block_count),
+        ]
+    }
+
+    pub fn get_block_size_metrics(&self) -> Vec<((&str, &str), u64)> {
+        vec![
+            (("type", "total"), self.total_block_size),
+            (("type", "complete"), self.complete_block_size),
+            (("type", "partial"), self.partial_block_size),
+            (("type", "follow_up"), self.follow_up_block_size),
+        ]
     }
 }
 

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -360,9 +360,9 @@ pub struct SuccessorsRequestStats {
 impl SuccessorsRequestStats {
     pub fn get_count_metrics(&self) -> Vec<((&str, &str), u64)> {
         vec![
-            (("type", "rx_total"), self.total_count),
-            (("type", "rx_initial"), self.initial_count),
-            (("type", "rx_follow_up"), self.follow_up_count),
+            (("type", "tx_total"), self.total_count),
+            (("type", "tx_initial"), self.initial_count),
+            (("type", "tx_follow_up"), self.follow_up_count),
         ]
     }
 }
@@ -389,28 +389,28 @@ pub struct SuccessorsResponseStats {
 impl SuccessorsResponseStats {
     pub fn get_count_metrics(&self) -> Vec<((&str, &str), u64)> {
         vec![
-            (("type", "tx_total"), self.total_count),
-            (("type", "tx_complete"), self.complete_count),
-            (("type", "tx_partial"), self.partial_count),
-            (("type", "tx_follow_up"), self.follow_up_count),
+            (("type", "rx_total"), self.total_count),
+            (("type", "rx_complete"), self.complete_count),
+            (("type", "rx_partial"), self.partial_count),
+            (("type", "rx_follow_up"), self.follow_up_count),
         ]
     }
 
     pub fn get_block_count_metrics(&self) -> Vec<((&str, &str), u64)> {
         vec![
-            (("type", "tx_total"), self.total_block_count),
-            (("type", "tx_complete"), self.complete_block_count),
-            (("type", "tx_partial"), self.partial_block_count),
-            (("type", "tx_follow_up"), self.follow_up_block_count),
+            (("type", "rx_total"), self.total_block_count),
+            (("type", "rx_complete"), self.complete_block_count),
+            (("type", "rx_partial"), self.partial_block_count),
+            (("type", "rx_follow_up"), self.follow_up_block_count),
         ]
     }
 
     pub fn get_block_size_metrics(&self) -> Vec<((&str, &str), u64)> {
         vec![
-            (("type", "tx_total"), self.total_block_size),
-            (("type", "tx_complete"), self.complete_block_size),
-            (("type", "tx_partial"), self.partial_block_size),
-            (("type", "tx_follow_up"), self.follow_up_block_size),
+            (("type", "rx_total"), self.total_block_size),
+            (("type", "rx_complete"), self.complete_block_size),
+            (("type", "rx_partial"), self.partial_block_size),
+            (("type", "rx_follow_up"), self.follow_up_block_size),
         ]
     }
 }

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -328,11 +328,11 @@ pub struct SyncingState {
 
     /// Stats about the request sent to GetSuccessors.
     #[serde(default)] // Ensures backward compatibility during deserialization
-    pub get_successors_request_stats: Option<SuccessorsRequestStats>,
+    pub get_successors_request_stats: SuccessorsRequestStats,
 
     /// Stats about the responses received from GetSuccessors.
     #[serde(default)] // Ensures backward compatibility during deserialization
-    pub get_successors_response_stats: Option<SuccessorsResponseStats>,
+    pub get_successors_response_stats: SuccessorsResponseStats,
 }
 
 impl Default for SyncingState {
@@ -344,8 +344,8 @@ impl Default for SyncingState {
             num_get_successors_rejects: 0,
             num_block_deserialize_errors: 0,
             num_insert_block_errors: 0,
-            get_successors_request_stats: None,
-            get_successors_response_stats: None,
+            get_successors_request_stats: SuccessorsRequestStats::default(),
+            get_successors_response_stats: SuccessorsResponseStats::default(),
         }
     }
 }

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -327,11 +327,13 @@ pub struct SyncingState {
     pub num_insert_block_errors: u64,
 
     /// Stats about the request sent to GetSuccessors.
-    #[serde(default)] // Ensures backward compatibility during deserialization
+    /// NOTE: serde(default) is used here for backward-compatibility.
+    #[serde(default)]
     pub get_successors_request_stats: SuccessorsRequestStats,
 
     /// Stats about the responses received from GetSuccessors.
-    #[serde(default)] // Ensures backward compatibility during deserialization
+    /// NOTE: serde(default) is used here for backward-compatibility.
+    #[serde(default)]
     pub get_successors_response_stats: SuccessorsResponseStats,
 }
 

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -360,9 +360,9 @@ pub struct SuccessorsRequestStats {
 impl SuccessorsRequestStats {
     pub fn get_count_metrics(&self) -> Vec<((&str, &str), u64)> {
         vec![
-            (("type", "total"), self.total_count),
-            (("type", "initial"), self.initial_count),
-            (("type", "follow_up"), self.follow_up_count),
+            (("type", "rx_total"), self.total_count),
+            (("type", "rx_initial"), self.initial_count),
+            (("type", "rx_follow_up"), self.follow_up_count),
         ]
     }
 }
@@ -389,28 +389,28 @@ pub struct SuccessorsResponseStats {
 impl SuccessorsResponseStats {
     pub fn get_count_metrics(&self) -> Vec<((&str, &str), u64)> {
         vec![
-            (("type", "total"), self.total_count),
-            (("type", "complete"), self.complete_count),
-            (("type", "partial"), self.partial_count),
-            (("type", "follow_up"), self.follow_up_count),
+            (("type", "tx_total"), self.total_count),
+            (("type", "tx_complete"), self.complete_count),
+            (("type", "tx_partial"), self.partial_count),
+            (("type", "tx_follow_up"), self.follow_up_count),
         ]
     }
 
     pub fn get_block_count_metrics(&self) -> Vec<((&str, &str), u64)> {
         vec![
-            (("type", "total"), self.total_block_count),
-            (("type", "complete"), self.complete_block_count),
-            (("type", "partial"), self.partial_block_count),
-            (("type", "follow_up"), self.follow_up_block_count),
+            (("type", "tx_total"), self.total_block_count),
+            (("type", "tx_complete"), self.complete_block_count),
+            (("type", "tx_partial"), self.partial_block_count),
+            (("type", "tx_follow_up"), self.follow_up_block_count),
         ]
     }
 
     pub fn get_block_size_metrics(&self) -> Vec<((&str, &str), u64)> {
         vec![
-            (("type", "total"), self.total_block_size),
-            (("type", "complete"), self.complete_block_size),
-            (("type", "partial"), self.partial_block_size),
-            (("type", "follow_up"), self.follow_up_block_size),
+            (("type", "tx_total"), self.total_block_size),
+            (("type", "tx_complete"), self.complete_block_size),
+            (("type", "tx_partial"), self.partial_block_size),
+            (("type", "tx_follow_up"), self.follow_up_block_size),
         ]
     }
 }

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -519,7 +519,11 @@ pub struct BlockIngestionStats {
 }
 
 impl BlockIngestionStats {
-    pub fn get_labels_and_values(&self) -> Vec<((&str, &str), u64)> {
+    pub fn get_num_rounds(&self) -> u32 {
+        self.num_rounds
+    }
+    
+    pub fn get_instruction_labels_and_values(&self) -> Vec<((&str, &str), u64)> {
         vec![
             (("instruction_count", "total"), self.ins_total),
             (

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -522,7 +522,7 @@ impl BlockIngestionStats {
     pub fn get_num_rounds(&self) -> u32 {
         self.num_rounds
     }
-    
+
     pub fn get_instruction_labels_and_values(&self) -> Vec<((&str, &str), u64)> {
         vec![
             (("instruction_count", "total"), self.ins_total),


### PR DESCRIPTION
This PR updates bitcoin canister metrics to include `get_successor` request / response stats.

New fields were added to the `SyncingState` with `#[serde(default)]` to ensure backward and forward compatibility.

<img width="1559" alt="image" src="https://github.com/user-attachments/assets/1765bb15-3913-4fe6-af77-f6987ce98849" />
