### PR TITLE
feat: add default fees for mainnet/testnet networks

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Run Tests
         shell: bash
         run: |
-          cargo test --release --all-targets --workspace --exclude benchmarks
+          cargo test --release --all-targets --workspace --exclude benchmarks --color always -- --color always
         env:
           RUST_BACKTRACE: 1
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -5,6 +5,7 @@ env:
   DFX_VERSION: 0.23.0
   POCKET_IC_SERVER_VERSION: 7.0.0
   CARGO_TERM_COLOR: always # Force Cargo to use colors
+  TERM: xterm-256color
 
 on:
   push:

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -268,6 +268,7 @@ $ cargo run --example upload -- \
 
 Prepare upgrade arguments
 ```shell
+# https://internetcomputer.org/docs/references/bitcoin-how-it-works#api-fees-and-pricing
 $ CUSTOM_FEES="record { 
   get_utxos_base = 50_000_000 : nat;
   get_utxos_cycles_per_ten_instructions = 10 : nat;

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -268,37 +268,6 @@ $ cargo run --example upload -- \
 
 Prepare upgrade arguments
 ```shell
-# https://internetcomputer.org/docs/references/bitcoin-how-it-works#api-fees-and-pricing
-$ TESTNET_FEES="record { 
-  get_utxos_base = 20_000_000 : nat;
-  get_utxos_cycles_per_ten_instructions = 10 : nat;
-  get_utxos_maximum = 4_000_000_000 : nat;
-  get_current_fee_percentiles = 4_000_000 : nat;
-  get_current_fee_percentiles_maximum = 40_000_000 : nat;
-  get_balance = 4_000_000 : nat;
-  get_balance_maximum = 40_000_000 : nat;
-  send_transaction_base = 2_000_000_000 : nat;
-  send_transaction_per_byte = 8_000_000 : nat;
-  get_block_headers_base = 20_000_000 : nat;
-  get_block_headers_cycles_per_ten_instructions = 10 : nat;
-  get_block_headers_maximum = 4_000_000_000 : nat;
-}"
-
-$ MAINNET_FEES="record { 
-  get_utxos_base = 50_000_000 : nat;
-  get_utxos_cycles_per_ten_instructions = 10 : nat;
-  get_utxos_maximum = 10_000_000_000 : nat;
-  get_current_fee_percentiles = 10_000_000 : nat;
-  get_current_fee_percentiles_maximum = 100_000_000 : nat;
-  get_balance = 10_000_000 : nat;
-  get_balance_maximum = 100_000_000 : nat;
-  send_transaction_base = 5_000_000_000 : nat;
-  send_transaction_per_byte = 20_000_000 : nat;
-  get_block_headers_base = 50_000_000 : nat;
-  get_block_headers_cycles_per_ten_instructions = 10 : nat;
-  get_block_headers_maximum = 10_000_000_000 : nat;
-}"
-
 # Select a subset of init arguments or make sure they copy current prod configuration.
 $ ARG="(record {
     network = opt variant { $NETWORK };
@@ -306,7 +275,6 @@ $ ARG="(record {
     syncing = opt variant { enabled };
     api_access = opt variant { disabled };
     watchdog_canister = opt opt principal \"$TESTNET_WATCHDOG_CANISTER_ID\";
-    fees = opt $TESTNET_FEES;
 })"
 ```
 

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -268,6 +268,21 @@ $ cargo run --example upload -- \
 
 Prepare upgrade arguments
 ```shell
+$ CUSTOM_FEES="record { 
+  get_utxos_base = 50_000_000 : nat;
+  get_utxos_cycles_per_ten_instructions = 10 : nat;
+  get_utxos_maximum = 10_000_000_000 : nat;
+  get_current_fee_percentiles = 10_000_000 : nat;
+  get_current_fee_percentiles_maximum = 100_000_000 : nat;
+  get_balance = 10_000_000 : nat;
+  get_balance_maximum = 100_000_000 : nat;
+  send_transaction_base = 5_000_000_000 : nat;
+  send_transaction_per_byte = 20_000_000 : nat;
+  get_block_headers_base = 50_000_000 : nat;
+  get_block_headers_cycles_per_ten_instructions = 10 : nat;
+  get_block_headers_maximum = 10_000_000_000 : nat;
+}"
+
 # Select a subset of init arguments or make sure they copy current prod configuration.
 $ ARG="(record {
     network = opt variant { $NETWORK };
