### PR TITLE
feat: cache tx fee rates in heap memory

### DIFF
--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -2,96 +2,96 @@ benches:
   bitcoin_get_balance_baseline:
     total:
       calls: 1
-      instructions: 6322996
+      instructions: 6322733
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_balance_stress:
     total:
       calls: 1
-      instructions: 254446186
+      instructions: 254445975
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_block_headers_baseline:
     total:
       calls: 1
-      instructions: 535503
+      instructions: 478427
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_block_headers_stress:
     total:
       calls: 1
-      instructions: 12511993
+      instructions: 12454451
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_current_fee_percentiles:
     total:
       calls: 1
-      instructions: 172619641
-      heap_increase: 2
+      instructions: 332904
+      heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_utxos_baseline:
     total:
       calls: 1
-      instructions: 7899273
+      instructions: 7801052
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_utxos_stress:
     total:
       calls: 1
-      instructions: 4701990094
-      heap_increase: 34
+      instructions: 4671927301
+      heap_increase: 35
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_many_branches:
     total:
       calls: 1
-      instructions: 5324402
+      instructions: 5345941
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_single_chain:
     total:
       calls: 1
-      instructions: 3536549
+      instructions: 3555455
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_with_forks:
     total:
       calls: 1
-      instructions: 3632158
+      instructions: 3651180
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_metrics:
     total:
       calls: 1
-      instructions: 10109002
+      instructions: 10108864
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   insert_300_blocks:
     total:
       calls: 1
-      instructions: 418809697
-      heap_increase: 12
+      instructions: 419630067
+      heap_increase: 13
       stable_memory_increase: 0
     scopes:
       validate:
         calls: 300
-        instructions: 368049650
-        heap_increase: 4
+        instructions: 368058498
+        heap_increase: 3
         stable_memory_increase: 0
       validate_block:
         calls: 300
-        instructions: 18307374
-        heap_increase: 2
+        instructions: 18302679
+        heap_increase: 1
         stable_memory_increase: 0
       validate_block/check_merkle_root:
         calls: 300
@@ -100,117 +100,117 @@ benches:
         stable_memory_increase: 0
       validate_block/ensure_unique_transactions:
         calls: 300
-        instructions: 8469033
+        instructions: 8464899
         heap_increase: 0
         stable_memory_increase: 0
       validate_header:
         calls: 300
-        instructions: 348623193
+        instructions: 348636989
         heap_increase: 0
         stable_memory_increase: 0
   insert_block_headers:
     total:
       calls: 1
-      instructions: 2847925737
+      instructions: 2847923749
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       validate_header:
         calls: 100
-        instructions: 2805794633
+        instructions: 2805796833
         heap_increase: 0
         stable_memory_increase: 0
   insert_block_headers_multiple_times:
     total:
       calls: 1
-      instructions: 10299836054
+      instructions: 10299667441
       heap_increase: 7
       stable_memory_increase: 0
     scopes:
       validate_header:
         calls: 1000
-        instructions: 8994711182
+        instructions: 8994733160
         heap_increase: 0
         stable_memory_increase: 0
   insert_block_with_10k_transactions:
     total:
       calls: 1
-      instructions: 1383878783
+      instructions: 1385301165
       heap_increase: 73
       stable_memory_increase: 0
     scopes:
       validate:
         calls: 1
-        instructions: 149625740
+        instructions: 149626836
         heap_increase: 20
         stable_memory_increase: 0
       validate_block:
         calls: 1
-        instructions: 149519946
+        instructions: 149521020
         heap_increase: 20
         stable_memory_increase: 0
       validate_block/check_merkle_root:
         calls: 1
-        instructions: 70700320
+        instructions: 70700188
         heap_increase: 0
         stable_memory_increase: 0
       validate_block/ensure_unique_transactions:
         calls: 1
-        instructions: 78815068
+        instructions: 78816053
         heap_increase: 20
         stable_memory_increase: 0
       validate_header:
         calls: 1
-        instructions: 102940
+        instructions: 102962
         heap_increase: 0
         stable_memory_increase: 0
   insert_block_with_1k_transactions:
     total:
       calls: 1
-      instructions: 114341861
+      instructions: 114485981
       heap_increase: 7
       stable_memory_increase: 0
     scopes:
       validate:
         calls: 1
-        instructions: 15141281
+        instructions: 15142028
         heap_increase: 2
         stable_memory_increase: 0
       validate_block:
         calls: 1
-        instructions: 15035487
+        instructions: 15036212
         heap_increase: 2
         stable_memory_increase: 0
       validate_block/check_merkle_root:
         calls: 1
-        instructions: 7117870
+        instructions: 7117672
         heap_increase: 0
         stable_memory_increase: 0
       validate_block/ensure_unique_transactions:
         calls: 1
-        instructions: 7913059
+        instructions: 7913761
         heap_increase: 2
         stable_memory_increase: 0
       validate_header:
         calls: 1
-        instructions: 102940
+        instructions: 102962
         heap_increase: 0
         stable_memory_increase: 0
   pre_upgrade_with_many_unstable_blocks:
     total:
       calls: 1
-      instructions: 5375548211
+      instructions: 5412471943
       heap_increase: 4088
       stable_memory_increase: 1792
     scopes:
       serialize_blocktree_flatten:
         calls: 1
-        instructions: 188082
+        instructions: 186219
         heap_increase: 0
         stable_memory_increase: 0
       serialize_blocktree_serialize_seq:
         calls: 1
-        instructions: 1917657304
+        instructions: 1929069386
         heap_increase: 2039
         stable_memory_increase: 0
 version: 0.4.0

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -16,7 +16,7 @@ benches:
   bitcoin_get_block_headers_baseline:
     total:
       calls: 1
-      instructions: 535970
+      instructions: 535464
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -30,68 +30,68 @@ benches:
   bitcoin_get_current_fee_percentiles:
     total:
       calls: 1
-      instructions: 332904
+      instructions: 332616
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_utxos_baseline:
     total:
       calls: 1
-      instructions: 7801052
+      instructions: 7800973
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_utxos_stress:
     total:
       calls: 1
-      instructions: 4671927301
+      instructions: 4671926538
       heap_increase: 35
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_many_branches:
     total:
       calls: 1
-      instructions: 5346062
+      instructions: 5346346
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_single_chain:
     total:
       calls: 1
-      instructions: 3555455
+      instructions: 3555104
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_with_forks:
     total:
       calls: 1
-      instructions: 3651079
+      instructions: 3651191
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_metrics:
     total:
       calls: 1
-      instructions: 10108897
+      instructions: 10110508
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   insert_300_blocks:
     total:
       calls: 1
-      instructions: 419581318
-      heap_increase: 13
+      instructions: 419119801
+      heap_increase: 12
       stable_memory_increase: 0
     scopes:
       validate:
         calls: 300
-        instructions: 368056051
-        heap_increase: 3
+        instructions: 368051471
+        heap_increase: 4
         stable_memory_increase: 0
       validate_block:
         calls: 300
-        instructions: 18301834
-        heap_increase: 1
+        instructions: 18305370
+        heap_increase: 2
         stable_memory_increase: 0
       validate_block/check_merkle_root:
         calls: 300
@@ -100,117 +100,117 @@ benches:
         stable_memory_increase: 0
       validate_block/ensure_unique_transactions:
         calls: 300
-        instructions: 8464054
+        instructions: 8467029
         heap_increase: 0
         stable_memory_increase: 0
       validate_header:
         calls: 300
-        instructions: 348635387
+        instructions: 348627018
         heap_increase: 0
         stable_memory_increase: 0
   insert_block_headers:
     total:
       calls: 1
-      instructions: 2847923749
+      instructions: 2847921608
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       validate_header:
         calls: 100
-        instructions: 2805796833
+        instructions: 2805794633
         heap_increase: 0
         stable_memory_increase: 0
   insert_block_headers_multiple_times:
     total:
       calls: 1
-      instructions: 10299667441
+      instructions: 10299636424
       heap_increase: 7
       stable_memory_increase: 0
     scopes:
       validate_header:
         calls: 1000
-        instructions: 8994733160
+        instructions: 8994711182
         heap_increase: 0
         stable_memory_increase: 0
   insert_block_with_10k_transactions:
     total:
       calls: 1
-      instructions: 1385300487
+      instructions: 1385300187
       heap_increase: 73
       stable_memory_increase: 0
     scopes:
       validate:
         calls: 1
-        instructions: 149626193
+        instructions: 149625740
         heap_increase: 20
         stable_memory_increase: 0
       validate_block:
         calls: 1
-        instructions: 149520377
+        instructions: 149519946
         heap_increase: 20
         stable_memory_increase: 0
       validate_block/check_merkle_root:
         calls: 1
-        instructions: 70700188
+        instructions: 70700320
         heap_increase: 0
         stable_memory_increase: 0
       validate_block/ensure_unique_transactions:
         calls: 1
-        instructions: 78815499
+        instructions: 78815068
         heap_increase: 20
         stable_memory_increase: 0
       validate_header:
         calls: 1
-        instructions: 102962
+        instructions: 102940
         heap_increase: 0
         stable_memory_increase: 0
   insert_block_with_1k_transactions:
     total:
       calls: 1
-      instructions: 114485451
+      instructions: 114485268
       heap_increase: 7
       stable_memory_increase: 0
     scopes:
       validate:
         calls: 1
-        instructions: 15141385
+        instructions: 15141281
         heap_increase: 2
         stable_memory_increase: 0
       validate_block:
         calls: 1
-        instructions: 15035569
+        instructions: 15035487
         heap_increase: 2
         stable_memory_increase: 0
       validate_block/check_merkle_root:
         calls: 1
-        instructions: 7117672
+        instructions: 7117870
         heap_increase: 0
         stable_memory_increase: 0
       validate_block/ensure_unique_transactions:
         calls: 1
-        instructions: 7913207
+        instructions: 7913059
         heap_increase: 2
         stable_memory_increase: 0
       validate_header:
         calls: 1
-        instructions: 102962
+        instructions: 102940
         heap_increase: 0
         stable_memory_increase: 0
   pre_upgrade_with_many_unstable_blocks:
     total:
       calls: 1
