### PR TITLE
fix: set a non-zero default stability threshold

### DIFF
--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -15,8 +15,10 @@ pub type Height = u32;
 pub type Page = ByteBuf;
 pub type BlockHeader = Vec<u8>;
 
-/// The default stability threshold for the Bitcoin canister.
-const DEFAULT_STABILITY_THRESHOLD: u128 = 24 * 6; // 24 hours at 10 minutes per block
+/// Default stability threshold for the Bitcoin canister.
+/// Must not be zero — a value of 0 can make the canister follow wrong branches,
+/// get stuck, and require a manual reset.
+const DEFAULT_STABILITY_THRESHOLD: u128 = 144; // ~24 hours at 10 min per block
 
 #[derive(CandidType, Clone, Copy, Deserialize, Debug, Eq, PartialEq, Serialize, Hash, DataSize)]
 pub enum Network {


### PR DESCRIPTION
Sets a non-zero `stability_threshold` to prevent the canister from following invalid branches and getting stuck.