### PR TITLE
feat: add get_successors_request_interval histogram metric

### DIFF
--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -1,5 +1,7 @@
 use crate::{
-    metrics::DurationHistogram, metrics::InstructionHistogram, state, types::HttpResponse,
+    metrics::{DurationHistogram, InstructionHistogram},
+    state,
+    types::HttpResponse,
     with_state,
 };
 use ic_btc_interface::Flag;

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -193,7 +193,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
                 .get_count_metrics(),
         )?;
 
-        encode_duration_histogram(w, &state.metrics.get_successors_request_interval_seconds)?;
+        encode_duration_histogram(w, &state.metrics.get_successors_request_interval)?;
 
         encode_labeled_gauge(
             w,

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -1,4 +1,7 @@
-use crate::{metrics::InstructionHistogram, state, types::HttpResponse, with_state};
+use crate::{
+    metrics::DurationHistogram, metrics::InstructionHistogram, state, types::HttpResponse,
+    with_state,
+};
 use ic_btc_interface::Flag;
 use ic_cdk::api::time;
 use ic_metrics_encoder::MetricsEncoder;
@@ -188,6 +191,8 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
                 .get_count_metrics(),
         )?;
 
+        encode_duration_histogram(w, &state.metrics.get_successors_request_interval_seconds)?;
+
         encode_labeled_gauge(
             w,
             "get_successors_response_count",
@@ -223,6 +228,13 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
 fn encode_instruction_histogram(
     metrics_encoder: &mut MetricsEncoder<Vec<u8>>,
     h: &InstructionHistogram,
+) -> io::Result<()> {
+    metrics_encoder.encode_histogram(&h.name, h.buckets(), h.sum, &h.help)
+}
+
+fn encode_duration_histogram(
+    metrics_encoder: &mut MetricsEncoder<Vec<u8>>,
+    h: &DurationHistogram,
 ) -> io::Result<()> {
     metrics_encoder.encode_histogram(&h.name, h.buckets(), h.sum, &h.help)
 }

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -1,6 +1,6 @@
 use crate::{
     api::get_current_fee_percentiles_impl,
-    runtime::{call_get_successors, cycles_burn, print},
+    runtime::{call_get_successors, cycles_burn, print, time_nanos},
     state::{self, ResponseToProcess},
     types::{
         GetSuccessorsCompleteResponse, GetSuccessorsRequest, GetSuccessorsRequestInitial,
@@ -71,7 +71,7 @@ async fn maybe_fetch_blocks() -> bool {
             GetSuccessorsRequest::FollowUp(_) => stats.follow_up_count += 1,
         }
 
-        let current_time = ic_cdk::api::time();
+        let current_time = time_nanos();
         if let Some(last_request_time) = &mut stats.last_request_time {
             let elapsed = std::time::Duration::from_nanos(current_time - *last_request_time);
             s.metrics

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -75,7 +75,7 @@ async fn maybe_fetch_blocks() -> bool {
         if let Some(last_request_time) = &mut stats.last_request_time {
             let elapsed = std::time::Duration::from_nanos(current_time - *last_request_time);
             s.metrics
-                .get_successors_request_interval_seconds
+                .get_successors_request_interval
                 .observe(elapsed.as_secs_f64());
         }
         stats.last_request_time = Some(current_time);

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -70,6 +70,15 @@ async fn maybe_fetch_blocks() -> bool {
             GetSuccessorsRequest::Initial(_) => stats.initial_count += 1,
             GetSuccessorsRequest::FollowUp(_) => stats.follow_up_count += 1,
         }
+
+        let current_time = ic_cdk::api::time();
+        if let Some(last_request_time) = &mut stats.last_request_time {
+            let elapsed = std::time::Duration::from_nanos(current_time - *last_request_time);
+            s.metrics
+                .get_successors_request_interval_seconds
+                .observe(elapsed.as_secs_f64());
+        }
+        stats.last_request_time = Some(current_time);
     });
 
     print(&format!("Sending request: {:?}", request));

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -71,14 +71,14 @@ async fn maybe_fetch_blocks() -> bool {
             GetSuccessorsRequest::FollowUp(_) => stats.follow_up_count += 1,
         }
 
-        let current_time = time_nanos();
-        if let Some(last_request_time) = &mut stats.last_request_time {
-            let elapsed = std::time::Duration::from_nanos(current_time - *last_request_time);
+        let curr_time = time_nanos();
+        if let Some(prev_time) = &mut stats.last_request_time {
+            let interval = std::time::Duration::from_nanos(curr_time - *prev_time);
             s.metrics
                 .get_successors_request_interval
-                .observe(elapsed.as_secs_f64());
+                .observe(interval.as_secs_f64());
         }
-        stats.last_request_time = Some(current_time);
+        stats.last_request_time = Some(curr_time);
     });
 
     print(&format!("Sending request: {:?}", request));

--- a/canister/src/metrics.rs
+++ b/canister/src/metrics.rs
@@ -38,8 +38,8 @@ pub struct Metrics {
     pub cycles_burnt: Option<u128>,
 
     /// The time interval between two consecutive GetSuccessors requests.
-    #[serde(default = "get_successors_request_interval_seconds")]
-    pub get_successors_request_interval_seconds: DurationHistogram,
+    #[serde(default = "get_successors_request_interval")]
+    pub get_successors_request_interval: DurationHistogram,
 }
 
 impl Default for Metrics {
@@ -87,7 +87,7 @@ impl Default for Metrics {
 
             cycles_burnt: Some(0),
 
-            get_successors_request_interval_seconds: get_successors_request_interval_seconds(),
+            get_successors_request_interval: get_successors_request_interval(),
         }
     }
 }
@@ -246,10 +246,10 @@ impl DurationHistogram {
     }
 }
 
