### PR TITLE
fix: get_successors request sends unique hashes

### DIFF
--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -1,36 +1,36 @@
 benches:
   get_metrics:
     total:
-      instructions: 86043839
+      instructions: 7886574
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   insert_300_blocks:
     total:
-      instructions: 533444042
+      instructions: 533460018
       heap_increase: 10
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers:
     total:
-      instructions: 3822494404
+      instructions: 3822496524
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers_multiple_times:
     total:
-      instructions: 13612598453
+      instructions: 13612576533
       heap_increase: 7
       stable_memory_increase: 0
     scopes: {}
   pre_upgrade_with_many_unstable_blocks:
     total:
-      instructions: 5930620770
+      instructions: 5930649713
       heap_increase: 4097
       stable_memory_increase: 1792
     scopes:
       serialize_blocktree:
-        instructions: 2368875763
+        instructions: 2368881738
         heap_increase: 2048
         stable_memory_increase: 0
       serialize_blocktree_flatten:
@@ -38,7 +38,7 @@ benches:
         heap_increase: 0
         stable_memory_increase: 0
       serialize_blocktree_serialize_seq:
-        instructions: 2368671822
+        instructions: 2368677797
         heap_increase: 2048
         stable_memory_increase: 0
 version: 0.1.8

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -8,7 +8,6 @@ use ic_btc_interface::Flag;
 use ic_cdk::api::time;
 use ic_metrics_encoder::MetricsEncoder;
 use serde_bytes::ByteBuf;
-use std::collections::HashSet;
 use std::io;
 
 const WASM_PAGE_SIZE: u64 = 65536;

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -78,7 +78,6 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             state.unstable_blocks.num_tips() as f64,
             "The number of tips in the unstable block tree.",
         )?;
-
         w.encode_gauge(
             "unstable_blocks_total",
             state::get_block_hashes(state).len() as f64,

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -8,6 +8,7 @@ use ic_btc_interface::Flag;
 use ic_cdk::api::time;
 use ic_metrics_encoder::MetricsEncoder;
 use serde_bytes::ByteBuf;
+use std::collections::HashSet;
 use std::io;
 
 const WASM_PAGE_SIZE: u64 = 65536;
@@ -78,9 +79,14 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             state.unstable_blocks.num_tips() as f64,
             "The number of tips in the unstable block tree.",
         )?;
+
+        let unique: HashSet<_> = state::get_unstable_blocks(state)
+            .iter()
+            .map(|b| b.block_hash())
+            .collect();
         w.encode_gauge(
             "unstable_blocks_total",
-            state::get_unstable_blocks(state).len() as f64,
+            unique.len() as f64,
             "The number of unstable blocks.",
         )?;
         w.encode_gauge(

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -80,13 +80,9 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             "The number of tips in the unstable block tree.",
         )?;
 
