### PR TITLE
ci(reproducibility): fix canister names

### DIFF
--- a/e2e-tests/reproducibility.sh
+++ b/e2e-tests/reproducibility.sh
@@ -28,13 +28,13 @@ docker build -t canisters "$dockerfile_dir"
 tmpdir=$(mktemp -d)
 
 # Extract the wasm files from the first build
-docker run --rm -v "$tmpdir:/output" canisters cp /watchdog-canister.wasm.gz /output/watchdog-canister.wasm.gz
-docker run --rm -v "$tmpdir:/output" canisters cp /uploader-canister.wasm.gz /output/uploader-canister.wasm.gz
+docker run --rm -v "$tmpdir:/output" canisters cp /watchdog.wasm.gz /output/watchdog.wasm.gz
+docker run --rm -v "$tmpdir:/output" canisters cp /uploader.wasm.gz /output/uploader.wasm.gz
 docker run --rm -v "$tmpdir:/output" canisters cp /ic-btc-canister.wasm.gz /output/ic-btc-canister.wasm.gz
 
 # Calculate the SHA256 sums for the first build
 echo "Calculating SHA256 sums (1st build)..."
-if ! sha256sum1=$(sha256sum "$tmpdir/watchdog-canister.wasm.gz" "$tmpdir/uploader-canister.wasm.gz" "$tmpdir/ic-btc-canister.wasm.gz" 2>&1); then
+if ! sha256sum1=$(sha256sum "$tmpdir/watchdog.wasm.gz" "$tmpdir/uploader.wasm.gz" "$tmpdir/ic-btc-canister.wasm.gz" 2>&1); then
   echo "ERROR: Failed to calculate SHA256 sums for 1st build"
   echo "$sha256sum1"
   exit 1
@@ -45,13 +45,13 @@ echo "Building Docker image (2nd build)..."
 docker build -t canisters "$dockerfile_dir"
 
 # Extract the wasm files from the second build
-docker run --rm -v "$tmpdir:/output" canisters cp /watchdog-canister.wasm.gz /output/watchdog-canister.wasm.gz
-docker run --rm -v "$tmpdir:/output" canisters cp /uploader-canister.wasm.gz /output/uploader-canister.wasm.gz
+docker run --rm -v "$tmpdir:/output" canisters cp /watchdog.wasm.gz /output/watchdog.wasm.gz
+docker run --rm -v "$tmpdir:/output" canisters cp /uploader.wasm.gz /output/uploader.wasm.gz
 docker run --rm -v "$tmpdir:/output" canisters cp /ic-btc-canister.wasm.gz /output/ic-btc-canister.wasm.gz
 
 # Calculate the SHA256 sums for the second build
 echo "Calculating SHA256 sums (2nd build)..."
-if ! sha256sum2=$(sha256sum "$tmpdir/watchdog-canister.wasm.gz" "$tmpdir/uploader-canister.wasm.gz" "$tmpdir/ic-btc-canister.wasm.gz" 2>&1); then
+if ! sha256sum2=$(sha256sum "$tmpdir/watchdog.wasm.gz" "$tmpdir/uploader.wasm.gz" "$tmpdir/ic-btc-canister.wasm.gz" 2>&1); then
   echo "ERROR: Failed to calculate SHA256 sums for 2nd build"
   echo "$sha256sum2"
   exit 1

--- a/e2e-tests/reproducibility.sh
+++ b/e2e-tests/reproducibility.sh
@@ -34,7 +34,11 @@ docker run --rm -v "$tmpdir:/output" canisters cp /ic-btc-canister.wasm.gz /outp
 
 # Calculate the SHA256 sums for the first build
 echo "Calculating SHA256 sums (1st build)..."
-sha256sum1=$(sha256sum "$tmpdir/watchdog-canister.wasm.gz" "$tmpdir/uploader-canister.wasm.gz" "$tmpdir/ic-btc-canister.wasm.gz")
+if ! sha256sum1=$(sha256sum "$tmpdir/watchdog-canister.wasm.gz" "$tmpdir/uploader-canister.wasm.gz" "$tmpdir/ic-btc-canister.wasm.gz" 2>&1); then
+  echo "ERROR: Failed to calculate SHA256 sums for 1st build"
+  echo "$sha256sum1"
+  exit 1
+fi
 
 # Build the Docker image for the second time
 echo "Building Docker image (2nd build)..."
@@ -47,7 +51,11 @@ docker run --rm -v "$tmpdir:/output" canisters cp /ic-btc-canister.wasm.gz /outp
 
 # Calculate the SHA256 sums for the second build
 echo "Calculating SHA256 sums (2nd build)..."
-sha256sum2=$(sha256sum "$tmpdir/watchdog-canister.wasm.gz" "$tmpdir/uploader-canister.wasm.gz" "$tmpdir/ic-btc-canister.wasm.gz")
+if ! sha256sum2=$(sha256sum "$tmpdir/watchdog-canister.wasm.gz" "$tmpdir/uploader-canister.wasm.gz" "$tmpdir/ic-btc-canister.wasm.gz" 2>&1); then
+  echo "ERROR: Failed to calculate SHA256 sums for 2nd build"
+  echo "$sha256sum2"
+  exit 1
+fi
 
 # Compare the SHA256 sums
 if [ "$sha256sum1" = "$sha256sum2" ]; then


### PR DESCRIPTION
Previously, the reproducibility check was skipped for the `uploader` and `watchdog` canister because of incorrect naming (example: https://github.com/dfinity/bitcoin-canister/actions/runs/16171179985/job/45644840159?pr=409#step:3:1679). This PR fixes the canister names to make the reproducibility check work again and add a condition so that the reproducibility check fails if canister names are wrong.