-fn get_successors_request_interval_seconds() -> DurationHistogram {
+fn get_successors_request_interval() -> DurationHistogram {
     DurationHistogram::new(
-        "get_successors_request_interval_seconds",
-        "The time interval between two consecutive GetSuccessors requests.",
+        "get_successors_request_interval",
+        "The time interval between two consecutive GetSuccessors requests in seconds.",
     )
 }
 

--- a/canister/src/metrics.rs
+++ b/canister/src/metrics.rs
@@ -187,7 +187,6 @@ fn decimal_buckets(min_power: u32, max_power: u32) -> Vec<u64> {
 }
 
 /// A histogram for observing time intervals.
-/// Example buckets: (0s, 1s, 2s, 5s, ..., 50_000s, +Inf)
 #[derive(Serialize, Deserialize, PartialEq)]
 pub struct DurationHistogram {
     pub name: String,
@@ -209,8 +208,9 @@ impl DurationHistogram {
     }
 
     /// Returns the bucket thresholds.
+    /// Example buckets: (1s, 2s, 5s, ..., 500_000s, +Inf)
     fn thresholds() -> Vec<u64> {
-        decimal_buckets(0, 3)
+        decimal_buckets(0, 4)
     }
 
     /// Observes a new value by updating the corresponding bucket count.

--- a/canister/src/metrics.rs
+++ b/canister/src/metrics.rs
@@ -36,6 +36,10 @@ pub struct Metrics {
 
     /// The total number of cycles burnt.
     pub cycles_burnt: Option<u128>,
+
+    /// The time interval between two consecutive GetSuccessors requests.
+    #[serde(default = "get_successors_request_interval_seconds")]
+    pub get_successors_request_interval_seconds: DurationHistogram,
 }
 
 impl Default for Metrics {
@@ -82,6 +86,8 @@ impl Default for Metrics {
             ),
 
             cycles_burnt: Some(0),
+
+            get_successors_request_interval_seconds: get_successors_request_interval_seconds(),
         }
     }
 }