-      instructions: 5412471948
+      instructions: 5377789603
       heap_increase: 4088
       stable_memory_increase: 1792
     scopes:
       serialize_blocktree_flatten:
         calls: 1
-        instructions: 186219
+        instructions: 187325
         heap_increase: 0
         stable_memory_increase: 0
       serialize_blocktree_serialize_seq:
         calls: 1
-        instructions: 1929069386
+        instructions: 1917674254
         heap_increase: 2039
         stable_memory_increase: 0
 version: 0.4.0

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -16,14 +16,14 @@ benches:
   bitcoin_get_block_headers_baseline:
     total:
       calls: 1
-      instructions: 478427
+      instructions: 535970
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_block_headers_stress:
     total:
       calls: 1
-      instructions: 12454451
+      instructions: 12511954
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -51,7 +51,7 @@ benches:
   get_blockchain_info_many_branches:
     total:
       calls: 1
-      instructions: 5345941
+      instructions: 5346062
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -65,32 +65,32 @@ benches:
   get_blockchain_info_with_forks:
     total:
       calls: 1
-      instructions: 3651180
+      instructions: 3651079
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_metrics:
     total:
       calls: 1
-      instructions: 10108864
+      instructions: 10108897
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   insert_300_blocks:
     total:
       calls: 1
-      instructions: 419630067
+      instructions: 419581318
       heap_increase: 13
       stable_memory_increase: 0
     scopes:
       validate:
         calls: 300
-        instructions: 368058498
+        instructions: 368056051
         heap_increase: 3
         stable_memory_increase: 0
       validate_block:
         calls: 300
-        instructions: 18302679
+        instructions: 18301834
         heap_increase: 1
         stable_memory_increase: 0
       validate_block/check_merkle_root:
@@ -100,12 +100,12 @@ benches:
         stable_memory_increase: 0
       validate_block/ensure_unique_transactions:
         calls: 300
-        instructions: 8464899
+        instructions: 8464054
         heap_increase: 0
         stable_memory_increase: 0
       validate_header:
         calls: 300
-        instructions: 348636989
+        instructions: 348635387
         heap_increase: 0
         stable_memory_increase: 0
   insert_block_headers:
@@ -135,18 +135,18 @@ benches:
   insert_block_with_10k_transactions:
     total:
       calls: 1
-      instructions: 1385301165
+      instructions: 1385300487
       heap_increase: 73
       stable_memory_increase: 0
     scopes:
       validate:
         calls: 1
-        instructions: 149626836
+        instructions: 149626193
         heap_increase: 20
         stable_memory_increase: 0
       validate_block:
         calls: 1
-        instructions: 149521020
+        instructions: 149520377
         heap_increase: 20
         stable_memory_increase: 0
       validate_block/check_merkle_root:
@@ -156,7 +156,7 @@ benches:
         stable_memory_increase: 0
       validate_block/ensure_unique_transactions:
         calls: 1
-        instructions: 78816053
+        instructions: 78815499
         heap_increase: 20
         stable_memory_increase: 0
       validate_header:
@@ -167,18 +167,18 @@ benches:
   insert_block_with_1k_transactions:
     total:
       calls: 1
-      instructions: 114485981
+      instructions: 114485451
       heap_increase: 7
       stable_memory_increase: 0
     scopes:
       validate:
         calls: 1
-        instructions: 15142028
+        instructions: 15141385
         heap_increase: 2
         stable_memory_increase: 0
       validate_block:
         calls: 1
-        instructions: 15036212
+        instructions: 15035569
         heap_increase: 2
         stable_memory_increase: 0
       validate_block/check_merkle_root:
@@ -188,7 +188,7 @@ benches:
         stable_memory_increase: 0
       validate_block/ensure_unique_transactions:
         calls: 1
-        instructions: 7913761
+        instructions: 7913207
         heap_increase: 2
         stable_memory_increase: 0
       validate_header:
@@ -199,7 +199,7 @@ benches:
   pre_upgrade_with_many_unstable_blocks:
     total:
       calls: 1
-      instructions: 5412471943
+      instructions: 5412471948
       heap_increase: 4088
       stable_memory_increase: 1792
     scopes:

--- a/canister/proptest-regressions/api/get_utxos.txt
+++ b/canister/proptest-regressions/api/get_utxos.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 144288837c91f91a5d4266925755783006ecf982d4bbe3a2846dae7672805d35 # shrinks to num_transactions = 1, num_blocks = 2, utxo_limit = 10

--- a/canister/proptest-regressions/tests/confirmation_counts.txt
+++ b/canister/proptest-regressions/tests/confirmation_counts.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 39b9eef7bcd123ffa0828836270c48f2c6b7a9229c764958b49c23a77efe6967 # shrinks to chain_len = 2
+cc cf669bc68d3dce79b0f8214a7f6ad25dd4864d28f432ee8bcb46ea0c8eec12d9 # shrinks to chain_len = 9, fork_idx = 0

--- a/canister/src/api.rs
+++ b/canister/src/api.rs
@@ -7,6 +7,7 @@ mod send_transaction;
 pub(crate) mod set_config;
 pub use fee_percentiles::get_current_fee_percentiles;
 pub(crate) use fee_percentiles::get_current_fee_percentiles_impl;
+pub(crate) use fee_percentiles::get_tx_fee_per_byte;
 #[cfg(feature = "canbench-rs")]
 pub use fee_percentiles::get_current_fee_percentiles_without_fees;
 pub use get_balance::get_balance;

--- a/canister/src/api.rs
+++ b/canister/src/api.rs
@@ -7,9 +7,9 @@ mod send_transaction;
 pub(crate) mod set_config;
 pub use fee_percentiles::get_current_fee_percentiles;
 pub(crate) use fee_percentiles::get_current_fee_percentiles_impl;
-pub(crate) use fee_percentiles::get_tx_fee_per_byte;
 #[cfg(feature = "canbench-rs")]
 pub use fee_percentiles::get_current_fee_percentiles_without_fees;
+pub(crate) use fee_percentiles::get_tx_fee_per_byte;
 pub use get_balance::get_balance;
 pub use get_balance::get_balance_query;
 pub use get_block_headers::get_block_headers;

--- a/canister/src/api.rs
+++ b/canister/src/api.rs
@@ -9,7 +9,6 @@ pub use fee_percentiles::get_current_fee_percentiles;
 pub(crate) use fee_percentiles::get_current_fee_percentiles_impl;
 #[cfg(feature = "canbench-rs")]
 pub use fee_percentiles::get_current_fee_percentiles_without_fees;
-pub(crate) use fee_percentiles::get_tx_fee_per_byte;
 pub use get_balance::get_balance;
 pub use get_balance::get_balance_query;
 pub use get_block_headers::get_block_headers;

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -136,26 +136,17 @@ fn get_tx_fee_per_byte(
         return None;
     }
 
-    let mut satoshi = 0;
+    let mut input_sum: u64 = 0;
     for tx_in in tx.input() {
         let outpoint = (&tx_in.previous_output).into();
-        satoshi += unstable_blocks
+        input_sum += unstable_blocks
             .get_tx_out(&outpoint)
             .unwrap_or_else(|| panic!("tx out of outpoint {:?} must exist", outpoint))
             .0
             .value;
     }
-    for tx_out in tx.output() {
-        satoshi -= tx_out.value.to_sat();
-    }
-
-    if tx.vsize() > 0 {
-        // Don't use floating point division to avoid non-determinism.
-        Some(((1000 * satoshi) / tx.vsize() as u64) as MillisatoshiPerByte)
-    } else {
-        // Calculating fee is not possible for a zero-size invalid transaction.
-        None
-    }
+    let output_sum: u64 = tx.output().iter().map(|o| o.value.to_sat()).sum();
+    crate::types::fee_rate_per_vbyte(input_sum - output_sum, tx.vsize())
 }
 
 /// Compute percentiles of input values.

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -667,4 +667,103 @@ mod test {
             assert_eq!(x, vec![fee_per_vsize; PERCENTILE_BUCKETS]);
         });
     }
