### PR TITLE
refactor: move block metrics to `CachedBlock`

### DIFF
--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -2,95 +2,95 @@ benches:
   bitcoin_get_balance_baseline:
     total:
       calls: 1
-      instructions: 6189268
+      instructions: 6189038
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_balance_stress:
     total:
       calls: 1
-      instructions: 254312139
+      instructions: 254311743
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_block_headers_baseline:
     total:
       calls: 1
-      instructions: 372085
+      instructions: 372270
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_block_headers_stress:
     total:
       calls: 1
-      instructions: 2858129
+      instructions: 2857996
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_current_fee_percentiles:
     total:
       calls: 1
-      instructions: 200417
+      instructions: 47246
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_utxos_baseline:
     total:
       calls: 1
-      instructions: 7724239
+      instructions: 7816291
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_utxos_stress:
     total:
       calls: 1
-      instructions: 4656447316
+      instructions: 4686318652
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_many_branches:
     total:
       calls: 1
-      instructions: 2827427
+      instructions: 887844
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_single_chain:
     total:
       calls: 1
-      instructions: 2241415
+      instructions: 376638
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_with_forks:
     total:
       calls: 1
-      instructions: 2272275
+      instructions: 407334
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_metrics:
     total:
       calls: 1
-      instructions: 3502068
+      instructions: 3522936
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   insert_300_blocks:
     total:
       calls: 1
-      instructions: 441793239
-      heap_increase: 10
+      instructions: 441231719
+      heap_increase: 9
       stable_memory_increase: 0
     scopes:
       validate:
         calls: 300
-        instructions: 368878913
+        instructions: 368896159
         heap_increase: 1
         stable_memory_increase: 0
       validate_block:
         calls: 300
-        instructions: 18315665
+        instructions: 18321557
         heap_increase: 0
         stable_memory_increase: 0
       validate_block/check_merkle_root:
@@ -100,18 +100,18 @@ benches:
         stable_memory_increase: 0
       validate_block/ensure_unique_transactions:
         calls: 300
-        instructions: 8478094
+        instructions: 8484173
         heap_increase: 0
         stable_memory_increase: 0
       validate_header:
         calls: 300
-        instructions: 349444360
+        instructions: 349455411
         heap_increase: 0
         stable_memory_increase: 0
   insert_block_headers:
     total:
       calls: 1
-      instructions: 2844241130
+      instructions: 2844071043
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
@@ -123,7 +123,7 @@ benches:
   insert_block_headers_multiple_times:
     total:
       calls: 1
-      instructions: 10300828046
+      instructions: 10300806046
       heap_increase: 7
       stable_memory_increase: 0
     scopes:
@@ -135,7 +135,7 @@ benches:
   insert_block_with_10k_transactions:
     total:
       calls: 1
-      instructions: 1402366137
+      instructions: 1402364466
       heap_increase: 74
       stable_memory_increase: 0
     scopes:
@@ -167,18 +167,18 @@ benches:
   insert_block_with_1k_transactions:
     total:
       calls: 1
-      instructions: 116138686
+      instructions: 116137706
       heap_increase: 7
       stable_memory_increase: 0
     scopes:
       validate:
         calls: 1
-        instructions: 15146714
+        instructions: 15146818
         heap_increase: 0
         stable_memory_increase: 0
       validate_block:
         calls: 1
-        instructions: 15040991
+        instructions: 15041095
         heap_increase: 0
         stable_memory_increase: 0
       validate_block/check_merkle_root:
@@ -188,7 +188,7 @@ benches:
         stable_memory_increase: 0
       validate_block/ensure_unique_transactions:
         calls: 1
-        instructions: 7918558
+        instructions: 7918662
         heap_increase: 0
         stable_memory_increase: 0
       validate_header:
@@ -199,18 +199,18 @@ benches:
   pre_upgrade_with_many_unstable_blocks:
     total:
       calls: 1
-      instructions: 3410581376
+      instructions: 3383555132
       heap_increase: 1538
       stable_memory_increase: 1024
     scopes:
       serialize_blocktree_flatten:
         calls: 1
-        instructions: 253900
+        instructions: 229669
         heap_increase: 0
         stable_memory_increase: 0
       serialize_blocktree_serialize_seq:
         calls: 1
-        instructions: 36605976
+        instructions: 36574256
         heap_increase: 0
         stable_memory_increase: 0
 version: 0.4.0

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -104,18 +104,17 @@ fn get_fees_per_byte(
         }
 
         // Use cached fees if available, otherwise compute from transactions.
