### PR TITLE
feat(benchmarks): add mock time

### DIFF
--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -27,6 +27,9 @@ fn init() {
                 .collect(),
         );
     });
+
+    // Set a current time to avoid header validation failures due to blocks appearing to be in the future
+    ic_btc_canister::runtime::set_mock_time_secs(1750077112); // June 2025
 }
 
 // Benchmarks inserting the first 300 blocks of the Bitcoin testnet.


### PR DESCRIPTION
[XC-394](https://dfinity.atlassian.net/browse/XC-394?atlOrigin=eyJpIjoiNjY4NjU1ZDIxYTY3NDRiNThhMmFhZTVkOTI3NjBkNDYiLCJwIjoiaiJ9): This PR adds the possibility to mock time in `canister/src/runtime.rs`. This is especially useful in benchmark where calling `ic_cdk::api::time()` would always return the same value, namely `1620328630000000023` (May 6, 2021). Because this value is earlier than testnet4 genesis, header timestamp validation would always fail since by consensus rules, timestamp in headers must not be further than 2 hours in the future.