### PR TITLE
fix: fix min_explorers number for testnet watchdog canister

### DIFF
--- a/.github/workflows/canbench-post-comment.yml
+++ b/.github/workflows/canbench-post-comment.yml
@@ -28,11 +28,15 @@ jobs:
     strategy:
       matrix: ${{fromJSON(needs.download-results.outputs.matrix)}}
     steps:
+      - name: Get current timestamp
+        id: timestamp
+        run: echo "time=$(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> $GITHUB_ENV
+
       - name: Post comment
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
-            **Last updated:** $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+            **Last updated:** ${{ env.time }}
 
             ${{ matrix.benchmark.result }}
           comment_tag: ${{ matrix.benchmark.title }}

--- a/watchdog/src/config.rs
+++ b/watchdog/src/config.rs
@@ -84,7 +84,7 @@ impl Config {
             bitcoin_network: BitcoinNetwork::Testnet,
             blocks_behind_threshold: 1000,
             blocks_ahead_threshold: 1000,
-            min_explorers: 2,
+            min_explorers: 1,
             bitcoin_canister_principal: Principal::from_text(TESTNET_BITCOIN_CANISTER_PRINCIPAL)
                 .unwrap(),
             delay_before_first_fetch_sec: DELAY_BEFORE_FIRST_FETCH_SEC,


### PR DESCRIPTION
This PR fixes `min_explorers=1` for the testnet watchdog canister, as only Mempool is currently used.

It also fixes canbench timestamp.