### PR TITLE
fix: fix canbench results formatting

### DIFF
--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -314,19 +314,11 @@ pub fn get_main_chain_length(blocks: &UnstableBlocks) -> usize {
 }
 
 pub fn get_block_hashes(blocks: &UnstableBlocks) -> Vec<BlockHash> {
-    let _ = blocks.tree.get_hashes();
-    blocks
-        .tree
-        .blockchains()
-        .into_iter()
-        .flat_map(|bc| bc.into_chain())
-        .map(|block| block.block_hash())
-        .collect()
+    blocks.tree.get_hashes()
 }
 
 pub fn blocks_count(blocks: &UnstableBlocks) -> usize {
-    let _ = blocks.tree.blocks_count();
-    get_block_hashes(blocks).len()
+    blocks.tree.blocks_count()
 }
 
 /// Returns a blockchain starting from the anchor and ending with the `tip`.

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -314,7 +314,7 @@ pub fn get_main_chain_length(blocks: &UnstableBlocks) -> usize {
 }
 
 pub fn get_block_hashes(blocks: &UnstableBlocks) -> Vec<BlockHash> {
-    //blocks.tree.get_hashes()
+    let _ = blocks.tree.get_hashes();
     blocks
         .tree
         .blockchains()

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -325,7 +325,8 @@ pub fn get_block_hashes(blocks: &UnstableBlocks) -> Vec<BlockHash> {
 }
 
 pub fn blocks_count(blocks: &UnstableBlocks) -> usize {
-    blocks.tree.blocks_count()
+    let _ = blocks.tree.blocks_count();
+    get_block_hashes(blocks).len()
 }
 
 /// Returns a blockchain starting from the anchor and ending with the `tip`.

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -314,7 +314,14 @@ pub fn get_main_chain_length(blocks: &UnstableBlocks) -> usize {
 }
 
 pub fn get_block_hashes(blocks: &UnstableBlocks) -> Vec<BlockHash> {
-    blocks.tree.get_hashes()
+    //blocks.tree.get_hashes()
+    blocks
+        .tree
+        .blockchains()
+        .into_iter()
+        .flat_map(|bc| bc.into_chain())
+        .map(|block| block.block_hash())
+        .collect()
 }
 
 pub fn blocks_count(blocks: &UnstableBlocks) -> usize {

--- a/scripts/canbench_ci_run_benchmark.sh
+++ b/scripts/canbench_ci_run_benchmark.sh
@@ -73,9 +73,9 @@ if [ -f "$MAIN_BRANCH_RESULTS_FILE" ]; then
   ' "$CANBENCH_OUTPUT" > "${CANBENCH_OUTPUT}.tmp" && mv "${CANBENCH_OUTPUT}.tmp" "$CANBENCH_OUTPUT"
 
   # Add a top-level summary of detected performance changes
-  if grep -q "(improved by" "${CANBENCH_OUTPUT}"; then
+  if grep -q "(improved " "${CANBENCH_OUTPUT}"; then
     echo "**🟢 Performance improvements detected! 🎉**" >> "$COMMENT_MESSAGE_PATH"
-  elif grep -q "(regress" "${CANBENCH_OUTPUT}"; then
+  elif grep -q "(regressed " "${CANBENCH_OUTPUT}"; then
     echo "**🔴 Performance regressions detected! 😱**" >> "$COMMENT_MESSAGE_PATH"
   else
     echo "**ℹ️ No significant performance changes detected 👍**" >> "$COMMENT_MESSAGE_PATH"

--- a/scripts/canbench_ci_run_benchmark.sh
+++ b/scripts/canbench_ci_run_benchmark.sh
@@ -65,9 +65,9 @@ if [ -f "$MAIN_BRANCH_RESULTS_FILE" ]; then
   popd
 
   # Append markers to individual benchmark results
-  sed -i 's/\(improved by[^)]*\)/\1 🟢/' "$CANBENCH_OUTPUT"
-  sed -i 's/\(regress[^)]*\)/\1 🔴/' "$CANBENCH_OUTPUT"
-  sed -i 's/\(new[^)]*\)/\1 🟡/' "$CANBENCH_OUTPUT"
+  sed -i 's/\(improved [^)]*\))/\1/; s/$/ 🟢/' "$CANBENCH_OUTPUT"
+  sed -i 's/\(regressed [^)]*\))/\1/; s/$/ 🔴/' "$CANBENCH_OUTPUT"
+  sed -i 's/\(new[^)]*\))/\1/; s/$/ 🟡/' "$CANBENCH_OUTPUT"
 
   # Add a top-level summary of detected performance changes
   if grep -q "(improved by" "${CANBENCH_OUTPUT}"; then

--- a/scripts/canbench_ci_run_benchmark.sh
+++ b/scripts/canbench_ci_run_benchmark.sh
@@ -65,9 +65,9 @@ if [ -f "$MAIN_BRANCH_RESULTS_FILE" ]; then
   popd
 
   # Append markers to individual benchmark results
-  sed -i 's/\(improved [^)]*\))/\1/; s/$/ 🟢/' "$CANBENCH_OUTPUT"
-  sed -i 's/\(regressed [^)]*\))/\1/; s/$/ 🔴/' "$CANBENCH_OUTPUT"
-  sed -i 's/\(new[^)]*\))/\1/; s/$/ 🟡/' "$CANBENCH_OUTPUT"
+  sed -i '/improved by[^)]*)/ s/\(improved by[^)]*\))/\1 🟢/' "$CANBENCH_OUTPUT"
+  sed -i '/regressed by[^)]*)/ s/\(regressed by[^)]*\))/\1 🔴/' "$CANBENCH_OUTPUT"
+  sed -i '/new[^)]*)/ s/\(new[^)]*\))/\1 🟡/' "$CANBENCH_OUTPUT"
 
   # Add a top-level summary of detected performance changes
   if grep -q "(improved by" "${CANBENCH_OUTPUT}"; then

--- a/scripts/canbench_ci_run_benchmark.sh
+++ b/scripts/canbench_ci_run_benchmark.sh
@@ -65,9 +65,12 @@ if [ -f "$MAIN_BRANCH_RESULTS_FILE" ]; then
   popd
 
   # Append markers to individual benchmark results
-  sed -i '/improved by[^)]*)/ s/\(improved by[^)]*\))/\1 🟢/' "$CANBENCH_OUTPUT"
-  sed -i '/regressed by[^)]*)/ s/\(regressed by[^)]*\))/\1 🔴/' "$CANBENCH_OUTPUT"
-  sed -i '/new[^)]*)/ s/\(new[^)]*\))/\1 🟡/' "$CANBENCH_OUTPUT"
+  awk '
+  /\(improved by/ { print $0, "🟢"; next }
+  /\(regressed by/ { print $0, "🔴"; next }
+  /\(new\)/ { print $0, "🟡"; next }
+  { print }
+  ' "$CANBENCH_OUTPUT" > "${CANBENCH_OUTPUT}.tmp" && mv "${CANBENCH_OUTPUT}.tmp" "$CANBENCH_OUTPUT"
 
   # Add a top-level summary of detected performance changes
   if grep -q "(improved by" "${CANBENCH_OUTPUT}"; then

--- a/scripts/canbench_ci_run_benchmark.sh
+++ b/scripts/canbench_ci_run_benchmark.sh
@@ -66,8 +66,8 @@ if [ -f "$MAIN_BRANCH_RESULTS_FILE" ]; then
 
   # Append markers to individual benchmark results
   awk '
-  /\(improved by/ { print $0, "🟢"; next }
-  /\(regressed by/ { print $0, "🔴"; next }
+  /\(improved / { print $0, "🟢"; next }
+  /\(regressed / { print $0, "🔴"; next }
   /\(new\)/ { print $0, "🟡"; next }
   { print }
   ' "$CANBENCH_OUTPUT" > "${CANBENCH_OUTPUT}.tmp" && mv "${CANBENCH_OUTPUT}.tmp" "$CANBENCH_OUTPUT"


### PR DESCRIPTION
This PR fixes a formatting issue in Canbench results where emojis were placed in the middle of the line instead of at the end.

Example of how it looks after the fix:
```
Benchmark: get_metrics
  total:
    instructions: 405.58 M (regressed by 5042.70%) 🔴
    heap_increase: 2 pages (regressed from 0) 🔴
    stable_memory_increase: 0 pages (no change)
```