### PR TITLE
chore: fix typo

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -269,7 +269,7 @@ $ cargo run --example upload -- \
 Prepare upgrade arguments
 ```shell
 # Select a subset of init arguments or make sure they copy current prod configuration.
-$ ARG="(opt record {
+$ ARG="(record {
     network = opt variant { $NETWORK };
     stability_threshold = opt $STABILITY_THRESHOLD;
     syncing = opt variant { enabled };


### PR DESCRIPTION
This PR fixes a typo in init param argument of bitcoin canister which is not optional.

Reference [code](https://github.com/dfinity/bitcoin-canister/blob/ef3015332f2d8e33000787891da951d3404ca7de/canister/candid.did#L129).