+
+    #[test]
+    fn block_fees_are_populated_during_insert() {
+        let number_of_blocks = 5;
+        let blocks = generate_blocks(10_000, number_of_blocks);
+        let stability_threshold = blocks.len() as u128;
+        init_state(blocks, stability_threshold);
+
+        with_state(|state| {
+            let main_chain = unstable_blocks::get_main_chain(&state.unstable_blocks);
+            // Every block on the main chain should have cached fees.
+            for block in main_chain.into_chain() {
+                let cached = state
+                    .unstable_blocks
+                    .get_block_fees(block.block_hash());
+                // The genesis block (anchor) has no cached fees (it was inserted
+                // via `new`, not `push`). All other blocks should have fees.
+                if block.txdata().iter().any(|tx| !tx.is_coinbase()) {
+                    assert!(cached.is_some(), "block {} should have cached fees", block.block_hash());
+                }
+            }
+
+            // Verify the cached fees match what get_fees_per_byte returns.
+            let main_chain = unstable_blocks::get_main_chain(&state.unstable_blocks);
+            let fees = get_fees_per_byte(
+                main_chain.into_chain(),
+                &state.unstable_blocks,
+                10_000,
+            );
+            assert_eq!(fees.len(), number_of_blocks as usize);
+            assert_eq!(fees, vec![33, 25, 16, 8, 0]);
+        });
+    }
+
+    #[test]
+    fn block_fees_are_cleaned_up_on_stable_block_ingestion() {
+        let number_of_blocks = 5;
+        let blocks = generate_blocks(10_000, number_of_blocks);
+        // Low stability threshold so blocks become stable quickly.
+        let stability_threshold = 2;
+        init_state(blocks.clone(), stability_threshold);
+
+        // After init_state, some blocks have been ingested into the UTXO set.
+        // Verify that their fees were cleaned up.
+        with_state(|state| {
+            let stable_height = state.stable_height();
+            assert!(stable_height > 0, "some blocks should be stable");
+
+            // Blocks that were ingested (stable) should NOT have cached fees.
+            // Only blocks still in the unstable tree should have them.
+            let unstable_hashes: Vec<_> = state::get_block_hashes(state);
+            for hash in &unstable_hashes {
+                // Blocks in the unstable tree that have transactions should have fees.
+                // (The anchor block may or may not depending on whether it was re-inserted.)
+                let _fees = state.unstable_blocks.get_block_fees(hash);
+                // Just checking it doesn't panic.
+            }
+
+            // The first blocks (now stable) should not have cached fees.
+            let block_0_hash = blocks[0].block_hash();
+            assert!(
+                state.unstable_blocks.get_block_fees(block_0_hash).is_none(),
+                "stable block should not have cached fees"
+            );
+        });
+    }
+
+    #[test]
+    fn correct_fees_after_upgrade_with_empty_block_fees_cache() {
+        let number_of_blocks = 5;
+        let blocks = generate_blocks(10_000, number_of_blocks);
+        let stability_threshold = blocks.len() as u128;
+        init_state(blocks, stability_threshold);
+
+        // Verify fees are correct before simulating upgrade.
+        let percentiles_before = get_current_fee_percentiles();
+        assert_eq!(percentiles_before.len(), PERCENTILE_BUCKETS);
+
+        // Simulate upgrade: clear the block_fees cache and the fee percentiles cache.
+        with_state_mut(|state| {
+            state.unstable_blocks.clear_block_fees();
+            state.fee_percentiles_cache = None;
+        });
+
+        // Verify that all cached block fees are gone.
+        with_state(|state| {
+            let main_chain = unstable_blocks::get_main_chain(&state.unstable_blocks);
+            for block in main_chain.into_chain() {
+                assert!(
+                    state.unstable_blocks.get_block_fees(block.block_hash()).is_none(),
+                    "block fees should be empty after simulated upgrade"
+                );
+            }
+        });
+
+        // Fee percentiles should still be correct via the fallback path.
+        let percentiles_after = get_current_fee_percentiles();
+        assert_eq!(percentiles_after, percentiles_before);
+    }
 }

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -747,9 +747,9 @@ mod test {
         let percentiles_before = get_current_fee_percentiles();
         assert_eq!(percentiles_before.len(), PERCENTILE_BUCKETS);
 
-        // Simulate upgrade: clear the block_fee_rates cache and the fee percentiles cache.
+        // Simulate upgrade: clear the block_metrics cache and the fee percentiles cache.
         with_state_mut(|state| {
-            state.unstable_blocks.clear_block_fee_rates();
+            state.unstable_blocks.clear_block_metrics();
             state.fee_percentiles_cache = None;
         });
 

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -124,7 +124,7 @@ fn get_fees_per_byte(
 }
 
 /// Computes the fees per byte of the given transaction.
-pub(crate) fn get_tx_fee_per_byte(
+fn get_tx_fee_per_byte(
     tx: &Transaction,
     unstable_blocks: &UnstableBlocks,
 ) -> Option<MillisatoshiPerByte> {

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -679,23 +679,21 @@ mod test {
             let main_chain = unstable_blocks::get_main_chain(&state.unstable_blocks);
             // Every block on the main chain should have cached fees.
             for block in main_chain.into_chain() {
-                let cached = state
-                    .unstable_blocks
-                    .get_block_fees(block.block_hash());
+                let cached = state.unstable_blocks.get_block_fees(block.block_hash());
                 // The genesis block (anchor) has no cached fees (it was inserted
                 // via `new`, not `push`). All other blocks should have fees.
                 if block.txdata().iter().any(|tx| !tx.is_coinbase()) {
-                    assert!(cached.is_some(), "block {} should have cached fees", block.block_hash());
+                    assert!(
+                        cached.is_some(),
+                        "block {} should have cached fees",
+                        block.block_hash()
+                    );
                 }
             }
 
             // Verify the cached fees match what get_fees_per_byte returns.
             let main_chain = unstable_blocks::get_main_chain(&state.unstable_blocks);
-            let fees = get_fees_per_byte(
-                main_chain.into_chain(),
-                &state.unstable_blocks,
-                10_000,
-            );
+            let fees = get_fees_per_byte(main_chain.into_chain(), &state.unstable_blocks, 10_000);
             assert_eq!(fees.len(), number_of_blocks as usize);
             assert_eq!(fees, vec![33, 25, 16, 8, 0]);
         });
@@ -756,7 +754,10 @@ mod test {
             let main_chain = unstable_blocks::get_main_chain(&state.unstable_blocks);
             for block in main_chain.into_chain() {
                 assert!(
-                    state.unstable_blocks.get_block_fees(block.block_hash()).is_none(),
+                    state
+                        .unstable_blocks
+                        .get_block_fees(block.block_hash())
+                        .is_none(),
                     "block fees should be empty after simulated upgrade"
                 );
             }

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -104,7 +104,7 @@ fn get_fees_per_byte(
 
         // Use cached fees if available, otherwise compute from transactions.
         let block_fee_rates: Cow<'_, [MillisatoshiPerByte]> =
-            match unstable_blocks.get_block_fees(block.block_hash()) {
+            match unstable_blocks.get_block_fee_rates(block.block_hash()) {
                 Some(cached) => Cow::Borrowed(cached),
                 None => Cow::Owned(
                     block
@@ -664,7 +664,7 @@ mod test {
     }
 
     #[test]
-    fn block_fees_are_populated_during_insert() {
+    fn block_fee_rates_are_populated_during_insert() {
         let number_of_blocks = 5;
         let blocks = generate_blocks(10_000, number_of_blocks);
         let stability_threshold = blocks.len() as u128;
@@ -672,63 +672,72 @@ mod test {
 
         with_state(|state| {
             let main_chain = unstable_blocks::get_main_chain(&state.unstable_blocks);
-            // Every block on the main chain should have cached fees.
-            for block in main_chain.into_chain() {
-                let cached = state.unstable_blocks.get_block_fees(block.block_hash());
-                // The genesis block (anchor) has no cached fees (it was inserted
-                // via `new`, not `push`). All other blocks should have fees.
-                if block.txdata().iter().any(|tx| !tx.is_coinbase()) {
-                    assert!(
-                        cached.is_some(),
-                        "block {} should have cached fees",
-                        block.block_hash()
-                    );
+            let chain = main_chain.into_chain();
+
+            // Every block on the main chain should have cached fees except the genesis block.
+            // Collect them (most recent first) to compare against get_fees_per_byte.
+            let mut cached_fees: Vec<MillisatoshiPerByte> = Vec::new();
+            for block in chain.iter().rev() {
+                if let Some(rates) = state
+                    .unstable_blocks
+                    .get_block_fee_rates(block.block_hash())
+                {
+                    cached_fees.extend_from_slice(rates);
                 }
             }
+            assert_eq!(cached_fees.len(), number_of_blocks as usize);
 
             // Verify the cached fees match what get_fees_per_byte returns.
             let main_chain = unstable_blocks::get_main_chain(&state.unstable_blocks);
-            let fees = get_fees_per_byte(main_chain.into_chain(), &state.unstable_blocks, 10_000);
-            assert_eq!(fees.len(), number_of_blocks as usize);
-            assert_eq!(fees, vec![33, 25, 16, 8, 0]);
+            let fee_rates =
+                get_fees_per_byte(main_chain.into_chain(), &state.unstable_blocks, 10_000);
+            assert_eq!(fee_rates, cached_fees);
         });
     }
 
     #[test]
-    fn block_fees_are_cleaned_up_on_stable_block_ingestion() {
-        let number_of_blocks = 5;
+    fn block_fee_rates_are_cleaned_up_on_stable_block_ingestion() {
+        let number_of_blocks = 10;
         let blocks = generate_blocks(10_000, number_of_blocks);
-        // Low stability threshold so blocks become stable quickly.
-        let stability_threshold = 2;
+        let stability_threshold = 5;
         init_state(blocks.clone(), stability_threshold);
 
         // After init_state, some blocks have been ingested into the UTXO set.
-        // Verify that their fees were cleaned up.
+        // Verify that stable blocks had their fees cleaned up and unstable blocks kept theirs.
         with_state(|state| {
-            let stable_height = state.stable_height();
-            assert!(stable_height > 0, "some blocks should be stable");
+            let unstable_chain = unstable_blocks::get_main_chain(&state.unstable_blocks)
+                .into_chain();
+            let num_stable = blocks.len() - unstable_chain.len();
+            assert!(num_stable > 0, "some blocks should be stable");
 
-            // Blocks that were ingested (stable) should NOT have cached fees.
-            // Only blocks still in the unstable tree should have them.
-            let unstable_hashes: Vec<_> = state::get_block_hashes(state);
-            for hash in &unstable_hashes {
-                // Blocks in the unstable tree that have transactions should have fees.
-                // (The anchor block may or may not depending on whether it was re-inserted.)
-                let _fees = state.unstable_blocks.get_block_fees(hash);
-                // Just checking it doesn't panic.
+            // Stable blocks (popped from the unstable tree) should NOT have cached fees.
+            for block in &blocks[..num_stable] {
+                assert!(
+                    state
+                        .unstable_blocks
+                        .get_block_fee_rates(block.block_hash())
+                        .is_none(),
+                    "stable block {} should not have cached fees",
+                    block.block_hash()
+                );
             }
 
-            // The first blocks (now stable) should not have cached fees.
-            let block_0_hash = blocks[0].block_hash();
-            assert!(
-                state.unstable_blocks.get_block_fees(block_0_hash).is_none(),
-                "stable block should not have cached fees"
-            );
+            // Unstable blocks (excluding the anchor) should have cached fees.
+            for block in unstable_chain.iter().skip(1) {
+                assert!(
+                    state
+                        .unstable_blocks
+                        .get_block_fee_rates(block.block_hash())
+                        .is_some(),
+                    "unstable block {} should have cached fees",
+                    block.block_hash()
+                );
+            }
         });
     }
 
     #[test]
-    fn correct_fees_after_upgrade_with_empty_block_fees_cache() {
+    fn correct_fees_after_upgrade_with_empty_block_fee_rates_cache() {
         let number_of_blocks = 5;
         let blocks = generate_blocks(10_000, number_of_blocks);
         let stability_threshold = blocks.len() as u128;
@@ -738,9 +747,9 @@ mod test {
         let percentiles_before = get_current_fee_percentiles();
         assert_eq!(percentiles_before.len(), PERCENTILE_BUCKETS);
 
-        // Simulate upgrade: clear the block_fees cache and the fee percentiles cache.
+        // Simulate upgrade: clear the block_fee_rates cache and the fee percentiles cache.
         with_state_mut(|state| {
-            state.unstable_blocks.clear_block_fees();
+            state.unstable_blocks.clear_block_fee_rates();
             state.fee_percentiles_cache = None;
         });
 
@@ -751,7 +760,7 @@ mod test {
                 assert!(
                     state
                         .unstable_blocks
-                        .get_block_fees(block.block_hash())
+                        .get_block_fee_rates(block.block_hash())
                         .is_none(),
                     "block fees should be empty after simulated upgrade"
                 );

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -85,7 +85,7 @@ fn get_current_fee_percentiles_with_number_of_transactions(
     fee_percentiles
 }
 
-/// Returns the fees per byte of the last `number_of_transactions` transactions on the main chain.
+/// Returns the fees per vbyte of the last `number_of_transactions` transactions on the main chain.
 /// Reads pre-computed fee rates from the block_fees cache in unstable blocks.
 /// Falls back to computing fees from transactions directly for blocks without
 /// cached fees (e.g. blocks already in the tree at upgrade time).
@@ -126,7 +126,7 @@ fn get_fees_per_byte(
     fees
 }
 
-/// Computes the fees per byte of the given transaction.
+/// Computes the fees per vbyte of the given transaction.
 fn get_tx_fee_per_byte(
     tx: &Transaction,
     unstable_blocks: &UnstableBlocks,

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -84,28 +84,26 @@ fn get_current_fee_percentiles_with_number_of_transactions(
     fee_percentiles
 }
 
-/// Computes the fees per byte of the last `number_of_transactions` transactions on the main chain.
-/// Fees are returned in a reversed order, starting with the most recent ones, followed by the older ones.
-/// Eg. for transactions [..., Tn-2, Tn-1, Tn] fees would be [Fn, Fn-1, Fn-2, ...].
+/// Returns the fees per byte of the last `number_of_transactions` transactions on the main chain.
+/// Reads pre-computed fee rates from the block_fees cache in unstable blocks.
+/// Fees are returned starting with the most recent transactions.
 fn get_fees_per_byte(
     main_chain: Vec<&Block>,
     unstable_blocks: &UnstableBlocks,
     number_of_transactions: u32,
 ) -> Vec<MillisatoshiPerByte> {
     let mut fees = Vec::new();
-    let mut tx_i = 0;
+    let mut tx_count: u32 = 0;
     for block in main_chain.iter().rev() {
-        if tx_i >= number_of_transactions {
+        if tx_count >= number_of_transactions {
             break;
         }
-        for tx in block.txdata() {
-            if tx_i >= number_of_transactions {
-                break;
-            }
-            if !tx.is_coinbase() {
-                tx_i += 1;
-            }
-            if let Some(fee) = get_tx_fee_per_byte(tx, unstable_blocks) {
+        if let Some(block_fee_rates) = unstable_blocks.get_block_fees(block.block_hash()) {
+            for &fee in block_fee_rates {
+                if tx_count >= number_of_transactions {
+                    break;
+                }
+                tx_count += 1;
                 fees.push(fee);
             }
         }
@@ -114,7 +112,7 @@ fn get_fees_per_byte(
 }
 
 /// Computes the fees per byte of the given transaction.
-fn get_tx_fee_per_byte(
+pub(crate) fn get_tx_fee_per_byte(
     tx: &Transaction,
     unstable_blocks: &UnstableBlocks,
 ) -> Option<MillisatoshiPerByte> {

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -146,7 +146,8 @@ fn get_tx_fee_per_byte(
             .value;
     }
     let output_sum: u64 = tx.output().iter().map(|o| o.value.to_sat()).sum();
-    crate::types::fee_rate_per_vbyte(input_sum - output_sum, tx.vsize())
+    let fee_satoshi = input_sum.checked_sub(output_sum)?;
+    crate::types::fee_rate_per_vbyte(fee_satoshi, tx.vsize())
 }
 
 /// Compute percentiles of input values.

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -86,6 +86,8 @@ fn get_current_fee_percentiles_with_number_of_transactions(
 
 /// Returns the fees per byte of the last `number_of_transactions` transactions on the main chain.
 /// Reads pre-computed fee rates from the block_fees cache in unstable blocks.
+/// Falls back to computing fees from transactions directly for blocks without
+/// cached fees (e.g. blocks already in the tree at upgrade time).
 /// Fees are returned starting with the most recent transactions.
 fn get_fees_per_byte(
     main_chain: Vec<&Block>,
@@ -98,14 +100,24 @@ fn get_fees_per_byte(
         if tx_count >= number_of_transactions {
             break;
         }
-        if let Some(block_fee_rates) = unstable_blocks.get_block_fees(block.block_hash()) {
-            for &fee in block_fee_rates {
-                if tx_count >= number_of_transactions {
-                    break;
-                }
-                tx_count += 1;
-                fees.push(fee);
+
+        // Use cached fees if available, otherwise compute from transactions.
+        let block_fee_rates: Vec<MillisatoshiPerByte> =
+            match unstable_blocks.get_block_fees(block.block_hash()) {
+                Some(cached) => cached.to_vec(),
+                None => block
+                    .txdata()
+                    .iter()
+                    .filter_map(|tx| get_tx_fee_per_byte(tx, unstable_blocks))
+                    .collect(),
+            };
+
+        for &fee in &block_fee_rates {
+            if tx_count >= number_of_transactions {
+                break;
             }
+            tx_count += 1;
+            fees.push(fee);
         }
     }
     fees

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use ic_btc_interface::MillisatoshiPerByte;
 use ic_btc_types::{Block, Transaction};
+use std::borrow::Cow;
 
 /// The number of transactions to include in the percentiles calculation.
 const NUM_TRANSACTIONS: u32 = 10_000;
@@ -102,17 +103,19 @@ fn get_fees_per_byte(
         }
 
         // Use cached fees if available, otherwise compute from transactions.
-        let block_fee_rates: Vec<MillisatoshiPerByte> =
+        let block_fee_rates: Cow<'_, [MillisatoshiPerByte]> =
             match unstable_blocks.get_block_fees(block.block_hash()) {
-                Some(cached) => cached.to_vec(),
-                None => block
-                    .txdata()
-                    .iter()
-                    .filter_map(|tx| get_tx_fee_per_byte(tx, unstable_blocks))
-                    .collect(),
+                Some(cached) => Cow::Borrowed(cached),
+                None => Cow::Owned(
+                    block
+                        .txdata()
+                        .iter()
+                        .filter_map(|tx| get_tx_fee_per_byte(tx, unstable_blocks))
+                        .collect(),
+                ),
             };
 
-        for &fee in &block_fee_rates {
+        for &fee in block_fee_rates.iter() {
             if tx_count >= number_of_transactions {
                 break;
             }

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -705,8 +705,8 @@ mod test {
         // After init_state, some blocks have been ingested into the UTXO set.
         // Verify that stable blocks had their fees cleaned up and unstable blocks kept theirs.
         with_state(|state| {
-            let unstable_chain = unstable_blocks::get_main_chain(&state.unstable_blocks)
-                .into_chain();
+            let unstable_chain =
+                unstable_blocks::get_main_chain(&state.unstable_blocks).into_chain();
             let num_stable = blocks.len() - unstable_chain.len();
             assert!(num_stable > 0, "some blocks should be stable");
 

--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -614,6 +614,7 @@ pub fn into_bitcoin_network(network: Network) -> BitcoinNetwork {
 /// Returns `None` if `vsize` is zero.
 pub fn fee_rate_per_vbyte(fee_satoshi: u64, vsize: usize) -> Option<MillisatoshiPerByte> {
     if vsize > 0 {
+        // Don't use floating point division to avoid non-determinism.
         Some(((1000 * fee_satoshi) / vsize as u64) as MillisatoshiPerByte)
     } else {
         None

--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -6,8 +6,8 @@ use candid::CandidType;
 use datasize::DataSize;
 use ic_btc_interface::{
     Address as AddressStr, GetBalanceRequest as PublicGetBalanceRequest,
-    GetUtxosRequest as PublicGetUtxosRequest, Height, Network, Satoshi, UtxosFilter,
-    UtxosFilterInRequest,
+    GetUtxosRequest as PublicGetUtxosRequest, Height, MillisatoshiPerByte, Network, Satoshi,
+    UtxosFilter, UtxosFilterInRequest,
 };
 use ic_btc_types::{BlockHash, OutPoint, Txid};
 use ic_stable_structures::{
@@ -606,6 +606,17 @@ pub fn into_bitcoin_network(network: Network) -> BitcoinNetwork {
         Network::Mainnet => BitcoinNetwork::Bitcoin,
         Network::Testnet => BitcoinNetwork::Testnet4,
         Network::Regtest => BitcoinNetwork::Regtest,
+    }
+}
+
+/// Computes the fee rate in millisatoshi per byte for a transaction
+/// given its total fee in satoshi and its virtual size.
+/// Returns `None` if `vsize` is zero.
+pub fn fee_rate_per_vbyte(fee_satoshi: u64, vsize: usize) -> Option<MillisatoshiPerByte> {
+    if vsize > 0 {
+        Some(((1000 * fee_satoshi) / vsize as u64) as MillisatoshiPerByte)
+    } else {
+        None
     }
 }
 

--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -609,6 +609,15 @@ pub fn into_bitcoin_network(network: Network) -> BitcoinNetwork {
     }
 }
 
+/// Per-block metrics.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct BlockMetrics {
+    /// Fee rates (millisatoshi per vbyte) for non-coinbase transactions.
+    pub fee_rates: Vec<MillisatoshiPerByte>,
+    /// Net UTXO count change (outputs created - inputs spent).
+    pub utxo_delta: i64,
+}
+
 /// Computes the fee rate in millisatoshi per vbyte for a transaction
 /// given its total fee in satoshi and its virtual size.
 /// Returns `None` if `vsize` is zero.

--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -609,7 +609,7 @@ pub fn into_bitcoin_network(network: Network) -> BitcoinNetwork {
     }
 }
 
-/// Computes the fee rate in millisatoshi per byte for a transaction
+/// Computes the fee rate in millisatoshi per vbyte for a transaction
 /// given its total fee in satoshi and its virtual size.
 /// Returns `None` if `vsize` is zero.
 pub fn fee_rate_per_vbyte(fee_satoshi: u64, vsize: usize) -> Option<MillisatoshiPerByte> {

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -120,6 +120,12 @@ impl UnstableBlocks {
         self.block_fees.get(block_hash).map(|v| v.as_slice())
     }
 
+    /// Clears all cached block fees. Used in tests to simulate post-upgrade state.
+    #[cfg(test)]
+    pub fn clear_block_fees(&mut self) {
+        self.block_fees.clear();
+    }
+
     pub fn stability_threshold(&self) -> u32 {
         self.stability_threshold
     }

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -72,7 +72,7 @@ pub struct UnstableBlocks {
     next_block_headers: NextBlockHeaders,
     // Fee rates (millisatoshi per vbyte) for each block's transactions.
     #[serde(default)]
-    block_fees: BTreeMap<BlockHash, Vec<MillisatoshiPerByte>>,
+    block_fee_rates: BTreeMap<BlockHash, Vec<MillisatoshiPerByte>>,
 }
 
 impl UnstableBlocks {
@@ -89,7 +89,7 @@ impl UnstableBlocks {
             outpoints_cache,
             network,
             next_block_headers: NextBlockHeaders::default(),
-            block_fees: BTreeMap::new(),
+            block_fee_rates: BTreeMap::new(),
         }
     }
 
@@ -117,13 +117,13 @@ impl UnstableBlocks {
 
     /// Returns the pre-computed fee rates for the given block.
     pub fn get_block_fees(&self, block_hash: &BlockHash) -> Option<&[MillisatoshiPerByte]> {
-        self.block_fees.get(block_hash).map(|v| v.as_slice())
+        self.block_fee_rates.get(block_hash).map(|v| v.as_slice())
     }
 
-    /// Clears all cached block fees. Used in tests to simulate post-upgrade state.
+    /// Clears all cached block fee rates. Used in tests to simulate post-upgrade state.
     #[cfg(test)]
     pub fn clear_block_fees(&mut self) {
-        self.block_fees.clear();
+        self.block_fee_rates.clear();
     }
 
     pub fn stability_threshold(&self) -> u32 {
@@ -274,10 +274,10 @@ pub fn pop(blocks: &mut UnstableBlocks, stable_height: Height) -> Option<Block> 
     let mut tree = blocks.tree.remove_child(stable_child_idx);
     std::mem::swap(&mut tree, &mut blocks.tree);
 
-    // Remove the outpoints and fees of obsolete blocks from the cache.
+    // Remove the outpoints and fee rates of obsolete blocks from the cache.
     for block in tree.blocks() {
         blocks.outpoints_cache.remove(block);
-        blocks.block_fees.remove(block.block_hash());
+        blocks.block_fee_rates.remove(block.block_hash());
     }
 
     blocks.next_block_headers.remove_until_height(stable_height);
@@ -306,7 +306,7 @@ pub fn push(
         .outpoints_cache
         .insert(utxos, &block, height)
         .expect("inserting to outpoints cache must succeed.");
-    blocks.block_fees.insert(block_hash, fees);
+    blocks.block_fee_rates.insert(block_hash, fees);
 
     parent_block_tree.extend(block)?;
 

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -79,7 +79,7 @@ impl UnstableBlocks {
     pub fn new(utxos: &UtxoSet, stability_threshold: u32, anchor: Block, network: Network) -> Self {
         // Create a cache of the transaction outputs, starting with the given anchor block.
         let mut outpoints_cache = OutPointsCache::new();
-        let _anchor_fees = outpoints_cache
+        outpoints_cache
             .insert(utxos, &anchor, utxos.next_height())
             .expect("anchor block must be valid.");
 
@@ -115,14 +115,14 @@ impl UnstableBlocks {
         self.outpoints_cache.get_net_utxo_delta(block_hash)
     }
 
-    /// Returns the pre-computed fee rates for the given block.
-    pub fn get_block_fees(&self, block_hash: &BlockHash) -> Option<&[MillisatoshiPerByte]> {
+    /// Returns the fee rates for the given block.
+    pub fn get_block_fee_rates(&self, block_hash: &BlockHash) -> Option<&[MillisatoshiPerByte]> {
         self.block_fee_rates.get(block_hash).map(|v| v.as_slice())
     }
 
     /// Clears all cached block fee rates. Used in tests to simulate post-upgrade state.
     #[cfg(test)]
-    pub fn clear_block_fees(&mut self) {
+    pub fn clear_block_fee_rates(&mut self) {
         self.block_fee_rates.clear();
     }
 

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -70,7 +70,7 @@ pub struct UnstableBlocks {
     network: Network,
     // The headers of the blocks that are expected to be received.
     next_block_headers: NextBlockHeaders,
-    // Pre-computed fee rates (millisatoshi per vbyte) for each block's transactions.
+    // Fee rates (millisatoshi per vbyte) for each block's transactions.
     #[serde(default)]
     block_fees: BTreeMap<BlockHash, Vec<MillisatoshiPerByte>>,
 }

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -79,7 +79,7 @@ impl UnstableBlocks {
     pub fn new(utxos: &UtxoSet, stability_threshold: u32, anchor: Block, network: Network) -> Self {
         // Create a cache of the transaction outputs, starting with the given anchor block.
         let mut outpoints_cache = OutPointsCache::new();
-        outpoints_cache
+        let _anchor_fees = outpoints_cache
             .insert(utxos, &anchor, utxos.next_height())
             .expect("anchor block must be valid.");
 
@@ -302,17 +302,11 @@ pub fn push(
 
     let height = utxos.next_height() + depth + 1;
 
-    blocks
+    // Insert outpoints and compute fee rates in a single pass.
+    let fees = blocks
         .outpoints_cache
         .insert(utxos, &block, height)
         .expect("inserting to outpoints cache must succeed.");
-
-    // Pre-compute fee rates now that the outpoints cache is populated.
-    let fees = block
-        .txdata()
-        .iter()
-        .filter_map(|tx| crate::api::get_tx_fee_per_byte(tx, blocks))
-        .collect();
     blocks.block_fees.insert(block_hash, fees);
 
     blocks.tree.extend(block)?;

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -7,10 +7,11 @@ use crate::{
     UtxoSet,
 };
 use bitcoin::block::Header;
-use ic_btc_interface::{Height, Network};
+use ic_btc_interface::{Height, MillisatoshiPerByte, Network};
 use ic_btc_types::{Block, BlockHash, OutPoint};
 use outpoints_cache::OutPointsCache;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 mod next_block_headers;
 use self::next_block_headers::NextBlockHeaders;
@@ -69,6 +70,9 @@ pub struct UnstableBlocks {
     network: Network,
     // The headers of the blocks that are expected to be received.
     next_block_headers: NextBlockHeaders,
+    // Pre-computed fee rates (millisatoshi per vbyte) for each block's transactions.
+    #[serde(default)]
+    block_fees: BTreeMap<BlockHash, Vec<MillisatoshiPerByte>>,
 }
 
 impl UnstableBlocks {
@@ -85,6 +89,7 @@ impl UnstableBlocks {
             outpoints_cache,
             network,
             next_block_headers: NextBlockHeaders::default(),
+            block_fees: BTreeMap::new(),
         }
     }
 
@@ -108,6 +113,11 @@ impl UnstableBlocks {
     /// Returns the net UTXO count change for the given block (added - removed).
     pub fn get_net_utxo_delta(&self, block_hash: &BlockHash) -> i64 {
         self.outpoints_cache.get_net_utxo_delta(block_hash)
+    }
+
+    /// Returns the pre-computed fee rates for the given block.
+    pub fn get_block_fees(&self, block_hash: &BlockHash) -> Option<&[MillisatoshiPerByte]> {
+        self.block_fees.get(block_hash).map(|v| v.as_slice())
     }
 
     pub fn stability_threshold(&self) -> u32 {
@@ -258,9 +268,10 @@ pub fn pop(blocks: &mut UnstableBlocks, stable_height: Height) -> Option<Block> 
     let mut tree = blocks.tree.remove_child(stable_child_idx);
     std::mem::swap(&mut tree, &mut blocks.tree);
 
-    // Remove the outpoints of obsolete blocks from the cache.
+    // Remove the outpoints and fees of obsolete blocks from the cache.
     for block in tree.blocks() {
         blocks.outpoints_cache.remove(block);
+        blocks.block_fees.remove(block.block_hash());
     }
 
     blocks.next_block_headers.remove_until_height(stable_height);
@@ -277,7 +288,8 @@ pub fn push(
     block: Block,
 ) -> Result<(), BlockDoesNotExtendTree> {
     let block_hash = *block.block_hash();
-    let (parent_block_tree, depth) = blocks
+
+    let (_, depth) = blocks
         .tree
         .find_mut(&block.header().prev_blockhash.into())
         .ok_or(BlockDoesNotExtendTree(block_hash))?;
@@ -289,7 +301,15 @@ pub fn push(
         .insert(utxos, &block, height)
         .expect("inserting to outpoints cache must succeed.");
 
-    parent_block_tree.extend(block)?;
+    // Pre-compute fee rates now that the outpoints cache is populated.
+    let fees = block
+        .txdata()
+        .iter()
+        .filter_map(|tx| crate::api::get_tx_fee_per_byte(tx, blocks))
+        .collect();
+    blocks.block_fees.insert(block_hash, fees);
+
+    blocks.tree.extend(block)?;
 
     blocks.next_block_headers.remove(&block_hash);
 

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -3,13 +3,13 @@ mod outpoints_cache;
 use crate::{
     blocktree::{BlockChain, BlockDoesNotExtendTree, BlockTree, Depth, DifficultyBasedDepth},
     runtime::print,
-    types::{Address, TxOut},
+    types::{Address, BlockMetrics, TxOut},
     UtxoSet,
 };
 use bitcoin::block::Header;
 use ic_btc_interface::{Height, MillisatoshiPerByte, Network};
 use ic_btc_types::{Block, BlockHash, OutPoint};
-use outpoints_cache::OutPointsCache;
+use outpoints_cache::{insert_outpoints, OutPointsCache};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -70,18 +70,21 @@ pub struct UnstableBlocks {
     network: Network,
     // The headers of the blocks that are expected to be received.
     next_block_headers: NextBlockHeaders,
-    // Fee rates (millisatoshi per vbyte) for each block's transactions.
+    // Per-block metrics (fee rates, UTXO delta, etc.) computed during block processing.
     #[serde(default)]
-    block_fee_rates: BTreeMap<BlockHash, Vec<MillisatoshiPerByte>>,
+    block_metrics: BTreeMap<BlockHash, BlockMetrics>,
 }
 
 impl UnstableBlocks {
     pub fn new(utxos: &UtxoSet, stability_threshold: u32, anchor: Block, network: Network) -> Self {
-        // Create a cache of the transaction outputs, starting with the given anchor block.
+        // Process the anchor block: populate the outpoints cache and compute metrics.
         let mut outpoints_cache = OutPointsCache::new();
-        outpoints_cache
-            .insert(utxos, &anchor, utxos.next_height())
-            .expect("anchor block must be valid.");
+        let anchor_metrics =
+            insert_outpoints(&mut outpoints_cache, utxos, &anchor, utxos.next_height())
+                .expect("anchor block must be valid.");
+
+        let mut block_metrics = BTreeMap::new();
+        block_metrics.insert(*anchor.block_hash(), anchor_metrics);
 
         Self {
             stability_threshold,
@@ -89,7 +92,7 @@ impl UnstableBlocks {
             outpoints_cache,
             network,
             next_block_headers: NextBlockHeaders::default(),
-            block_fee_rates: BTreeMap::new(),
+            block_metrics,
         }
     }
 
@@ -112,18 +115,23 @@ impl UnstableBlocks {
 
     /// Returns the net UTXO count change for the given block (added - removed).
     pub fn get_net_utxo_delta(&self, block_hash: &BlockHash) -> i64 {
-        self.outpoints_cache.get_net_utxo_delta(block_hash)
+        self.block_metrics
+            .get(block_hash)
+            .map(|m| m.utxo_delta)
+            .unwrap_or(0)
     }
 
     /// Returns the fee rates for the given block.
     pub fn get_block_fee_rates(&self, block_hash: &BlockHash) -> Option<&[MillisatoshiPerByte]> {
-        self.block_fee_rates.get(block_hash).map(|v| v.as_slice())
+        self.block_metrics
+            .get(block_hash)
+            .map(|m| m.fee_rates.as_slice())
     }
 
-    /// Clears all cached block fee rates. Used in tests to simulate post-upgrade state.
+    /// Clears all cached block metrics. Used in tests to simulate post-upgrade state.
     #[cfg(test)]
-    pub fn clear_block_fee_rates(&mut self) {
-        self.block_fee_rates.clear();
+    pub fn clear_block_metrics(&mut self) {
+        self.block_metrics.clear();
     }
 
     pub fn stability_threshold(&self) -> u32 {
@@ -274,10 +282,10 @@ pub fn pop(blocks: &mut UnstableBlocks, stable_height: Height) -> Option<Block> 
     let mut tree = blocks.tree.remove_child(stable_child_idx);
     std::mem::swap(&mut tree, &mut blocks.tree);
 
-    // Remove the outpoints and fee rates of obsolete blocks from the cache.
+    // Remove the outpoints and metrics of obsolete blocks from the cache.
     for block in tree.blocks() {
         blocks.outpoints_cache.remove(block);
-        blocks.block_fee_rates.remove(block.block_hash());
+        blocks.block_metrics.remove(block.block_hash());
     }
 
     blocks.next_block_headers.remove_until_height(stable_height);
@@ -301,12 +309,10 @@ pub fn push(
 
     let height = utxos.next_height() + depth + 1;
 
-    // Insert outpoints and compute fee rates in a single pass.
-    let fees = blocks
-        .outpoints_cache
-        .insert(utxos, &block, height)
-        .expect("inserting to outpoints cache must succeed.");
-    blocks.block_fee_rates.insert(block_hash, fees);
+    // Process the block in a single pass: populate the outpoints cache and compute metrics.
+    let metrics = insert_outpoints(&mut blocks.outpoints_cache, utxos, &block, height)
+        .expect("processing block must succeed.");
+    blocks.block_metrics.insert(block_hash, metrics);
 
     parent_block_tree.extend(block)?;
 

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -294,8 +294,7 @@ pub fn push(
     block: Block,
 ) -> Result<(), BlockDoesNotExtendTree> {
     let block_hash = *block.block_hash();
-
-    let (_, depth) = blocks
+    let (parent_block_tree, depth) = blocks
         .tree
         .find_mut(&block.header().prev_blockhash.into())
         .ok_or(BlockDoesNotExtendTree(block_hash))?;
@@ -309,7 +308,7 @@ pub fn push(
         .expect("inserting to outpoints cache must succeed.");
     blocks.block_fees.insert(block_hash, fees);
 
-    blocks.tree.extend(block)?;
+    parent_block_tree.extend(block)?;
 
     blocks.next_block_headers.remove(&block_hash);
 

--- a/canister/src/unstable_blocks/outpoints_cache.rs
+++ b/canister/src/unstable_blocks/outpoints_cache.rs
@@ -74,7 +74,7 @@ impl OutPointsCache {
 
     /// Inserts the outpoints in a block, along with their transaction outputs, into the cache.
     ///
-    /// Also computes and returns fee rates (millisatoshi per byte) for non-coinbase
+    /// Also computes and returns fee rates (millisatoshi per vbyte) for non-coinbase
     /// transactions as a byproduct of the input value lookups already performed here.
     pub fn insert(
         &mut self,

--- a/canister/src/unstable_blocks/outpoints_cache.rs
+++ b/canister/src/unstable_blocks/outpoints_cache.rs
@@ -2,7 +2,7 @@ use crate::{
     types::{Address, TxOut},
     UtxoSet,
 };
-use ic_btc_interface::Height;
+use ic_btc_interface::{Height, MillisatoshiPerByte};
 use ic_btc_types::{Block, BlockHash, OutPoint};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -73,17 +73,21 @@ impl OutPointsCache {
     }
 
     /// Inserts the outpoints in a block, along with their transaction outputs, into the cache.
+    ///
+    /// Also computes and returns fee rates (millisatoshi per byte) for non-coinbase
+    /// transactions as a byproduct of the input value lookups already performed here.
     pub fn insert(
         &mut self,
         utxos: &UtxoSet,
         block: &Block,
         height: Height,
-    ) -> Result<(), TxOutNotFound> {
+    ) -> Result<Vec<MillisatoshiPerByte>, TxOutNotFound> {
         // A map to store all the transaction outputs referenced by the given block.
         let mut tx_outs: BTreeMap<OutPoint, TxOutInfo> = BTreeMap::new();
         let mut removed_outpoints = BTreeMap::new();
         let mut added_outpoints = BTreeMap::new();
         let mut utxo_delta: i64 = 0;
+        let mut block_fees = Vec::new();
 
         // The inputs of a transaction contain outpoints that reference the previous
         // outputs that it is consuming. These outputs can be retrieved from a number
@@ -101,6 +105,8 @@ impl OutPointsCache {
             if !tx.is_coinbase() {
                 utxo_delta -= tx.input().len() as i64;
             }
+
+            let mut input_sum: u64 = 0;
 
             for input in tx.input() {
                 if input.previous_output.is_null() {
@@ -123,6 +129,8 @@ impl OutPointsCache {
                             .ok_or_else(|| TxOutNotFound(outpoint.clone()))?,
                     },
                 };
+
+                input_sum += txout.value;
 
                 if let Ok(address) = Address::from_script(
                     bitcoin::Script::from_bytes(&txout.script_pubkey),
@@ -161,6 +169,14 @@ impl OutPointsCache {
                 });
                 entry.count += 1;
             }
+
+            // Compute fee rate for non-coinbase transactions.
+            if !tx.is_coinbase() && tx.vsize() > 0 {
+                let output_sum: u64 = tx.output().iter().map(|o| o.value.to_sat()).sum();
+                let fee_satoshi = input_sum - output_sum;
+                block_fees
+                    .push(((1000 * fee_satoshi) / tx.vsize() as u64) as MillisatoshiPerByte);
+            }
         }
 
         // Merge all the transaction outputs of this block into the cache.
@@ -177,7 +193,7 @@ impl OutPointsCache {
             .insert(*block.block_hash(), removed_outpoints);
         self.utxo_deltas.insert(*block.block_hash(), utxo_delta);
 
-        Ok(())
+        Ok(block_fees)
     }
 
     /// Removes the outpoints of a block from the cache.

--- a/canister/src/unstable_blocks/outpoints_cache.rs
+++ b/canister/src/unstable_blocks/outpoints_cache.rs
@@ -173,9 +173,10 @@ impl OutPointsCache {
             // Compute fee rate for non-coinbase transactions.
             if !tx.is_coinbase() {
                 let output_sum: u64 = tx.output().iter().map(|o| o.value.to_sat()).sum();
-                let fee_satoshi = input_sum - output_sum;
-                if let Some(rate) = crate::types::fee_rate_per_vbyte(fee_satoshi, tx.vsize()) {
-                    block_fees.push(rate);
+                if let Some(fee_satoshi) = input_sum.checked_sub(output_sum) {
+                    if let Some(rate) = crate::types::fee_rate_per_vbyte(fee_satoshi, tx.vsize()) {
+                        block_fees.push(rate);
+                    }
                 }
             }
         }

--- a/canister/src/unstable_blocks/outpoints_cache.rs
+++ b/canister/src/unstable_blocks/outpoints_cache.rs
@@ -1,11 +1,135 @@
 use crate::{
-    types::{Address, TxOut},
+    types::{Address, BlockMetrics, TxOut},
     UtxoSet,
 };
-use ic_btc_interface::{Height, MillisatoshiPerByte};
+use ic_btc_interface::Height;
 use ic_btc_types::{Block, BlockHash, OutPoint};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+
+/// Caches a block's outpoints and computes [`BlockMetrics`] in a single pass.
+pub fn insert_outpoints(
+    cache: &mut OutPointsCache,
+    utxos: &UtxoSet,
+    block: &Block,
+    height: Height,
+) -> Result<BlockMetrics, TxOutNotFound> {
+    let mut tx_outs: BTreeMap<OutPoint, TxOutInfo> = BTreeMap::new();
+    let mut removed_outpoints = BTreeMap::new();
+    let mut added_outpoints = BTreeMap::new();
+    let mut utxo_delta: i64 = 0;
+    let mut fee_rates = Vec::with_capacity(block.txdata().len().saturating_sub(1));
+
+    // The inputs of a transaction contain outpoints that reference the previous
+    // outputs that it is consuming. These outputs can be retrieved from a number
+    // of sources:
+    //
+    // 1. From the UTXO set, if the outpoint references a tx in a stable block.
+    //
+    // 2. From the block, if the outpoint references a previous tx in the same block.
+    //
+    // 3. From the cache itself, if the outpoint references a tx in an unstable block.
+    //    The assumption here is that this cache already contains all the outpoints
+    //    referenced by the unstable blocks.
+    for tx in block.txdata() {
+        utxo_delta += tx.output().len() as i64;
+        if !tx.is_coinbase() {
+            utxo_delta -= tx.input().len() as i64;
+        }
+
+        let mut input_sum: u64 = 0;
+
+        for input in tx.input() {
+            if input.previous_output.is_null() {
+                continue;
+            }
+
+            let outpoint = (&input.previous_output).into();
+
+            // Lookup the `TxOut` in the current cache.
+            let (txout, height) = match cache.get_tx_out(&outpoint) {
+                Some((txout, height)) => (txout.clone(), height),
+
+                // Lookup the `TxOut` in the current block.
+                None => match tx_outs.get(&outpoint) {
+                    Some(e) => (e.txout.clone(), e.height),
+
+                    // Lookup the `TxOut` in the UTXO set.
+                    None => utxos
+                        .get_utxo(&outpoint)
+                        .ok_or_else(|| TxOutNotFound(outpoint.clone()))?,
+                },
+            };
+
+            input_sum += txout.value;
+
+            if let Ok(address) = Address::from_script(
+                bitcoin::Script::from_bytes(&txout.script_pubkey),
+                utxos.network(),
+            ) {
+                let entry = removed_outpoints.entry(address).or_insert(vec![]);
+                entry.push(outpoint.clone());
+            }
+
+            let entry = tx_outs.entry(outpoint).or_insert(TxOutInfo {
+                txout,
+                height,
+                count: 0,
+            });
+            entry.count += 1;
+        }
+
+        for (i, txout) in tx.output().iter().enumerate() {
+            let outpoint = OutPoint {
+                txid: tx.txid(),
+                vout: i as u32,
+            };
+
+            if let Ok(address) = Address::from_script(&txout.script_pubkey, utxos.network()) {
+                let entry = added_outpoints.entry(address).or_insert(vec![]);
+                entry.push(outpoint.clone());
+            }
+
+            let entry = tx_outs.entry(outpoint.clone()).or_insert(TxOutInfo {
+                txout: txout.into(),
+                height,
+                count: 0,
+            });
+            entry.count += 1;
+        }
+
+        // Compute fee rate for non-coinbase transactions.
+        if !tx.is_coinbase() {
+            let output_sum: u64 = tx.output().iter().map(|o| o.value.to_sat()).sum();
+            if let Some(fee_satoshi) = input_sum.checked_sub(output_sum) {
+                if let Some(rate) = crate::types::fee_rate_per_vbyte(fee_satoshi, tx.vsize()) {
+                    fee_rates.push(rate);
+                }
+            }
+        }
+    }
+
+    // Merge all the transaction outputs of this block into the cache.
+    for (outpoint, tx_out_info) in tx_outs {
+        cache
+            .tx_outs
+            .entry(outpoint)
+            .and_modify(|t| t.count += tx_out_info.count)
+            .or_insert(tx_out_info);
+    }
+
+    cache
+        .added_outpoints
+        .insert(*block.block_hash(), added_outpoints);
+    cache
+        .removed_outpoints
+        .insert(*block.block_hash(), removed_outpoints);
+
+    Ok(BlockMetrics {
+        fee_rates,
+        utxo_delta,
+    })
+}
 
 /// A cache maintaining data related to outpoints in unstable blocks.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -18,10 +142,6 @@ pub struct OutPointsCache {
 
     /// Caches the outpoints removed for each address in a block.
     removed_outpoints: BTreeMap<BlockHash, BTreeMap<Address, Vec<OutPoint>>>,
-
-    /// Caches the net UTXO count change per block (outputs created - inputs spent).
-    #[serde(default)]
-    utxo_deltas: BTreeMap<BlockHash, i64>,
 }
 
 impl OutPointsCache {
@@ -30,7 +150,6 @@ impl OutPointsCache {
             tx_outs: BTreeMap::new(),
             added_outpoints: BTreeMap::new(),
             removed_outpoints: BTreeMap::new(),
-            utxo_deltas: BTreeMap::new(),
         }
     }
 
@@ -60,142 +179,11 @@ impl OutPointsCache {
             .unwrap_or(&[])
     }
 
-    /// Returns the net UTXO count change for the given block (outputs created - inputs spent).
-    pub fn get_net_utxo_delta(&self, block_hash: &BlockHash) -> i64 {
-        self.utxo_deltas.get(block_hash).copied().unwrap_or(0)
-    }
-
     /// Retrieves the `TxOut` associated with the given `outpoint`, along with its height.
     pub fn get_tx_out(&self, outpoint: &OutPoint) -> Option<(&TxOut, Height)> {
         self.tx_outs
             .get(outpoint)
             .map(|info| (&info.txout, info.height))
-    }
-
-    /// Inserts the outpoints in a block, along with their transaction outputs, into the cache.
-    ///
-    /// Also computes and returns fee rates (millisatoshi per vbyte) for non-coinbase
-    /// transactions as a byproduct of the input value lookups already performed here.
-    pub fn insert(
-        &mut self,
-        utxos: &UtxoSet,
-        block: &Block,
-        height: Height,
-    ) -> Result<Vec<MillisatoshiPerByte>, TxOutNotFound> {
-        // A map to store all the transaction outputs referenced by the given block.
-        let mut tx_outs: BTreeMap<OutPoint, TxOutInfo> = BTreeMap::new();
-        let mut removed_outpoints = BTreeMap::new();
-        let mut added_outpoints = BTreeMap::new();
-        let mut utxo_delta: i64 = 0;
-        let mut block_fee_rates = Vec::with_capacity(block.txdata().len().saturating_sub(1));
-
-        // The inputs of a transaction contain outpoints that reference the previous
-        // outputs that it is consuming. These outputs can be retrieved from a number
-        // of sources:
-        //
-        // 1. From the UTXO set, if the outpoint references a tx in a stable block.
-        //
-        // 2. From the block, if the outpoint references a previous tx in the same block.
-        //
-        // 3. From the cache itself, if the outpoint references a tx in an unstable block.
-        //    The assumption here is that this cache already contains all the outpoints
-        //    referenced by the unstable blocks.
-        for tx in block.txdata() {
-            utxo_delta += tx.output().len() as i64;
-            if !tx.is_coinbase() {
-                utxo_delta -= tx.input().len() as i64;
-            }
-
-            let mut input_sum: u64 = 0;
-
-            for input in tx.input() {
-                if input.previous_output.is_null() {
-                    continue;
-                }
-
-                let outpoint = (&input.previous_output).into();
-
-                // Lookup the `TxOut` in the current cache.
-                let (txout, height) = match self.get_tx_out(&outpoint) {
-                    Some((txout, height)) => (txout.clone(), height),
-
-                    // Lookup the `TxOut` in the current block.
-                    None => match tx_outs.get(&outpoint) {
-                        Some(e) => (e.txout.clone(), e.height),
-
-                        // Lookup the `TxOut` in the UTXO set.
-                        None => utxos
-                            .get_utxo(&outpoint)
-                            .ok_or_else(|| TxOutNotFound(outpoint.clone()))?,
-                    },
-                };
-
-                input_sum += txout.value;
-
-                if let Ok(address) = Address::from_script(
-                    bitcoin::Script::from_bytes(&txout.script_pubkey),
-                    utxos.network(),
-                ) {
-                    let entry = removed_outpoints.entry(address).or_insert(vec![]);
-                    entry.push(outpoint.clone());
-                }
-
-                let entry = tx_outs.entry(outpoint).or_insert(TxOutInfo {
-                    txout,
-                    height,
-                    count: 0,
-                });
-                entry.count += 1;
-            }
-
-            // Outputs can be inserted as-is into the cache, maintaining a count of how
-            // many we inserted into the cache that reference them.
-            for (i, txout) in tx.output().iter().enumerate() {
-                let outpoint = OutPoint {
-                    txid: tx.txid(),
-                    vout: i as u32,
-                };
-
-                if let Ok(address) = Address::from_script(&txout.script_pubkey, utxos.network()) {
-                    let entry = added_outpoints.entry(address).or_insert(vec![]);
-                    entry.push(outpoint.clone());
-                }
-
-                // Retrieve the associated entry in the cache and increment its count.
-                let entry = tx_outs.entry(outpoint.clone()).or_insert(TxOutInfo {
-                    txout: txout.into(),
-                    height,
-                    count: 0,
-                });
-                entry.count += 1;
-            }
-
-            // Compute fee rate for non-coinbase transactions.
-            if !tx.is_coinbase() {
-                let output_sum: u64 = tx.output().iter().map(|o| o.value.to_sat()).sum();
-                if let Some(fee_satoshi) = input_sum.checked_sub(output_sum) {
-                    if let Some(rate) = crate::types::fee_rate_per_vbyte(fee_satoshi, tx.vsize()) {
-                        block_fee_rates.push(rate);
-                    }
-                }
-            }
-        }
-
-        // Merge all the transaction outputs of this block into the cache.
-        for (outpoint, tx_out_info) in tx_outs {
-            self.tx_outs
-                .entry(outpoint)
-                .and_modify(|t| t.count += tx_out_info.count)
-                .or_insert(tx_out_info);
-        }
-
-        self.added_outpoints
-            .insert(*block.block_hash(), added_outpoints);
-        self.removed_outpoints
-            .insert(*block.block_hash(), removed_outpoints);
-        self.utxo_deltas.insert(*block.block_hash(), utxo_delta);
-
-        Ok(block_fee_rates)
     }
 
     /// Removes the outpoints of a block from the cache.
@@ -244,7 +232,6 @@ impl OutPointsCache {
         let block_hash = block.block_hash();
         self.added_outpoints.remove(block_hash);
         self.removed_outpoints.remove(block_hash);
-        self.utxo_deltas.remove(block_hash);
     }
 }
 
@@ -302,7 +289,7 @@ mod test {
         let mut cache = OutPointsCache::new();
 
         // Insert the genesis block and verify
-        cache.insert(&utxos, &block_0, 0).unwrap();
+        insert_outpoints(&mut cache, &utxos, &block_0, 0).unwrap();
 
         // The cache contains the outpoint of block 0.
         let outpoint_0 = OutPoint {
@@ -334,7 +321,7 @@ mod test {
             .with_transaction(tx_1.clone())
             .build();
 
-        cache.insert(&utxos, &block_1, 1).unwrap();
+        insert_outpoints(&mut cache, &utxos, &block_1, 1).unwrap();
 
         let outpoint_coinbase_1 = OutPoint {
             txid: tx_coinbase_block_1.txid(),
@@ -382,10 +369,6 @@ mod test {
                         address_1.clone() => vec![OutPoint::new(tx_0.txid(), 0)]
                     },
                 },
-                utxo_deltas: maplit::btreemap! {
-                    *block_0.block_hash() => 1,
-                    *block_1.block_hash() => 1, // coinbase(1 output) + spend(1 input, 1 output) = +1
-                },
             }
         );
 
@@ -422,9 +405,6 @@ mod test {
                         address_1 => vec![OutPoint::new(tx_0.txid(), 0)]
                     },
                 },
-                utxo_deltas: maplit::btreemap! {
-                    *block_1.block_hash() => 1,
-                },
             }
         );
 
@@ -436,7 +416,6 @@ mod test {
                 tx_outs: maplit::btreemap! {},
                 added_outpoints: maplit::btreemap! {},
                 removed_outpoints: maplit::btreemap! {},
-                utxo_deltas: maplit::btreemap! {},
             }
         );
     }
@@ -475,7 +454,7 @@ mod test {
             .build();
 
         assert_eq!(
-            cache.insert(&utxos, &block_1, 1),
+            insert_outpoints(&mut cache, &utxos, &block_1, 1),
             Err(TxOutNotFound(outpoint_0))
         );
     }
@@ -497,7 +476,7 @@ mod test {
         let utxos = UtxoSet::new(network);
         let mut cache = OutPointsCache::new();
 
-        cache.insert(&utxos, &block_0, 0).unwrap();
+        insert_outpoints(&mut cache, &utxos, &block_0, 0).unwrap();
 
         // The outpoint of block 0.
         let outpoint_0 = OutPoint {
@@ -524,7 +503,7 @@ mod test {
 
         // Inserting the block fails, as its referencing a faulty outpoint.
         assert_eq!(
-            cache.insert(&utxos, &block_1, 1),
+            insert_outpoints(&mut cache, &utxos, &block_1, 1),
             Err(TxOutNotFound(faulty_outpoint))
         );
 
@@ -546,9 +525,6 @@ mod test {
                 },
                 removed_outpoints: maplit::btreemap! {
                     *block_0.block_hash() => maplit::btreemap! {}
-                },
-                utxo_deltas: maplit::btreemap! {
-                    *block_0.block_hash() => 1,
                 },
             }
         );

--- a/canister/src/unstable_blocks/outpoints_cache.rs
+++ b/canister/src/unstable_blocks/outpoints_cache.rs
@@ -87,7 +87,7 @@ impl OutPointsCache {
         let mut removed_outpoints = BTreeMap::new();
         let mut added_outpoints = BTreeMap::new();
         let mut utxo_delta: i64 = 0;
-        let mut block_fees = Vec::new();
+        let mut block_fees = Vec::with_capacity(block.txdata().len());
 
         // The inputs of a transaction contain outpoints that reference the previous
         // outputs that it is consuming. These outputs can be retrieved from a number

--- a/canister/src/unstable_blocks/outpoints_cache.rs
+++ b/canister/src/unstable_blocks/outpoints_cache.rs
@@ -171,10 +171,12 @@ impl OutPointsCache {
             }
 
             // Compute fee rate for non-coinbase transactions.
-            if !tx.is_coinbase() && tx.vsize() > 0 {
+            if !tx.is_coinbase() {
                 let output_sum: u64 = tx.output().iter().map(|o| o.value.to_sat()).sum();
                 let fee_satoshi = input_sum - output_sum;
-                block_fees.push(((1000 * fee_satoshi) / tx.vsize() as u64) as MillisatoshiPerByte);
+                if let Some(rate) = crate::types::fee_rate_per_vbyte(fee_satoshi, tx.vsize()) {
+                    block_fees.push(rate);
+                }
             }
         }
 

--- a/canister/src/unstable_blocks/outpoints_cache.rs
+++ b/canister/src/unstable_blocks/outpoints_cache.rs
@@ -174,8 +174,7 @@ impl OutPointsCache {
             if !tx.is_coinbase() && tx.vsize() > 0 {
                 let output_sum: u64 = tx.output().iter().map(|o| o.value.to_sat()).sum();
                 let fee_satoshi = input_sum - output_sum;
-                block_fees
-                    .push(((1000 * fee_satoshi) / tx.vsize() as u64) as MillisatoshiPerByte);
+                block_fees.push(((1000 * fee_satoshi) / tx.vsize() as u64) as MillisatoshiPerByte);
             }
         }
 

--- a/canister/src/unstable_blocks/outpoints_cache.rs
+++ b/canister/src/unstable_blocks/outpoints_cache.rs
@@ -87,8 +87,7 @@ impl OutPointsCache {
         let mut removed_outpoints = BTreeMap::new();
         let mut added_outpoints = BTreeMap::new();
         let mut utxo_delta: i64 = 0;
-        let mut block_fee_rates =
-            Vec::with_capacity(block.txdata().len().checked_sub(1).unwrap_or(0));
+        let mut block_fee_rates = Vec::with_capacity(block.txdata().len().saturating_sub(1));
 
         // The inputs of a transaction contain outpoints that reference the previous
         // outputs that it is consuming. These outputs can be retrieved from a number

--- a/canister/src/unstable_blocks/outpoints_cache.rs
+++ b/canister/src/unstable_blocks/outpoints_cache.rs
@@ -87,7 +87,8 @@ impl OutPointsCache {
         let mut removed_outpoints = BTreeMap::new();
         let mut added_outpoints = BTreeMap::new();
         let mut utxo_delta: i64 = 0;
-        let mut block_fees = Vec::with_capacity(block.txdata().len());
+        let mut block_fee_rates =
+            Vec::with_capacity(block.txdata().len().checked_sub(1).unwrap_or(0));
 
         // The inputs of a transaction contain outpoints that reference the previous
         // outputs that it is consuming. These outputs can be retrieved from a number
@@ -175,7 +176,7 @@ impl OutPointsCache {
                 let output_sum: u64 = tx.output().iter().map(|o| o.value.to_sat()).sum();
                 if let Some(fee_satoshi) = input_sum.checked_sub(output_sum) {
                     if let Some(rate) = crate::types::fee_rate_per_vbyte(fee_satoshi, tx.vsize()) {
-                        block_fees.push(rate);
+                        block_fee_rates.push(rate);
                     }
                 }
             }
@@ -195,7 +196,7 @@ impl OutPointsCache {
             .insert(*block.block_hash(), removed_outpoints);
         self.utxo_deltas.insert(*block.block_hash(), utxo_delta);
 
-        Ok(block_fees)
+        Ok(block_fee_rates)
     }
 
     /// Removes the outpoints of a block from the cache.


### PR DESCRIPTION
## Summary                                 

- Introduce `BlockMetrics` struct containing fee rates and UTXO deltas cached in heap memory in `UnstableBlocks`
- Move `utxo_deltas` field from `OutPointsCache` to `BlockMetrics`.
- Pre-compute and cache per-block fee rates in `BlockMetrics` during block insertion (`push`), eliminating expensive transaction input lookups at query time.
- Extract block processing into a standalone `insert_outpoints` function that populates the `OutPointsCache` and computes `BlockMetrics` in a single pass.
- `get_fees_per_byte` now reads cached fees instead of re-deriving them from the `OutPointsCache`, with a fallback to on-the-fly computation for blocks without cached fees (useful after the upgrade).
- Block metrics are cleaned up alongside outpoints when blocks become stable (`pop`).
                                                                                          
 ## Motivation                              
                                                                                          
Previously, `get_current_fee_percentiles` iterated through all transactions on the main chain and looked up each input's value via the `OutPointsCache` on every call. This work is now done once at block insertion time and stored in a `BTreeMap<BlockHash, Vec<MillisatoshiPerByte>>` inside `UnstableBlocks` in heap memory. At query time, fees are simply collected from the cache.
                                                                                          
##  Design decisions          

- `BlockMetrics` (defined in `types.rs`) bundles all per-block derived data. In the future, these metrics will be stored alongside the `CachedBlock` struct (see https://github.com/dfinity/bitcoin-canister/pull/506).
- Fees (not percentiles) are stored per block, so forks are handled naturally — each block has its own fee data, and main chain changes just look up different block hashes.
- `insert_outpoints` is a free function rather than a method on `OutPointsCache` so that additional actions not tied to outpoints can be performed while iterating the transactions, such as computing metrics.                                                 
   
 ## Test plan                                                                               
- `block_fees_are_populated_during_insert` — verifies fees are cached for every block inserted via `push`.      
- `block_fees_are_cleaned_up_on_stable_block_ingestion` — verifies fees are removed when blocks become stable.
- `correct_fees_after_upgrade_with_empty_block_fees_cache` — simulates post-upgrade empty cache, verifies fallback produces correct results.