@@ -275,6 +290,7 @@ $ ARG="(record {
     syncing = opt variant { enabled };
     api_access = opt variant { disabled };
     watchdog_canister = opt opt principal \"$TESTNET_WATCHDOG_CANISTER_ID\";
+    fees = opt $CUSTOM_FEES;
 })"
 ```
 

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -595,7 +595,7 @@ mod test {
         });
 
         with_state(|s| {
-            assert!(s.syncing_state.syncing == Flag::Disabled);
+            assert_eq!(s.syncing_state.syncing, Flag::Disabled);
         });
 
         init(InitConfig {
@@ -604,7 +604,7 @@ mod test {
         });
 
         with_state(|s| {
-            assert!(s.syncing_state.syncing == Flag::Enabled);
+            assert_eq!(s.syncing_state.syncing, Flag::Enabled);
         });
     }
 
@@ -616,7 +616,7 @@ mod test {
         });
 
         with_state(|s| {
-            assert!(s.disable_api_if_not_fully_synced == Flag::Disabled);
+            assert_eq!(s.disable_api_if_not_fully_synced, Flag::Disabled);
         });
 
         init(InitConfig {
@@ -625,12 +625,12 @@ mod test {
         });
 
         with_state(|s| {
-            assert!(s.disable_api_if_not_fully_synced == Flag::Enabled);
+            assert_eq!(s.disable_api_if_not_fully_synced, Flag::Enabled);
         });
     }
 
     #[test]
-    fn init_sets_default_fees_if_not_explicitly_provided() {
+    fn init_applies_default_fees_when_not_explicitly_provided() {
         let custom = Fees {
             get_utxos_base: 123,
             ..Default::default()
@@ -643,16 +643,14 @@ mod test {
             (Network::Mainnet, Some(custom.clone()), custom.clone()),
             (Network::Regtest, Some(custom.clone()), custom),
         ];
-        for (network, fees, expected) in test_cases {
+        for (network, provided_fees, expected_fees) in test_cases {
             init(InitConfig {
                 network: Some(network),
-                fees,
+                fees: provided_fees.clone(),
                 ..Default::default()
             });
 
-            with_state(|s| {
-                assert!(s.fees == expected);
-            });
+            with_state(|s| assert_eq!(s.fees, expected_fees));
         }
     }
 }

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -293,7 +293,7 @@ pub(crate) fn is_synced() -> bool {
 #[cfg(test)]
 mod test {
     use super::*;
-    use ic_btc_interface::{Network, NetworkInRequest};
+    use ic_btc_interface::{Fees, Network, NetworkInRequest};
     use ic_btc_test_utils::build_regtest_chain;
     use proptest::prelude::*;
 
@@ -627,5 +627,32 @@ mod test {
         with_state(|s| {
             assert!(s.disable_api_if_not_fully_synced == Flag::Enabled);
         });
+    }
+
+    #[test]
+    fn init_sets_default_fees() {
+        let custom = Fees {
+            get_utxos_base: 123,
+            ..Default::default()
+        };
+        let test_cases = [
+            (Network::Testnet, None, Fees::testnet()),
+            (Network::Mainnet, None, Fees::mainnet()),
+            (Network::Regtest, None, Fees::default()),
+            (Network::Testnet, Some(custom.clone()), custom.clone()),
+            (Network::Mainnet, Some(custom.clone()), custom.clone()),
+            (Network::Regtest, Some(custom.clone()), custom),
+        ];
+        for (network, fees, expected) in test_cases {
+            init(InitConfig {
+                network: Some(network),
+                fees,
+                ..Default::default()
+            });
+
+            with_state(|s| {
+                assert!(s.fees == expected);
+            });
+        }
     }
 }

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -630,7 +630,7 @@ mod test {
     }
 
     #[test]
-    fn init_sets_default_fees() {
+    fn init_sets_default_fees_if_not_explicitly_provided() {
         let custom = Fees {
             get_utxos_base: 123,
             ..Default::default()

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -83,6 +83,12 @@ impl State {
         let unstable_blocks =
             UnstableBlocks::new(&utxos, stability_threshold, genesis_block, network);
 
+        let fees = match network {
+            Network::Mainnet => Fees::mainnet(),
+            Network::Testnet => Fees::testnet(),
+            _ => Fees::default(),
+        };
+
         Self {
             utxos,
             unstable_blocks,
@@ -90,7 +96,7 @@ impl State {
             blocks_source: Principal::management_canister(),
             fee_percentiles_cache: None,
             stable_block_headers: BlockHeaderStore::init(),
-            fees: Fees::default(),
+            fees,
             metrics: Metrics::default(),
             api_access: Flag::Enabled,
             disable_api_if_not_fully_synced: Flag::Enabled,

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -86,7 +86,7 @@ impl State {
         let fees = match network {
             Network::Mainnet => Fees::mainnet(),
             Network::Testnet => Fees::testnet(),
-            _ => Fees::default(),
+            Network::Regtest => Fees::default(),
         };
 
         Self {

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -634,14 +634,9 @@ impl From<InitConfig> for Config {
             config.syncing = syncing;
         }
 
+        let fees_explicitly_set = init_config.fees.is_some();
         if let Some(fees) = init_config.fees {
             config.fees = fees;
-        } else {
-            match config.network {
-                Network::Mainnet => config.fees = Fees::mainnet(),
-                Network::Testnet => config.fees = Fees::testnet(),
-                _ => config.fees = Fees::default(),
-            }
         }
 
         if let Some(api_access) = init_config.api_access {
@@ -662,6 +657,15 @@ impl From<InitConfig> for Config {
 
         if let Some(lazily_evaluate_fee_percentiles) = init_config.lazily_evaluate_fee_percentiles {
             config.lazily_evaluate_fee_percentiles = lazily_evaluate_fee_percentiles;
+        }
+
+        // Config post-processing.
+        if !fees_explicitly_set {
+            config.fees = match config.network {
+                Network::Mainnet => Fees::mainnet(),
+                Network::Testnet => Fees::testnet(),
+                _ => config.fees, // Keep unchanged for the rest of the networks.
+            };
         }
 
         config

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -636,6 +636,12 @@ impl From<InitConfig> for Config {
 
         if let Some(fees) = init_config.fees {
             config.fees = fees;
+        } else {
+            match config.network {
+                Network::Mainnet => config.fees = Fees::mainnet(),
+                Network::Testnet => config.fees = Fees::testnet(),
+                _ => config.fees = Fees::default(),
+            }
         }
 
         if let Some(api_access) = init_config.api_access {
@@ -723,6 +729,52 @@ pub struct Fees {
     /// The maximum amount of cycles that can be charged in a `get_block_headers` request.
     /// A request must send at least this amount for it to be accepted.
     pub get_block_headers_maximum: u128,
+}
+
+impl Fees {
+    pub fn testnet() -> Self {
+        // https://internetcomputer.org/docs/references/bitcoin-how-it-works#bitcoin-testnet
+        Self {
+            get_utxos_base: 20_000_000,
+            get_utxos_cycles_per_ten_instructions: 10,
+            get_utxos_maximum: 4_000_000_000,
+
+            get_current_fee_percentiles: 4_000_000,
+            get_current_fee_percentiles_maximum: 40_000_000,
+
+            get_balance: 4_000_000,
+            get_balance_maximum: 40_000_000,
+
+            send_transaction_base: 2_000_000_000,
+            send_transaction_per_byte: 8_000_000,
+
+            get_block_headers_base: 20_000_000,
+            get_block_headers_cycles_per_ten_instructions: 10,
+            get_block_headers_maximum: 4_000_000_000,
+        }
+    }
+
+    pub fn mainnet() -> Self {
+        // https://internetcomputer.org/docs/references/bitcoin-how-it-works#bitcoin-mainnet
+        Self {
+            get_utxos_base: 50_000_000,
+            get_utxos_cycles_per_ten_instructions: 10,
+            get_utxos_maximum: 10_000_000_000,
+
+            get_current_fee_percentiles: 10_000_000,
+            get_current_fee_percentiles_maximum: 100_000_000,
+
+            get_balance: 10_000_000,
+            get_balance_maximum: 100_000_000,
+
+            send_transaction_base: 5_000_000_000,
+            send_transaction_per_byte: 20_000_000,
+
+            get_block_headers_base: 50_000_000,
+            get_block_headers_cycles_per_ten_instructions: 10,
+            get_block_headers_maximum: 10_000_000_000,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -664,7 +664,7 @@ impl From<InitConfig> for Config {
             config.fees = match config.network {
                 Network::Mainnet => Fees::mainnet(),
                 Network::Testnet => Fees::testnet(),
-                _ => config.fees, // Keep unchanged for the rest of the networks.
+                Network::Regtest => config.fees, // Keep unchanged for regtest.
             };
         }
 


### PR DESCRIPTION
This PR adds auto-setup for fees if not explicitly provided during initialisation.

Fees values hardcoded depending on config network (mainnet/testnet) and rely on [docs](https://internetcomputer.org/docs/references/bitcoin-how-it-works#bitcoin-testnet).