@@ -159,6 +165,91 @@ fn default_get_block_headers_unstable_blocks() -> InstructionHistogram {
     InstructionHistogram::new(
         "inst_count_get_block_headers_unstable_blocks",
         "Instructions needed to build the block headers vec in a get_block_headers request from unstable blocks.",
+    )
+}
+
+/// Generates logarithmic buckets in decimal format.
+/// Example: `decimal_buckets(0, 4)` produces `[1, 2, 5, 10, ..., 50000]`
+fn decimal_buckets(min_power: u32, max_power: u32) -> Vec<u64> {
+    assert!(
+        min_power <= max_power,
+        "min_power must be <= max_power, given {} and {}",
+        min_power,
+        max_power
+    );
+    let mut buckets = Vec::with_capacity(3 * (max_power - min_power + 1) as usize);
+    for n in min_power..=max_power {
+        for &m in &[1, 2, 5] {
+            buckets.push(m * 10_u64.pow(n));
+        }
+    }
+    buckets
+}
+
+/// A histogram for observing time intervals.
+/// Example buckets: (0s, 1s, 2s, 5s, ..., 50_000s, +Inf)
+#[derive(Serialize, Deserialize, PartialEq)]
+pub struct DurationHistogram {
+    pub name: String,
+    pub help: String,
+    thresholds: Vec<u64>,  // Stores bucket thresholds
+    pub buckets: Vec<u64>, // Stores observation counts per bucket
+    pub sum: f64,
+}
+
+impl DurationHistogram {
+    pub fn new<S: Into<String>>(name: S, help: S) -> Self {
+        Self {
+            name: name.into(),
+            help: help.into(),
+            sum: 0.0,
+            thresholds: Self::thresholds(),
+            buckets: vec![0; Self::thresholds().len()], // One count per threshold
+        }
+    }
+
+    /// Returns the bucket thresholds.
+    fn thresholds() -> Vec<u64> {
+        decimal_buckets(0, 3)
+    }
+
+    /// Observes a new value by updating the corresponding bucket count.
+    pub fn observe(&mut self, value: f64) {
+        if value < 0.0 {
+            return; // Ignore negative values
+        }
+        let bucket_idx = self.get_bucket(value);
+        self.buckets[bucket_idx] += 1;
+        self.sum += value;
+    }
+
+    /// Finds the index of the bucket where `value` belongs.
+    fn get_bucket(&self, value: f64) -> usize {
+        if value == 0.0 {
+            return 0; // Zero goes into the first bucket
+        }
+
+        let value = value as u64;
+        match Self::thresholds().binary_search(&value) {
+            Ok(idx) => idx,                              // Exact match found
+            Err(idx) => idx.min(self.buckets.len() - 1), // Next larger bucket or last bucket
+        }
+    }
+
+    /// Returns an iterator over bucket thresholds and their observed counts.
+    pub fn buckets(&self) -> impl Iterator<Item = (f64, f64)> + '_ {
+        self.thresholds
+            .iter()
+            .map(|&e| e as f64)
+            .chain(std::iter::once(f64::INFINITY))
+            .zip(self.buckets.iter().map(|&e| e as f64))
+    }
+}
+
+fn get_successors_request_interval_seconds() -> DurationHistogram {
+    DurationHistogram::new(
+        "get_successors_request_interval_seconds",
+        "The time interval between two consecutive GetSuccessors requests.",
     )
 }
 

--- a/canister/src/metrics.rs
+++ b/canister/src/metrics.rs
@@ -208,7 +208,7 @@ impl DurationHistogram {
     }
 
     /// Returns the bucket thresholds.
-    /// Example buckets: (1s, 2s, 5s, ..., 500_000s, +Inf)
+    /// Example buckets: (1s, 2s, 5s, ..., 50_000s, +Inf)
     fn thresholds() -> Vec<u64> {
         decimal_buckets(0, 4)
     }

--- a/canister/src/runtime.rs
+++ b/canister/src/runtime.rs
@@ -201,7 +201,7 @@ pub fn get_cycles_balance() -> u64 {
     CYCLES_BALANCE.with(|c| *c.borrow())
 }
 
