### PR TITLE
chore: proposal to upgrade the bitcoin and watchdog canister

### DIFF
--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -15,8 +15,9 @@ jobs:
 
       - name: Sanitize PR title
         id: sanitize
+        env:
+          RAW_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          RAW_TITLE="${{ github.event.pull_request.title }}"
           ESCAPED_TITLE=$(echo "$RAW_TITLE" \
             | sed 's/&/\&amp;/g' \
             | sed 's/</\&lt;/g' \

--- a/deployment/mainnet/bitcoin_canister_upgrade_2025_09_04.md
+++ b/deployment/mainnet/bitcoin_canister_upgrade_2025_09_04.md
@@ -23,25 +23,25 @@ and upgrade dependencies to their latest versions.
 
 ```
 git log --format='%C(auto) %h %s' release/2024-08-30.. -- canister
- b86ac5f fix: fix stuck canister after upgrade during block fetch (#405) --
+ b86ac5f fix: fix stuck canister after upgrade during block fetch (#405)
  a611575 feat(runtime): add mocking time (#401)
  6167314 fix: adaptive max depth limit calculation for unstable blocks tree (#385)
  ee3d395 fix: [EXC-1987] Fix encoding of get_block_headers metrics on Bitcoin canister (#383)
  82863a8 chore: adjust testnet unstable max depth difference (#382)
  b2177ec chore: cleanups (#381)
  063beb8 fix: fix unstable tree block stability check for testnet (#379)
- ced4b1b fix: fix memory leak (#378) --
- e19928c feat: add default fees for mainnet/testnet networks (#376) ???
+ ced4b1b fix: fix memory leak (#378)
+ e19928c feat: add default fees for mainnet/testnet networks (#376)
  cbf67c8 chore: update dfx to 0.23 and rust to 1.81 (#372)
- f96124b chore: update get_successors metrics (#364) --
- 0e9a055 fix: get_successors request sends unique hashes (#363) --
- f63b04f feat: add get_successors_request_interval histogram metric (#361) --
- 414a7fa feat: add get_successors request / response metrics for bitcoin canister (#360) --
+ f96124b chore: update get_successors metrics (#364)
+ 0e9a055 fix: get_successors request sends unique hashes (#363)
+ f63b04f feat: add get_successors_request_interval histogram metric (#361)
+ 414a7fa feat: add get_successors request / response metrics for bitcoin canister (#360)
  6f88899 fix: reduce Bitcoin canister logs by skipping full GetSuccessorsResponse (#359)
  93213b2 chore: add instructions for generating testnet_blocks.txt (#351)
  47c5d1f feat: upgrade bitcoin crate to 0.32.4 for testnet4 support (#349)
  64f3183 fix: remove `rand` dependency from Bitcoin canister (#348)
- f7afb9d chore: Upgrade stable structures to 0.6.7 (#346) --
+ f7afb9d chore: Upgrade stable structures to 0.6.7 (#346)
  32c70fa chore: rename usage of BlockHeader to Header for bitcoin crate v.0.32.4 update (#345)
  ```
 

--- a/deployment/mainnet/bitcoin_canister_upgrade_2025_09_04.md
+++ b/deployment/mainnet/bitcoin_canister_upgrade_2025_09_04.md
@@ -56,6 +56,7 @@ didc encode '()' | xxd -r -p | sha256sum
 ## Wasm Verification
 
 Verify that the hash of the gzipped WASM matches the proposed hash.
+NOTE: This process is not yet guaranteed to match on Apple Silicon.
 
 ```
 git fetch

--- a/deployment/mainnet/bitcoin_canister_upgrade_2025_09_04.md
+++ b/deployment/mainnet/bitcoin_canister_upgrade_2025_09_04.md
@@ -1,0 +1,66 @@
+# Proposal to upgrade the Bitcoin canister
+
+Repository: `https://github.com/dfinity/bitcoin-canister.git`
+
+Git hash: `292b446a0ec64158eb2c68247530870ff201f274`
+
+New compressed Wasm hash: `42af59ae4fd5041f30f8ac12f324e3a93533de0cb89cd2278100c2389cbfff65`
+
+Upgrade args hash: `0fee102bd16b053022b69f2c65fd5e2f41d150ce9c214ac8731cfaf496ebda4e`
+
+Target canister: `ghsi2-tqaaa-aaaan-aaaca-cai`
+
+Previous Bitcoin canister proposal: https://dashboard.internetcomputer.org/proposal/132220
+
+---
+
+## Motivation
+
+This proposal aims to upgrade the Bitcoin canister to incorporate several bug fixes, add metrics for better monitoring,
+and upgrade dependencies to their latest versions.
+
+## Release Notes
+
+```
+git log --format='%C(auto) %h %s' release/2024-08-30.. -- canister
+ b86ac5f fix: fix stuck canister after upgrade during block fetch (#405) --
+ a611575 feat(runtime): add mocking time (#401)
+ 6167314 fix: adaptive max depth limit calculation for unstable blocks tree (#385)
+ ee3d395 fix: [EXC-1987] Fix encoding of get_block_headers metrics on Bitcoin canister (#383)
+ 82863a8 chore: adjust testnet unstable max depth difference (#382)
+ b2177ec chore: cleanups (#381)
+ 063beb8 fix: fix unstable tree block stability check for testnet (#379)
+ ced4b1b fix: fix memory leak (#378) --
+ e19928c feat: add default fees for mainnet/testnet networks (#376) ???
+ cbf67c8 chore: update dfx to 0.23 and rust to 1.81 (#372)
+ f96124b chore: update get_successors metrics (#364) --
+ 0e9a055 fix: get_successors request sends unique hashes (#363) --
+ f63b04f feat: add get_successors_request_interval histogram metric (#361) --
+ 414a7fa feat: add get_successors request / response metrics for bitcoin canister (#360) --
+ 6f88899 fix: reduce Bitcoin canister logs by skipping full GetSuccessorsResponse (#359)
+ 93213b2 chore: add instructions for generating testnet_blocks.txt (#351)
+ 47c5d1f feat: upgrade bitcoin crate to 0.32.4 for testnet4 support (#349)
+ 64f3183 fix: remove `rand` dependency from Bitcoin canister (#348)
+ f7afb9d chore: Upgrade stable structures to 0.6.7 (#346) --
+ 32c70fa chore: rename usage of BlockHeader to Header for bitcoin crate v.0.32.4 update (#345)
+ ```
+
+## Upgrade args
+
+```
+git fetch
+git checkout 292b446a0ec64158eb2c68247530870ff201f274
+didc encode '()' | xxd -r -p | sha256sum
+```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout 292b446a0ec64158eb2c68247530870ff201f274
+docker build -t canisters .
+docker run --rm canisters cat /ic-btc-canister.wasm.gz > ic-btc-canister.wasm.gz
+sha256sum ic-btc-canister.wasm.gz
+```

--- a/deployment/mainnet/watchdog_canister_upgrade_2025_09_04.md
+++ b/deployment/mainnet/watchdog_canister_upgrade_2025_09_04.md
@@ -1,0 +1,58 @@
+# Proposal to upgrade the Watchdog canister
+
+Repository: `https://github.com/dfinity/bitcoin-canister.git`
+
+Git hash: `292b446a0ec64158eb2c68247530870ff201f274`
+
+New compressed Wasm hash: `579d0ece72da46b0040fc7e395d9c4133bd117e2d2a6f7f6056252ec7ce29eb8`
+
+Upgrade args hash: `cb67b7d883fa8d54e0ef985460a0e1f47f213a27cfa40bdf2e2c68b833c352a4`
+
+Target canister: `gatoo-6iaaa-aaaan-aaacq-cai`
+
+Previous Bitcoin canister proposal: https://dashboard.internetcomputer.org/proposal/127666
+
+---
+
+## Motivation
+
+Upgrade dependencies to their latest versions and add new explorers.
+
+## Release Notes
+
+```
+git log --format='%C(auto) %h %s' release/2024-01-22.. -- watchdog
+ cbf67c8 chore: update dfx to 0.23 and rust to 1.81 (#372)
+ 1ec71ee fix: fix min_explorers number for testnet watchdog canister (#365)
+ ce710cb feat: migrate watchdog canister to Testnet4 (#352)
+ 64f3183 fix: remove `rand` dependency from Bitcoin canister (#348)
+ 2cdc183 chore: add watchdog canister metadata (#329)
+ c48571b chore: sort dependencies in Cargo.toml files (#330)
+ fcb41ac feat: re-enable tracking api.bitaps.com testnet explorer in watchdog canister (#328)
+ c225201 feat: improve height target calculation for watchdog canister (#327)
+ f029854 chore: add mainnet explorer bitcoinexplorer.org (#326)
+ 32102be fix: do not include canbench in production (#317)
+ c3ee79b chore: update threshold of watchdog testnet canister (#295)
+ 009784f chore: upgrade rust from 1.70 to 1.76 (#281)
+ 1692207 chore: revert a workaround for watchdog_health_status test due to fixed IPv4 dfx support (#280)
+ ```
+
+## Upgrade args
+
+```
+git fetch
+git checkout 292b446a0ec64158eb2c68247530870ff201f274
+didc encode '(variant { mainnet })' | xxd -r -p | sha256sum
+```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout 292b446a0ec64158eb2c68247530870ff201f274
+docker build -t canisters .
+docker run --rm canisters cat /watchdog.wasm.gz > watchdog.wasm.gz
+sha256sum watchdog.wasm.gz
+```

--- a/deployment/mainnet/watchdog_canister_upgrade_2025_09_04.md
+++ b/deployment/mainnet/watchdog_canister_upgrade_2025_09_04.md
@@ -10,7 +10,7 @@ Upgrade args hash: `ac446fe33f87ddff7ff126fa8322e26effbdca2701c719c2d29e4c9bfd9a
 
 Target canister: `gatoo-6iaaa-aaaan-aaacq-cai`
 
-Previous Bitcoin canister proposal: https://dashboard.internetcomputer.org/proposal/127666
+Previous Watchdog canister proposal: https://dashboard.internetcomputer.org/proposal/127666
 
 ---
 

--- a/deployment/mainnet/watchdog_canister_upgrade_2025_09_04.md
+++ b/deployment/mainnet/watchdog_canister_upgrade_2025_09_04.md
@@ -6,7 +6,7 @@ Git hash: `292b446a0ec64158eb2c68247530870ff201f274`
 
 New compressed Wasm hash: `579d0ece72da46b0040fc7e395d9c4133bd117e2d2a6f7f6056252ec7ce29eb8`
 
-Upgrade args hash: `cb67b7d883fa8d54e0ef985460a0e1f47f213a27cfa40bdf2e2c68b833c352a4`
+Upgrade args hash: `ac446fe33f87ddff7ff126fa8322e26effbdca2701c719c2d29e4c9bfd9aeecd`
 
 Target canister: `gatoo-6iaaa-aaaan-aaacq-cai`
 
@@ -42,7 +42,7 @@ git log --format='%C(auto) %h %s' release/2024-01-22.. -- watchdog
 ```
 git fetch
 git checkout 292b446a0ec64158eb2c68247530870ff201f274
-didc encode '(variant { mainnet })' | xxd -r -p | sha256sum
+didc encode -d ./watchdog/candid.did -t '(bitcoin_network)' "(variant { mainnet })" | xxd -r -p | sha256sum
 ```
 
 ## Wasm Verification

--- a/deployment/mainnet/watchdog_canister_upgrade_2025_09_04.md
+++ b/deployment/mainnet/watchdog_canister_upgrade_2025_09_04.md
@@ -48,6 +48,7 @@ didc encode -d ./watchdog/candid.did -t '(bitcoin_network)' "(variant { mainnet 
 ## Wasm Verification
 
 Verify that the hash of the gzipped WASM matches the proposed hash.
+NOTE: This process is not yet guaranteed to match on Apple Silicon.
 
 ```
 git fetch


### PR DESCRIPTION
These proposals aim to upgrade the Bitcoin and Watchdog canisters to the latest release [2025-07-02](https://github.com/dfinity/bitcoin-canister/releases/tag/release%2F2025-07-02) to incorporate several bug fixes, add metrics for better monitoring, and upgrade dependencies to their latest versions.