### PR TITLE
fix(validation): add timestamp validation check testnet4

### DIFF
--- a/validation/src/header.rs
+++ b/validation/src/header.rs
@@ -69,11 +69,7 @@ pub fn validate_header(
         }
     };
 
-    if *network != Network::Testnet4 {
-        // Skip timestamp validation for Testnet4; the first 2 blocks are 2 days apart.
-        // https://mempool.space/testnet4/block/00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043
-        is_timestamp_valid(store, header, current_time)?;
-    }
+    is_timestamp_valid(store, header, current_time)?;
 
     let header_target = header.target();
     if header_target > max_target(network) {


### PR DESCRIPTION
[XC-387](https://dfinity.atlassian.net/browse/XC-387?atlOrigin=eyJpIjoiMGViYWMzYjk5MmY1NGIyOThlZDdiMGE0YWZmMzIyNjUiLCJwIjoiaiJ9): Previously, validation of testnet4 block headers was skipped because the time returned by `ic_cdk::time()` within benchmarks was too far in the past, causing the condition that header timestamp must be less than 2 hours in the future to fail. PR https://github.com/dfinity/bitcoin-canister/pull/401 addressed this by introducing support for mocking time during benchmarks. With this change, timestamp validation for testnet4 headers can now be re-enabled.