-pub fn time_secs() -> u64 {
+pub fn time() -> u64 {
     time_nanos() / 1_000_000_000
 }
 

--- a/canister/src/runtime.rs
+++ b/canister/src/runtime.rs
@@ -218,6 +218,22 @@ pub fn time() -> u64 {
         .as_secs()
 }
 
+/// Returns the current time in seconds.
+#[cfg(target_arch = "wasm32")]
+pub fn time_nanos() -> u64 {
+    ic_cdk::api::time()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn time_nanos() -> u64 {
+    use std::time::SystemTime;
+
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64
+}
+
 #[cfg(target_arch = "wasm32")]
 pub fn cycles_burn() -> u128 {
     ic_cdk::api::cycles_burn(ic_cdk::api::canister_balance128())

--- a/canister/src/runtime.rs
+++ b/canister/src/runtime.rs
@@ -202,6 +202,7 @@ pub fn get_cycles_balance() -> u64 {
 }
 
 pub fn time() -> u64 {
+    // to get seconds from nanoseconds
     time_nanos() / 1_000_000_000
 }
 

--- a/canister/src/runtime.rs
+++ b/canister/src/runtime.rs
@@ -201,21 +201,8 @@ pub fn get_cycles_balance() -> u64 {
     CYCLES_BALANCE.with(|c| *c.borrow())
 }
 
-/// Returns the current time in seconds.
-#[cfg(target_arch = "wasm32")]
-pub fn time() -> u64 {
-    // to get seconds from nanoseconds
-    ic_cdk::api::time() / 1_000_000_000
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub fn time() -> u64 {
-    use std::time::SystemTime;
-
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_secs()
+pub fn time_secs() -> u64 {
+    time_nanos() / 1_000_000_000
 }
 
 /// Returns the current time in seconds.

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -357,6 +357,8 @@ pub struct SuccessorsRequestStats {
     pub total_count: u64,
     pub initial_count: u64,
     pub follow_up_count: u64,
+
+    pub last_request_time: Option<u64>,
 }
 
 impl SuccessorsRequestStats {

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -2,7 +2,7 @@ use crate::{
     address_utxoset::AddressUtxoSet,
     block_header_store::BlockHeaderStore,
     metrics::Metrics,
-    runtime::{inc_performance_counter, performance_counter, print, time_secs},
+    runtime::{inc_performance_counter, performance_counter, print, time},
     types::{
         into_bitcoin_network, Address, BlockHeaderBlob, GetSuccessorsCompleteResponse,
         GetSuccessorsPartialResponse, Slicing,
@@ -124,7 +124,7 @@ pub fn insert_block(state: &mut State, block: Block) -> Result<(), InsertBlockEr
         &ValidationContext::new(state, block.header())
             .map_err(|_| InsertBlockError::PrevHeaderNotFound)?,
         block.header(),
-        time_secs(),
+        time(),
     )?;
 
     unstable_blocks::push(&mut state.unstable_blocks, &state.utxos, block)
@@ -231,7 +231,7 @@ pub fn insert_next_block_headers(state: &mut State, next_block_headers: &[BlockH
                     &into_bitcoin_network(state.network()),
                     &store,
                     &block_header,
-                    time_secs(),
+                    time(),
                 ),
                 Err(err) => Err(err),
             };

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -2,7 +2,7 @@ use crate::{
     address_utxoset::AddressUtxoSet,
     block_header_store::BlockHeaderStore,
     metrics::Metrics,
-    runtime::{inc_performance_counter, performance_counter, print, time},
+    runtime::{inc_performance_counter, performance_counter, print, time_secs},
     types::{
         into_bitcoin_network, Address, BlockHeaderBlob, GetSuccessorsCompleteResponse,
         GetSuccessorsPartialResponse, Slicing,
@@ -124,7 +124,7 @@ pub fn insert_block(state: &mut State, block: Block) -> Result<(), InsertBlockEr
         &ValidationContext::new(state, block.header())
             .map_err(|_| InsertBlockError::PrevHeaderNotFound)?,
         block.header(),
-        time(),
+        time_secs(),
     )?;
 
     unstable_blocks::push(&mut state.unstable_blocks, &state.utxos, block)
@@ -231,7 +231,7 @@ pub fn insert_next_block_headers(state: &mut State, next_block_headers: &[BlockH
                     &into_bitcoin_network(state.network()),
                     &store,
                     &block_header,
-                    time(),
+                    time_secs(),
                 ),
                 Err(err) => Err(err),
             };

--- a/dfx.json
+++ b/dfx.json
@@ -1,7 +1,7 @@
 {
   "dfx": "0.21.0",
   "canisters": {
-    "bitcoin_t": {
+    "bitcoin": {
       "type": "custom",
       "candid": "./canister/candid.did",
       "wasm": "target/wasm32-unknown-unknown/release/ic-btc-canister.wasm.gz",
@@ -79,7 +79,7 @@
     },
     "testnet": {
       "providers": [
-        "http://[2602:fb2b:110:10:5046:dbff:fe83:f6a7]:8080"
+        "http://[2a00:fb01:400:42:5000:aaff:fea4:ae46]:8080"
       ],
       "type": "persistent"
     }

--- a/dfx.json
+++ b/dfx.json
@@ -1,7 +1,7 @@
 {
   "dfx": "0.21.0",
   "canisters": {
-    "bitcoin": {
+    "bitcoin_t": {
       "type": "custom",
       "candid": "./canister/candid.did",
       "wasm": "target/wasm32-unknown-unknown/release/ic-btc-canister.wasm.gz",
@@ -79,7 +79,7 @@
     },
     "testnet": {
       "providers": [
-        "http://[2a00:fb01:400:42:5000:aaff:fea4:ae46]:8080"
+        "http://[2602:fb2b:110:10:5046:dbff:fe83:f6a7]:8080"
       ],
       "type": "persistent"
     }


### PR DESCRIPTION
This PR adds a histogram metric for tracking `get_successors` request interval.

![image](https://github.com/user-attachments/assets/19fc4508-6397-441c-b975-30da2a366d23)