-        let unique: HashSet<_> = state::get_unstable_blocks(state)
-            .iter()
-            .map(|b| b.block_hash())
-            .collect();
         w.encode_gauge(
             "unstable_blocks_total",
-            unique.len() as f64,
+            state::get_block_hashes(state).len() as f64,
             "The number of unstable blocks.",
         )?;
         w.encode_gauge(

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -80,7 +80,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         )?;
         w.encode_gauge(
             "unstable_blocks_total",
-            state::get_block_hashes(state).len() as f64,
+            state::unstable_blocks_total(state) as f64,
             "The number of unstable blocks.",
         )?;
         w.encode_gauge(

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -269,7 +269,7 @@ impl BlockTree {
         find_mut_helper(self, blockhash, 0)
     }
 
-    // Returns true if a block exists in the tree, false otherwise.
+    /// Returns true if a block exists in the tree, false otherwise.
     fn contains(&self, block: &Block) -> bool {
         if self.root.block_hash() == block.block_hash() {
             return true;
@@ -282,6 +282,14 @@ impl BlockTree {
         }
 
         false
+    }
+
+    /// Returns the hashes of all blocks in the tree.
+    pub fn get_hashes(&self) -> Vec<BlockHash> {
+        let mut hashes = Vec::with_capacity(self.children.len() + 1);
+        hashes.push(self.root.block_hash());
+        hashes.extend(self.children.iter().flat_map(|child| child.get_hashes()));
+        hashes
     }
 }
 

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -291,6 +291,15 @@ impl BlockTree {
         hashes.extend(self.children.iter().flat_map(|child| child.get_hashes()));
         hashes
     }
+
+    /// Returns the number of blocks in the tree.
+    pub fn blocks_count(&self) -> usize {
+        1 + self
+            .children
+            .iter()
+            .map(|child| child.blocks_count())
+            .sum::<usize>()
+    }
 }
 
 /// An error thrown when trying to add a block that isn't a successor

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -283,11 +283,11 @@ fn maybe_get_successors_request() -> Option<GetSuccessorsRequest> {
             // We are guaranteed that there's always at least one block.
             let anchor = processed_block_hashes.remove(0);
 
-            // Deduplicate while maintaining order
+            // Deduplicate while maintaining order.
             let mut seen = HashSet::new();
             let unique: Vec<BlockHash> = processed_block_hashes
                 .iter()
-                .filter(|hash| seen.insert((*hash).clone())) // Insert returns false if already present
+                .filter(|hash| seen.insert((*hash).clone()))
                 .cloned()
                 .collect();
             if unique.len() != processed_block_hashes.len() {

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -275,33 +275,15 @@ fn maybe_get_successors_request() -> Option<GetSuccessorsRequest> {
         }
         None => {
             // No response is present. Send an initial request for new blocks.
-            let mut processed_block_hashes: Vec<BlockHash> = state::get_unstable_blocks(state)
-                .iter()
-                .map(|b| b.block_hash())
-                .collect();
+            let mut processed_block_hashes: Vec<BlockHash> = state::get_block_hashes(state);
 
             // We are guaranteed that there's always at least one block.
             let anchor = processed_block_hashes.remove(0);
 
-            // Deduplicate while maintaining order.
-            let mut seen = HashSet::new();
-            let unique: Vec<BlockHash> = processed_block_hashes
-                .iter()
-                .filter(|hash| seen.insert((*hash).clone()))
-                .cloned()
-                .collect();
-            if unique.len() != processed_block_hashes.len() {
-                print(&format!(
-                    "Error: Duplicate block hashes detected! Processed: {}, Unique: {}",
-                    processed_block_hashes.len(),
-                    unique.len(),
-                ));
-            }
-
             Some(GetSuccessorsRequest::Initial(GetSuccessorsRequestInitial {
                 network: state.network(),
                 anchor,
-                processed_block_hashes: unique.into_iter().collect(),
+                processed_block_hashes,
             }))
         }
     })

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -11,6 +11,7 @@ use crate::{
 use bitcoin::{consensus::Decodable, Block as BitcoinBlock};
 use ic_btc_interface::Flag;
 use ic_btc_types::{Block, BlockHash};
+use std::collections::HashSet;
 
 /// The heartbeat of the Bitcoin canister.
 ///
@@ -282,10 +283,19 @@ fn maybe_get_successors_request() -> Option<GetSuccessorsRequest> {
             // We are guaranteed that there's always at least one block.
             let anchor = processed_block_hashes.remove(0);
 
+            let unique: HashSet<_> = processed_block_hashes.iter().cloned().collect();
+            if unique.len() != processed_block_hashes.len() {
+                print(&format!(
+                    "Error: Duplicate block hashes detected! Processed: {}, Unique: {}",
+                    processed_block_hashes.len(),
+                    unique.len(),
+                ));
+            }
+
             Some(GetSuccessorsRequest::Initial(GetSuccessorsRequestInitial {
                 network: state.network(),
                 anchor,
-                processed_block_hashes,
+                processed_block_hashes: unique.into_iter().collect(),
             }))
         }
     })

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -283,7 +283,13 @@ fn maybe_get_successors_request() -> Option<GetSuccessorsRequest> {
             // We are guaranteed that there's always at least one block.
             let anchor = processed_block_hashes.remove(0);
 
-            let unique: HashSet<_> = processed_block_hashes.iter().cloned().collect();
+            // Deduplicate while maintaining order
+            let mut seen = HashSet::new();
+            let unique: Vec<BlockHash> = processed_block_hashes
+                .iter()
+                .filter(|hash| seen.insert((*hash).clone())) // Insert returns false if already present
+                .cloned()
+                .collect();
             if unique.len() != processed_block_hashes.len() {
                 print(&format!(
                     "Error: Duplicate block hashes detected! Processed: {}, Unique: {}",

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -11,7 +11,6 @@ use crate::{
 use bitcoin::{consensus::Decodable, Block as BitcoinBlock};
 use ic_btc_interface::Flag;
 use ic_btc_types::{Block, BlockHash};
-use std::collections::HashSet;
 
 /// The heartbeat of the Bitcoin canister.
 ///

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -268,6 +268,10 @@ pub fn get_block_hashes(state: &State) -> Vec<BlockHash> {
     unstable_blocks::get_block_hashes(&state.unstable_blocks)
 }
 
+pub fn unstable_blocks_total(state: &State) -> usize {
+    unstable_blocks::blocks_count(&state.unstable_blocks)
+}
+
 // The maximum size in bytes of a bitcoin script for it to be considered "small".
 const TX_OUT_SCRIPT_MAX_SIZE_SMALL: u32 = 25;
 

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -264,8 +264,8 @@ pub fn main_chain_height(state: &State) -> Height {
         - 1
 }
 
-pub fn get_unstable_blocks(state: &State) -> Vec<&Block> {
-    unstable_blocks::get_blocks(&state.unstable_blocks)
+pub fn get_block_hashes(state: &State) -> Vec<BlockHash> {
+    unstable_blocks::get_block_hashes(&state.unstable_blocks)
 }
 
 // The maximum size in bytes of a bitcoin script for it to be considered "small".

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -308,13 +308,8 @@ pub fn get_main_chain_length(blocks: &UnstableBlocks) -> usize {
     unreachable!("There must be at least one height with exactly one block.");
 }
 
-pub fn get_blocks(blocks: &UnstableBlocks) -> Vec<&Block> {
-    blocks
-        .tree
-        .blockchains()
-        .into_iter()
-        .flat_map(|bc| bc.into_chain())
-        .collect()
+pub fn get_block_hashes(blocks: &UnstableBlocks) -> Vec<BlockHash> {
+    blocks.tree.get_hashes()
 }
 
 /// Returns a blockchain starting from the anchor and ending with the `tip`.

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -312,6 +312,10 @@ pub fn get_block_hashes(blocks: &UnstableBlocks) -> Vec<BlockHash> {
     blocks.tree.get_hashes()
 }
 
+pub fn blocks_count(blocks: &UnstableBlocks) -> usize {
+    blocks.tree.blocks_count()
+}
+
 /// Returns a blockchain starting from the anchor and ending with the `tip`.
 ///
 /// If the `tip` doesn't exist in the tree, `None` is returned.


### PR DESCRIPTION
This PR fixes a number of block hashes sent in `get_successors` request and also reducing the cost of exposing metrics.