-        let block_fee_rates: Cow<'_, [MillisatoshiPerByte]> =
-            match unstable_blocks.get_block_fee_rates(block.block_hash()) {
-                Some(cached) => Cow::Borrowed(cached),
-                None => Cow::Owned(
-                    block
-                        .block()
-                        .txdata()
-                        .iter()
-                        .filter_map(|tx| get_tx_fee_per_byte(tx, unstable_blocks))
-                        .collect(),
-                ),
-            };
+        let block_fee_rates: Cow<'_, [MillisatoshiPerByte]> = match block.fee_rates() {
+            Some(cached) => Cow::Borrowed(cached),
+            None => Cow::Owned(
+                block
+                    .block()
+                    .txdata()
+                    .iter()
+                    .filter_map(|tx| get_tx_fee_per_byte(tx, unstable_blocks))
+                    .collect(),
+            ),
+        };
 
         for &fee in block_fee_rates.iter() {
             if tx_count >= number_of_transactions {
@@ -680,10 +679,7 @@ mod test {
             // Collect them (most recent first) to compare against get_fees_per_byte.
             let mut cached_fees: Vec<MillisatoshiPerByte> = Vec::new();
             for block in chain.iter().rev() {
-                if let Some(rates) = state
-                    .unstable_blocks
-                    .get_block_fee_rates(block.block_hash())
-                {
+                if let Some(rates) = block.fee_rates() {
                     cached_fees.extend_from_slice(rates);
                 }
             }
@@ -694,47 +690,6 @@ mod test {
             let fee_rates =
                 get_fees_per_byte(main_chain.into_chain(), &state.unstable_blocks, 10_000);
             assert_eq!(fee_rates, cached_fees);
-        });
-    }
-
-    #[test]
-    fn block_fee_rates_are_cleaned_up_on_stable_block_ingestion() {
-        let number_of_blocks = 10;
-        let blocks = generate_blocks(10_000, number_of_blocks);
-        let stability_threshold = 5;
-        init_state(blocks.clone(), stability_threshold);
-
-        // After init_state, some blocks have been ingested into the UTXO set.
-        // Verify that stable blocks had their fees cleaned up and unstable blocks kept theirs.
-        with_state(|state| {
-            let unstable_chain =
-                unstable_blocks::get_main_chain(&state.unstable_blocks).into_chain();
-            let num_stable = blocks.len() - unstable_chain.len();
-            assert!(num_stable > 0, "some blocks should be stable");
-
-            // Stable blocks (popped from the unstable tree) should NOT have cached fees.
-            for block in &blocks[..num_stable] {
-                assert!(
-                    state
-                        .unstable_blocks
-                        .get_block_fee_rates(block.block_hash())
-                        .is_none(),
-                    "stable block {} should not have cached fees",
-                    block.block_hash()
-                );
-            }
-
-            // Unstable blocks (excluding the anchor) should have cached fees.
-            for block in unstable_chain.iter().skip(1) {
-                assert!(
-                    state
-                        .unstable_blocks
-                        .get_block_fee_rates(block.block_hash())
-                        .is_some(),
-                    "unstable block {} should have cached fees",
-                    block.block_hash()
-                );
-            }
         });
     }
 
@@ -760,10 +715,7 @@ mod test {
             let main_chain = unstable_blocks::get_main_chain(&state.unstable_blocks);
             for block in main_chain.into_chain() {
                 assert!(
-                    state
-                        .unstable_blocks
-                        .get_block_fee_rates(block.block_hash())
-                        .is_none(),
+                    block.fee_rates().is_none(),
                     "block fees should be empty after simulated upgrade"
                 );
             }

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -1,5 +1,7 @@
+use crate::types::BlockMetrics;
 use crate::unstable_blocks::BlocksCache;
 use bitcoin::block::Header;
+use ic_btc_interface::MillisatoshiPerByte;
 use ic_btc_types::{Block, BlockHash};
 use std::fmt;
 mod serde;
@@ -16,6 +18,11 @@ pub struct CachedBlock {
     difficulty: u128,
     block_hash: BlockHash,
     header: Header,
+    /// Fee rates (millisatoshi per vbyte) for non-coinbase transactions.
+    /// `None` when not yet computed (e.g., after deserialization).
+    fee_rates: Option<Vec<MillisatoshiPerByte>>,
+    /// Net UTXO count change (outputs created - inputs spent).
+    utxo_delta: i64,
 }
 
 impl PartialEq for CachedBlock {
@@ -37,11 +44,31 @@ impl CachedBlock {
             difficulty,
             block_hash,
             header,
+            fee_rates: None,
+            utxo_delta: 0,
         }
     }
 
     pub fn block(&self) -> Block {
         self.cache.borrow().get(&self.block_hash).unwrap()
+    }
+
+    pub fn set_metrics(&mut self, metrics: BlockMetrics) {
+        self.fee_rates = Some(metrics.fee_rates);
+        self.utxo_delta = metrics.utxo_delta;
+    }
+
+    pub fn fee_rates(&self) -> Option<&[MillisatoshiPerByte]> {
+        self.fee_rates.as_deref()
+    }
+
+    pub fn utxo_delta(&self) -> i64 {
+        self.utxo_delta
+    }
+
+    fn clear_metrics(&mut self) {
+        self.fee_rates = None;
+        self.utxo_delta = 0;
     }
 }
 
@@ -233,8 +260,25 @@ impl BlockTree<CachedBlock> {
         self.root.cache.clone()
     }
 
-    pub fn extend_cached(&mut self, block: Block) -> Result<(), BlockDoesNotExtendTree> {
-        self.extend(CachedBlock::new_cached(self.cache(), block))
+    pub fn extend_cached(
+        &mut self,
+        block: Block,
+        metrics: BlockMetrics,
+    ) -> Result<(), BlockDoesNotExtendTree> {
+        let mut cached = CachedBlock::new_cached(self.cache(), block);
+        cached.set_metrics(metrics);
+        self.extend(cached)
+    }
+
+    pub fn set_root_metrics(&mut self, metrics: BlockMetrics) {
+        self.root.set_metrics(metrics);
+    }
+
+    pub fn clear_all_metrics(&mut self) {
+        self.root.clear_metrics();
+        for child in &mut self.children {
+            child.clear_all_metrics();
+        }
     }
 
     pub fn into_root_and_remove_from_cache(self) -> Block {
@@ -568,7 +612,7 @@ impl<Block: ChainBlock> BlockTree<Block> {
 
     /// Returns a `BlockTree` where the hash of the root matches the hash of the provided `block`
     /// if it exists, and `None` otherwise.
-    fn find(&self, block_hash: &BlockHash) -> Option<&BlockTree<Block>> {
+    pub(crate) fn find(&self, block_hash: &BlockHash) -> Option<&BlockTree<Block>> {
         if self.root.block_hash() == block_hash {
             return Some(self);
         }
@@ -713,7 +757,9 @@ mod test {
             // Each one of these should be a separate fork.
             let block = BlockBuilder::with_prev_header(&genesis_block_header).build();
             children.push(CachedBlock::new_cached(block_tree.cache(), block.clone()));
-            block_tree.extend_cached(block).unwrap();
+            block_tree
+                .extend_cached(block, BlockMetrics::default())
+                .unwrap();
         }
 
         assert_eq!(block_tree.children.len(), 4);
@@ -736,7 +782,9 @@ mod test {
         let mut block_tree = test_tree(blocks[0].clone());
 
         for block in blocks.iter().skip(1) {
-            block_tree.extend_cached(block.clone()).unwrap();
+            block_tree
+                .extend_cached(block.clone(), BlockMetrics::default())
+                .unwrap();
         }
 
         for (i, block) in blocks.iter().enumerate() {
@@ -775,7 +823,9 @@ mod test {
             }
 
             for block in blocks.iter().skip(1) {
-                block_tree.extend_cached(block.clone()).unwrap();
+                block_tree
+                    .extend_cached(block.clone(), BlockMetrics::default())
+                    .unwrap();
             }
 
             for (i, block) in blocks.iter().enumerate() {
@@ -826,6 +876,7 @@ mod test {
                 .extend_cached(
                     BlockBuilder::with_prev_header(&genesis_block_header)
                         .build_with_mock_difficulty(i),
+                    BlockMetrics::default(),
                 )
                 .unwrap();
         }
@@ -877,7 +928,9 @@ mod test {
 
         for (i, block) in chain.iter().enumerate().skip(1) {
             expected_blocks_with_depths_by_heights[i].push((block, (chain_len - i) as u32));
-            block_tree.extend_cached(block.clone()).unwrap();
+            block_tree
+                .extend_cached(block.clone(), BlockMetrics::default())
+                .unwrap();
         }
 
         let actual_block_hashes_with_depths_by_heights =
@@ -903,9 +956,15 @@ mod test {
         let fork = BlockChainBuilder::fork(&chain[0], 2).build();
 
         let mut block_tree = test_tree(chain[0].clone());
-        block_tree.extend_cached(chain[1].clone()).unwrap();
-        block_tree.extend_cached(fork[0].clone()).unwrap();
-        block_tree.extend_cached(fork[1].clone()).unwrap();
+        block_tree
+            .extend_cached(chain[1].clone(), BlockMetrics::default())
+            .unwrap();
+        block_tree
+            .extend_cached(fork[0].clone(), BlockMetrics::default())
+            .unwrap();
+        block_tree
+            .extend_cached(fork[1].clone(), BlockMetrics::default())
+            .unwrap();
 
         let block_hashes_with_depths_by_heights = block_tree.block_hashes_with_depths_by_heights();
 
@@ -952,7 +1011,7 @@ mod test {
         fn grow_tree(chain: Vec<Block>) -> BlockTree {
             let mut tree = test_tree(chain[0].clone());
             for block in chain.into_iter().skip(1) {
-                tree.extend_cached(block).unwrap();
+                tree.extend_cached(block, BlockMetrics::default()).unwrap();
             }
             tree
         }

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -612,7 +612,7 @@ impl<Block: ChainBlock> BlockTree<Block> {
 
     /// Returns a `BlockTree` where the hash of the root matches the hash of the provided `block`
     /// if it exists, and `None` otherwise.
-    pub(crate) fn find(&self, block_hash: &BlockHash) -> Option<&BlockTree<Block>> {
+    fn find(&self, block_hash: &BlockHash) -> Option<&BlockTree<Block>> {
         if self.root.block_hash() == block_hash {
             return Some(self);
         }

--- a/canister/src/blocktree/serde.rs
+++ b/canister/src/blocktree/serde.rs
@@ -160,6 +160,8 @@ impl<'de> TreeVisitor<'de, CachedBlock> for CachedBlockTreeVisitor {
                     block_hash,
                     difficulty,
                     header,
+                    fee_rates: None,
+                    utxo_delta: 0,
                 };
                 (block, size)
             })

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -339,7 +339,7 @@ pub fn blockchain_info(state: &State) -> crate::types::BlockchainInfo {
 
     let mut utxos_length = state.utxos.utxos_len() as i64;
     for block in main_chain.into_chain() {
-        utxos_length += state.unstable_blocks.get_net_utxo_delta(block.block_hash());
+        utxos_length += block.utxo_delta();
     }
 
     crate::types::BlockchainInfo {

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -4,7 +4,7 @@ use crate::{
         DifficultyBasedDepth,
     },
     runtime::print,
-    types::{Address, BlockMetrics, TxOut},
+    types::{Address, TxOut},
     UtxoSet,
 };
 use bitcoin::block::Header;
@@ -12,7 +12,6 @@ use ic_btc_interface::{Height, MillisatoshiPerByte, Network};
 use ic_btc_types::{Block, BlockHash, OutPoint};
 use outpoints_cache::{insert_outpoints, OutPointsCache};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 
 mod blocks_cache;
 mod next_block_headers;
@@ -74,9 +73,6 @@ pub struct GenericUnstableBlocks<Tree> {
     network: Network,
     // The headers of the blocks that are expected to be received.
     next_block_headers: NextBlockHeaders,
-    // Per-block metrics (fee rates, UTXO delta, etc.) computed during block processing.
-    #[serde(default)]
-    block_metrics: BTreeMap<BlockHash, BlockMetrics>,
 }
 
 impl<A> GenericUnstableBlocks<A> {
@@ -87,7 +83,6 @@ impl<A> GenericUnstableBlocks<A> {
             outpoints_cache,
             network,
             next_block_headers,
-            block_metrics,
         } = self;
         GenericUnstableBlocks {
             stability_threshold,
@@ -95,7 +90,6 @@ impl<A> GenericUnstableBlocks<A> {
             outpoints_cache,
             network,
             next_block_headers,
-            block_metrics,
         }
     }
 }
@@ -116,16 +110,15 @@ impl UnstableBlocks {
             insert_outpoints(&mut outpoints_cache, utxos, &anchor, utxos.next_height())
                 .expect("anchor block must be valid.");
 
-        let mut block_metrics = BTreeMap::new();
-        block_metrics.insert(*anchor.block_hash(), anchor_metrics);
+        let mut tree = BlockTree::new_with_cache(blocks_cache, anchor);
+        tree.set_root_metrics(anchor_metrics);
 
         Self {
             stability_threshold,
-            tree: BlockTree::new_with_cache(blocks_cache, anchor),
+            tree,
             outpoints_cache,
             network,
             next_block_headers: NextBlockHeaders::default(),
-            block_metrics,
         }
     }
 
@@ -153,23 +146,23 @@ impl UnstableBlocks {
 
     /// Returns the net UTXO count change for the given block (added - removed).
     pub fn get_net_utxo_delta(&self, block_hash: &BlockHash) -> i64 {
-        self.block_metrics
-            .get(block_hash)
-            .map(|m| m.utxo_delta)
+        self.tree
+            .find(block_hash)
+            .map(|subtree| subtree.root().utxo_delta())
             .unwrap_or(0)
     }
 
     /// Returns the fee rates for the given block.
     pub fn get_block_fee_rates(&self, block_hash: &BlockHash) -> Option<&[MillisatoshiPerByte]> {
-        self.block_metrics
-            .get(block_hash)
-            .map(|m| m.fee_rates.as_slice())
+        self.tree
+            .find(block_hash)
+            .and_then(|subtree| subtree.root().fee_rates())
     }
 
     /// Clears all cached block metrics. Used in tests to simulate post-upgrade state.
     #[cfg(test)]
     pub fn clear_block_metrics(&mut self) {
-        self.block_metrics.clear();
+        self.tree.clear_all_metrics();
     }
 
     pub fn stability_threshold(&self) -> u32 {
@@ -319,10 +312,9 @@ pub fn pop(blocks: &mut UnstableBlocks, stable_height: Height) -> Option<Block> 
     let mut tree = blocks.tree.remove_child(stable_child_idx);
     std::mem::swap(&mut tree, &mut blocks.tree);
 
-    // Remove the outpoints and metrics of obsolete blocks from the cache.
+    // Remove the outpoints of obsolete blocks from the cache.
     for block in tree.blocks() {
         blocks.outpoints_cache.remove(&block.block());
-        blocks.block_metrics.remove(block.block_hash());
     }
 
     blocks.next_block_headers.remove_until_height(stable_height);
@@ -349,9 +341,8 @@ pub fn push(
     // Process the block in a single pass: populate the outpoints cache and compute metrics.
     let metrics = insert_outpoints(&mut blocks.outpoints_cache, utxos, &block, height)
         .expect("processing block must succeed.");
-    blocks.block_metrics.insert(block_hash, metrics);
 
-    parent_block_tree.extend_cached(block)?;
+    parent_block_tree.extend_cached(block, metrics)?;
 
     blocks.next_block_headers.remove(&block_hash);
 

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -8,7 +8,7 @@ use crate::{
     UtxoSet,
 };
 use bitcoin::block::Header;
-use ic_btc_interface::{Height, MillisatoshiPerByte, Network};
+use ic_btc_interface::{Height, Network};
 use ic_btc_types::{Block, BlockHash, OutPoint};
 use outpoints_cache::{insert_outpoints, OutPointsCache};
 use serde::{Deserialize, Serialize};
@@ -142,21 +142,6 @@ impl UnstableBlocks {
     pub fn get_removed_outpoints(&self, block_hash: &BlockHash, address: &Address) -> &[OutPoint] {
         self.outpoints_cache
             .get_removed_outpoints(block_hash, address)
-    }
-
-    /// Returns the net UTXO count change for the given block (added - removed).
-    pub fn get_net_utxo_delta(&self, block_hash: &BlockHash) -> i64 {
-        self.tree
-            .find(block_hash)
-            .map(|subtree| subtree.root().utxo_delta())
-            .unwrap_or(0)
-    }
-
-    /// Returns the fee rates for the given block.
-    pub fn get_block_fee_rates(&self, block_hash: &BlockHash) -> Option<&[MillisatoshiPerByte]> {
-        self.tree
-            .find(block_hash)
-            .and_then(|subtree| subtree.root().fee_rates())
     }
 
     /// Clears all cached block metrics. Used in tests to simulate post-upgrade state.


### PR DESCRIPTION
## Summary
- Move `fee_rates` and `utxo_delta` from a side `BTreeMap<BlockHash, BlockMetrics>` on `GenericUnstableBlocks` into `CachedBlock` fields, co-locating per-block metrics with the block they belong to.
- Callers that already hold a `&CachedBlock` reference now access metrics directly (`block.fee_rates()`, `block.utxo_delta()`) instead of doing a hash-based lookup through `UnstableBlocks`.
- Metrics are not serialized — they default to `None`/`0` after deserialization, preserving backwards compatibility and the existing fallback recomputation path.
- Remove the `block_fee_rates_are_cleaned_up_on_stable_block_ingestion` test, which became tautological since metrics are now automatically dropped when a block is popped from the tree.

## Test plan
- [x] All existing tests pass (202 unit + 3 main + 1 integration)
- [ ] Verify no benchmark regressions on `get_blockchain_info` and `bitcoin_get_current_fee_percentiles`