### PR TITLE
fix: deflake scenario-1 e2e test

### DIFF
--- a/e2e-tests/scenario-1.sh
+++ b/e2e-tests/scenario-1.sh
@@ -34,7 +34,7 @@ if ! [[ $BLOCKCHAIN_INFO == *"height = 5"* ]]; then
 fi
 
 # Wait until the ingestion of stable blocks is complete.
-wait_until_stable_height 3 60
+wait_until_stable_height 3 120
 
 # Fetch the balance of an address we do not expect to have funds.
 BALANCE=$(dfx canister call bitcoin bitcoin_get_balance '(record {


### PR DESCRIPTION
### Root Cause

The `scenario-1` e2e tests in `e2e-tests` was [flaky](https://github.com/dfinity/bitcoin-canister/actions/runs/23789297648/job/69321192141?pr=506) because it was not waiting enough time to ingest all the stable block in stable memory.

### Fix

Increase the number of attempts from 60 to 120 (2 minutes) to ingest stable blocks in stable memory in the scenario-1 e2e test.