### PR TITLE
fix: adaptive max depth limit calculation for unstable blocks tree

### DIFF
--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -2,7 +2,7 @@ use crate::{
     metrics::{Histogram, InstructionHistogram},
     state,
     types::HttpResponse,
-    unstable_blocks::TESTNET_UNSTABLE_MAX_DEPTH_DIFFERENCE,
+    unstable_blocks::testnet_unstable_max_depth_difference,
     with_state,
 };
 use ic_btc_interface::Flag;
@@ -79,9 +79,10 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             state.unstable_blocks.normalized_stability_threshold() as f64,
             "The stability threshold normalized by the difficulty of the anchor block.",
         )?;
+        let unstable_blocks_total = state::unstable_blocks_total(state);
         w.encode_gauge(
             "testnet_unstable_max_depth_difference",
-            TESTNET_UNSTABLE_MAX_DEPTH_DIFFERENCE.get() as f64,
+            testnet_unstable_max_depth_difference(unstable_blocks_total).get() as f64,
             "Max depth difference between the two longest unstable branches in Testnet/Regtest.",
         )?;
         w.encode_gauge(
@@ -92,7 +93,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         encode_histogram(w, &state.metrics.unstable_blocks_tip_depths)?;
         w.encode_gauge(
             "unstable_blocks_total",
-            state::unstable_blocks_total(state) as f64,
+            unstable_blocks_total as f64,
             "The number of unstable blocks.",
         )?;
         w.encode_gauge(

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -72,12 +72,12 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         let stability_threshold = state.unstable_blocks.stability_threshold();
         w.encode_gauge(
             "stability_threshold",
-            state.unstable_blocks.stability_threshold() as f64,
+            stability_threshold as f64,
             "The stability threshold.",
         )?;
         w.encode_gauge(
             "normalized_stability_threshold",
-            stability_threshold as f64,
+            state.unstable_blocks.normalized_stability_threshold() as f64,
             "The stability threshold normalized by the difficulty of the anchor block.",
         )?;
         let unstable_blocks_total = state::unstable_blocks_total(state);

--- a/canister/src/api/metrics.rs
+++ b/canister/src/api/metrics.rs
@@ -69,6 +69,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             state.unstable_blocks.anchor_difficulty() as f64,
             "The difficulty of the anchor block.",
         )?;
+        let stability_threshold = state.unstable_blocks.stability_threshold();
         w.encode_gauge(
             "stability_threshold",
             state.unstable_blocks.stability_threshold() as f64,
@@ -76,13 +77,14 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         )?;
         w.encode_gauge(
             "normalized_stability_threshold",
-            state.unstable_blocks.normalized_stability_threshold() as f64,
+            stability_threshold as f64,
             "The stability threshold normalized by the difficulty of the anchor block.",
         )?;
         let unstable_blocks_total = state::unstable_blocks_total(state);
         w.encode_gauge(
             "testnet_unstable_max_depth_difference",
-            testnet_unstable_max_depth_difference(unstable_blocks_total).get() as f64,
+            testnet_unstable_max_depth_difference(unstable_blocks_total, stability_threshold).get()
+                as f64,
             "Max depth difference between the two longest unstable branches in Testnet/Regtest.",
         )?;
         w.encode_gauge(

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -1151,14 +1151,17 @@ mod test {
 
     #[test]
     fn test_testnet_unstable_max_depth_difference() {
+        // Empty unstable blocks tree has maximum depth difference limit.
         assert_eq!(
             testnet_unstable_max_depth_difference(0),
             MAX_TESTNET_UNSTABLE_DEPTH_DIFFERENCE
         );
+        // Unstable blocks tree with depth at the limit has minimum depth difference limit.
         assert_eq!(
             testnet_unstable_max_depth_difference(MAX_UNSTABLE_BLOCKS),
             MIN_TESTNET_UNSTABLE_DEPTH_DIFFERENCE
         );
+        // Unstable blocks tree with depth exceeding the limit has minimum depth difference limit.
         assert_eq!(
             testnet_unstable_max_depth_difference(MAX_UNSTABLE_BLOCKS + 1),
             MIN_TESTNET_UNSTABLE_DEPTH_DIFFERENCE

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -1151,17 +1151,19 @@ mod test {
 
     #[test]
     fn test_testnet_unstable_max_depth_difference() {
-        // Empty unstable blocks tree has maximum depth difference limit.
+        // When there are no unstable blocks, the max depth difference is at its highest.
         assert_eq!(
             testnet_unstable_max_depth_difference(0),
             MAX_TESTNET_UNSTABLE_DEPTH_DIFFERENCE
         );
-        // Unstable blocks tree with depth at the limit has minimum depth difference limit.
+
+        // At the limit, the depth difference is at its minimum.
         assert_eq!(
             testnet_unstable_max_depth_difference(MAX_UNSTABLE_BLOCKS),
             MIN_TESTNET_UNSTABLE_DEPTH_DIFFERENCE
         );
-        // Unstable blocks tree with depth exceeding the limit has minimum depth difference limit.
+
+        // Going over the limit keeps the depth difference at the minimum.
         assert_eq!(
             testnet_unstable_max_depth_difference(MAX_UNSTABLE_BLOCKS + 1),
             MIN_TESTNET_UNSTABLE_DEPTH_DIFFERENCE

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -20,6 +20,9 @@ use self::next_block_headers::NextBlockHeaders;
 const MAX_TESTNET_UNSTABLE_DEPTH_DIFFERENCE: Depth = Depth::new(500);
 
 /// Max number (soft limit) of unstable blocks in `Testnet` and `Regtest`.
+///
+/// When the number of unstable blocks exceeds this limit, the depth difference
+/// drops to the current `stability_threshold` value.
 const MAX_UNSTABLE_BLOCKS: usize = 1_500;
 
 /// Returns the maximum allowed depth difference between the two longest


### PR DESCRIPTION
This PR introduces adaptive logic to control the growth of the unstable block tree in testnets.

Unlike mainnet (which usually has 1–2 branches), testnets often have tens or hundreds of competing branches. This leads to a much larger unstable block tree—potentially 10–100x bigger than the main chain. Since this tree is stored in heap memory, its size must stay below 2 GiB to keep the canister upgradable. With 1 MiB blocks, this limits the tree to about 2,000 blocks.

Previously, testnet depth was capped by a constant (`TESTNET_UNSTABLE_MAX_DEPTH_DIFFERENCE`). This PR replaces that with an adaptive limit based on the `stability_threshold` and current tree size. The new logic applies backpressure to prevent unbounded growth.
