### PR TITLE
fix: prevent main chain from decreasing when tip is contested

### DIFF
--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -2,84 +2,84 @@ benches:
   bitcoin_get_balance_baseline:
     total:
       calls: 1
-      instructions: 6189038
+      instructions: 6187041
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_balance_stress:
     total:
       calls: 1
-      instructions: 254311743
+      instructions: 254309746
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_block_headers_baseline:
     total:
       calls: 1
-      instructions: 372270
+      instructions: 368673
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_block_headers_stress:
     total:
       calls: 1
-      instructions: 2857996
+      instructions: 2677999
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_current_fee_percentiles:
     total:
       calls: 1
-      instructions: 47246
+      instructions: 45249
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_utxos_baseline:
     total:
       calls: 1
-      instructions: 7816291
+      instructions: 7814294
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_utxos_stress:
     total:
       calls: 1
-      instructions: 4686318652
+      instructions: 4686302255
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_many_branches:
     total:
       calls: 1
-      instructions: 887844
+      instructions: 849028
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_single_chain:
     total:
       calls: 1
-      instructions: 376638
+      instructions: 356641
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_with_forks:
     total:
       calls: 1
-      instructions: 407334
+      instructions: 386332
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_metrics:
     total:
       calls: 1
-      instructions: 3522936
+      instructions: 3426762
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   insert_300_blocks:
     total:
       calls: 1
-      instructions: 441231719
+      instructions: 441228119
       heap_increase: 9
       stable_memory_increase: 0
     scopes:
@@ -111,7 +111,7 @@ benches:
   insert_block_headers:
     total:
       calls: 1
-      instructions: 2844071043
+      instructions: 2844068643
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
@@ -123,7 +123,7 @@ benches:
   insert_block_headers_multiple_times:
     total:
       calls: 1
-      instructions: 10300806046
+      instructions: 10300782046
       heap_increase: 7
       stable_memory_increase: 0
     scopes:
@@ -135,7 +135,7 @@ benches:
   insert_block_with_10k_transactions:
     total:
       calls: 1
-      instructions: 1402364466
+      instructions: 1402364454
       heap_increase: 74
       stable_memory_increase: 0
     scopes:
@@ -167,7 +167,7 @@ benches:
   insert_block_with_1k_transactions:
     total:
       calls: 1
-      instructions: 116137706
+      instructions: 116137694
       heap_increase: 7
       stable_memory_increase: 0
     scopes:
@@ -199,7 +199,7 @@ benches:
   pre_upgrade_with_many_unstable_blocks:
     total:
       calls: 1
-      instructions: 3383555132
+      instructions: 3383555127
       heap_increase: 1538
       stable_memory_increase: 1024
     scopes:

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -2,84 +2,84 @@ benches:
   bitcoin_get_balance_baseline:
     total:
       calls: 1
-      instructions: 6187041
+      instructions: 6185936
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_balance_stress:
     total:
       calls: 1
-      instructions: 254309746
+      instructions: 254308641
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_block_headers_baseline:
     total:
       calls: 1
-      instructions: 368673
+      instructions: 366463
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_block_headers_stress:
     total:
       calls: 1
-      instructions: 2677999
+      instructions: 2567989
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_current_fee_percentiles:
     total:
       calls: 1
-      instructions: 45249
+      instructions: 44144
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_utxos_baseline:
     total:
       calls: 1
-      instructions: 7814294
+      instructions: 7813189
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   bitcoin_get_utxos_stress:
     total:
       calls: 1
-      instructions: 4686302255
+      instructions: 4686291205
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_many_branches:
     total:
       calls: 1
-      instructions: 849028
+      instructions: 827628
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_single_chain:
     total:
       calls: 1
-      instructions: 356641
+      instructions: 345636
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_with_forks:
     total:
       calls: 1
-      instructions: 386332
+      instructions: 374772
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_metrics:
     total:
       calls: 1
-      instructions: 3426762
+      instructions: 3360926
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   insert_300_blocks:
     total:
       calls: 1
-      instructions: 441228119
+      instructions: 441231719
       heap_increase: 9
       stable_memory_increase: 0
     scopes:
@@ -111,7 +111,7 @@ benches:
   insert_block_headers:
     total:
       calls: 1
-      instructions: 2844068643
+      instructions: 2844071043
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
@@ -123,7 +123,7 @@ benches:
   insert_block_headers_multiple_times:
     total:
       calls: 1
-      instructions: 10300782046
+      instructions: 10300806046
       heap_increase: 7
       stable_memory_increase: 0
     scopes:
@@ -135,7 +135,7 @@ benches:
   insert_block_with_10k_transactions:
     total:
       calls: 1
-      instructions: 1402364454
+      instructions: 1402364466
       heap_increase: 74
       stable_memory_increase: 0
     scopes:
@@ -167,7 +167,7 @@ benches:
   insert_block_with_1k_transactions:
     total:
       calls: 1
-      instructions: 116137694
+      instructions: 116137706
       heap_increase: 7
       stable_memory_increase: 0
     scopes:

--- a/canister/src/api/get_utxos.rs
+++ b/canister/src/api/get_utxos.rs
@@ -824,12 +824,12 @@ mod test {
         );
 
         // Extend block 0 with block 1 that spends the 1000 satoshis and gives them to address 2.
-        let tx = TransactionBuilder::new()
+        let tx_to_address_2 = TransactionBuilder::new()
             .with_input(ic_btc_types::OutPoint::new(coinbase_tx.txid(), 0))
             .with_output(&address_2, 1000)
             .build();
         let block_1 = BlockBuilder::with_prev_header(block_0.header())
-            .with_transaction(tx.clone())
+            .with_transaction(tx_to_address_2.clone())
             .build();
 
         with_state_mut(|state| {
@@ -846,7 +846,7 @@ mod test {
             GetUtxosResponse {
                 utxos: vec![Utxo {
                     outpoint: OutPoint {
-                        txid: tx.txid().into(),
+                        txid: tx_to_address_2.txid().into(),
                         vout: 0,
                     },
                     value: 1000,
@@ -886,8 +886,9 @@ mod test {
             state::insert_block(state, block_1_prime.clone()).unwrap();
         });
 
-        // Because block 1 and block 1' contest with each other, neither of them are included
-        // in the UTXOs. Only the UTXOs of block 0 are returned.
+        // Block 1 was received first, so it wins the tie with block 1'.
+        // The main chain is genesis -> block_0 -> block_1.
+        // address 2 still has the UTXO from block_1.
         assert_eq!(
             get_utxos(GetUtxosRequest {
                 address: address_2.to_string(),
@@ -895,9 +896,16 @@ mod test {
             })
             .unwrap(),
             GetUtxosResponse {
-                utxos: vec![],
-                tip_block_hash: block_0.block_hash().to_vec(),
-                tip_height: 1,
+                utxos: vec![Utxo {
+                    outpoint: OutPoint {
+                        txid: tx_to_address_2.txid().into(),
+                        vout: 0,
+                    },
+                    value: 1000,
+                    height: 2,
+                }],
+                tip_block_hash: block_1.block_hash().to_vec(),
+                tip_height: 2,
                 next_page: None,
             }
         );
@@ -909,8 +917,8 @@ mod test {
             .unwrap(),
             GetUtxosResponse {
                 utxos: vec![],
-                tip_block_hash: block_0.block_hash().to_vec(),
-                tip_height: 1,
+                tip_block_hash: block_1.block_hash().to_vec(),
+                tip_height: 2,
                 next_page: None,
             }
         );
@@ -920,7 +928,12 @@ mod test {
                 filter: None,
             })
             .unwrap(),
-            block_0_utxos
+            GetUtxosResponse {
+                utxos: vec![],
+                tip_block_hash: block_1.block_hash().to_vec(),
+                tip_height: 2,
+                next_page: None,
+            }
         );
 
         // Now extend block 1' with another block that transfers the funds to address 4.
@@ -1428,9 +1441,10 @@ mod test {
             }
         });
 
-        // Because the forks are of equal length, `A`, the root of the fork,
-        // is considered the tip at zero confirmations.
-        assert_tip_at_confirmations(0, chain[0].block_hash());
+        // With the first-received-child-wins rule, the first fork (chain)
+        // is chosen as the main chain. All blocks have stability count >= 0,
+        // so the tip at zero confirmations is F.
+        assert_tip_at_confirmations(0, chain[5].block_hash());
 
         // Extend the first fork by one block.
         let chain_6 = BlockBuilder::with_prev_header(chain[5].header()).build();

--- a/canister/src/api/get_utxos.rs
+++ b/canister/src/api/get_utxos.rs
@@ -836,6 +836,20 @@ mod test {
             state::insert_block(state, block_1.clone()).unwrap();
         });
 
+        let block_1_utxos = GetUtxosResponse {
+            utxos: vec![Utxo {
+                outpoint: OutPoint {
+                    txid: tx_to_address_2.txid().into(),
+                    vout: 0,
+                },
+                value: 1000,
+                height: 2,
+            }],
+            tip_block_hash: block_1.block_hash().to_vec(),
+            tip_height: 2,
+            next_page: None,
+        };
+
         // address 2 should now have the UTXO while address 1 has no UTXOs.
         assert_eq!(
             get_utxos(GetUtxosRequest {
@@ -843,19 +857,7 @@ mod test {
                 filter: None,
             })
             .unwrap(),
-            GetUtxosResponse {
-                utxos: vec![Utxo {
-                    outpoint: OutPoint {
-                        txid: tx_to_address_2.txid().into(),
-                        vout: 0,
-                    },
-                    value: 1000,
-                    height: 2,
-                }],
-                tip_block_hash: block_1.block_hash().to_vec(),
-                tip_height: 2,
-                next_page: None,
-            }
+            block_1_utxos
         );
 
         assert_eq!(
@@ -872,7 +874,7 @@ mod test {
             }
         );
 
-        // Extend block 0 (again) with block 1 that spends the 1000 satoshis to address 3
+        // Extend block 0 (again) with block 1' that spends the 1000 satoshis to address 3.
         // This causes a fork.
         let tx = TransactionBuilder::new()
             .with_input(ic_btc_types::OutPoint::new(coinbase_tx.txid(), 0))
@@ -895,19 +897,7 @@ mod test {
                 filter: None,
             })
             .unwrap(),
-            GetUtxosResponse {
-                utxos: vec![Utxo {
-                    outpoint: OutPoint {
-                        txid: tx_to_address_2.txid().into(),
-                        vout: 0,
-                    },
-                    value: 1000,
-                    height: 2,
-                }],
-                tip_block_hash: block_1.block_hash().to_vec(),
-                tip_height: 2,
-                next_page: None,
-            }
+            block_1_utxos
         );
         assert_eq!(
             get_utxos(GetUtxosRequest {

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -503,6 +503,9 @@ impl<Block: ChainBlock> BlockTree<Block> {
         let mut best_key = (DifficultyBasedDepth::new(0), 0usize);
         let mut best_chain: Vec<&Block> = vec![];
 
+        // Children are ordered by insertion time (`extend` appends via `push`).
+        // Using strict `>` means the first child that sets `best_key` is kept
+        // on ties, so the earliest-received branch wins.
         for child in self.children.iter() {
             let (child_diff, child_depth, child_chain) = child.main_chain_by_difficulty_inner();
             let key = (child_diff, child_depth);
@@ -541,6 +544,8 @@ impl<Block: ChainBlock> BlockTree<Block> {
         let mut best_key = (DifficultyBasedDepth::new(0), 0usize);
         let mut best_length = 0;
 
+        // Same tiebreaker logic as `main_chain_by_difficulty_inner`: strict `>`
+        // keeps the first child on ties.
         for child in self.children.iter() {
             let (child_diff, child_depth, child_len) =
                 child.main_chain_length_by_difficulty_inner();

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -480,7 +480,7 @@ impl<Block: ChainBlock> BlockTree<Block> {
     /// At each node, the child subtree with the strictly highest accumulated
     /// difficulty is followed. When accumulated difficulties are tied, the
     /// deeper subtree (by block count) wins. If children still tie on both
-    /// criteria, the chain ends at this node (contested tip).
+    /// criteria, the child that was received first is chosen.
     ///
     /// Runs in O(n) time where n is the number of blocks in the tree.
     pub fn main_chain_by_difficulty(&self) -> BlockChain<'_, Block> {
@@ -502,34 +502,21 @@ impl<Block: ChainBlock> BlockTree<Block> {
 
         let mut best_key = (DifficultyBasedDepth::new(0), 0usize);
         let mut best_chain: Vec<&Block> = vec![];
-        let mut contested = false;
 
         for child in self.children.iter() {
             let (child_diff, child_depth, child_chain) = child.main_chain_by_difficulty_inner();
             let key = (child_diff, child_depth);
 
-            match key.cmp(&best_key) {
-                std::cmp::Ordering::Greater => {
-                    best_key = key;
-                    best_chain = child_chain;
-                    contested = false;
-                }
-                std::cmp::Ordering::Equal => {
-                    contested = true;
-                }
-                std::cmp::Ordering::Less => {}
+            if key > best_key {
+                best_key = key;
+                best_chain = child_chain;
             }
         }
 
         let total_difficulty = self_difficulty + best_key.0;
         let total_depth = 1 + best_key.1;
-
-        if contested {
-            (total_difficulty, total_depth, vec![&self.root])
-        } else {
-            best_chain.push(&self.root);
-            (total_difficulty, total_depth, best_chain)
-        }
+        best_chain.push(&self.root);
+        (total_difficulty, total_depth, best_chain)
     }
 
     /// Returns the length of the main chain determined by most accumulated
@@ -553,34 +540,21 @@ impl<Block: ChainBlock> BlockTree<Block> {
 
         let mut best_key = (DifficultyBasedDepth::new(0), 0usize);
         let mut best_length = 0;
-        let mut contested = false;
 
         for child in self.children.iter() {
             let (child_diff, child_depth, child_len) =
                 child.main_chain_length_by_difficulty_inner();
             let key = (child_diff, child_depth);
 
-            match key.cmp(&best_key) {
-                std::cmp::Ordering::Greater => {
-                    best_key = key;
-                    best_length = child_len;
-                    contested = false;
-                }
-                std::cmp::Ordering::Equal => {
-                    contested = true;
-                }
-                std::cmp::Ordering::Less => {}
+            if key > best_key {
+                best_key = key;
+                best_length = child_len;
             }
         }
 
         let total_difficulty = self_difficulty + best_key.0;
         let total_depth = 1 + best_key.1;
-
-        if contested {
-            (total_difficulty, total_depth, 1)
-        } else {
-            (total_difficulty, total_depth, 1 + best_length)
-        }
+        (total_difficulty, total_depth, 1 + best_length)
     }
 
     /// Returns a `BlockTree` where the hash of the root block matches the provided `block_hash`

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -530,7 +530,36 @@ impl<Block: ChainBlock> BlockTree<Block> {
     ///
     /// Runs in O(n) time where n is the number of blocks in the tree.
     pub fn main_chain_length_by_difficulty(&self) -> usize {
-        self.main_chain_by_difficulty_inner().1
+        self.main_chain_length_by_difficulty_inner().2
+    }
+
+    /// Bottom-up DFS returning (accumulated_difficulty, depth, main_chain_length).
+    fn main_chain_length_by_difficulty_inner(&self) -> (DifficultyBasedDepth, usize, usize) {
+        let self_difficulty = DifficultyBasedDepth::new(self.root.difficulty());
+
+        if self.children.is_empty() {
+            return (self_difficulty, 1, 1);
+        }
+
+        let mut best_key = (DifficultyBasedDepth::new(0), 0usize);
+        let mut best_length = 0;
+
+        // Same tiebreaker logic as `main_chain_by_difficulty_inner`: strict `>`
+        // keeps the first child on ties.
+        for child in self.children.iter() {
+            let (child_diff, child_depth, child_len) =
+                child.main_chain_length_by_difficulty_inner();
+            let key = (child_diff, child_depth);
+
+            if key > best_key {
+                best_key = key;
+                best_length = child_len;
+            }
+        }
+
+        let total_difficulty = self_difficulty + best_key.0;
+        let total_depth = 1 + best_key.1;
+        (total_difficulty, total_depth, 1 + best_length)
     }
 
     /// Returns a `BlockTree` where the hash of the root block matches the provided `block_hash`

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -530,36 +530,36 @@ impl<Block: ChainBlock> BlockTree<Block> {
     ///
     /// Runs in O(n) time where n is the number of blocks in the tree.
     pub fn main_chain_length_by_difficulty(&self) -> usize {
-        self.main_chain_length_by_difficulty_inner().2
+        self.main_chain_length_by_difficulty_inner().1
     }
 
-    /// Bottom-up DFS returning (accumulated_difficulty, depth, main_chain_length).
-    fn main_chain_length_by_difficulty_inner(&self) -> (DifficultyBasedDepth, usize, usize) {
+    /// Bottom-up DFS returning (accumulated_difficulty, main_chain_length).
+    ///
+    /// Same logic as [`main_chain_by_difficulty_inner`](Self::main_chain_by_difficulty_inner),
+    /// but avoids the per-node `Vec<&Block>` allocation since only the chain
+    /// length is needed.
+    fn main_chain_length_by_difficulty_inner(&self) -> (DifficultyBasedDepth, usize) {
         let self_difficulty = DifficultyBasedDepth::new(self.root.difficulty());
 
         if self.children.is_empty() {
-            return (self_difficulty, 1, 1);
+            return (self_difficulty, 1);
         }
 
         let mut best_key = (DifficultyBasedDepth::new(0), 0usize);
-        let mut best_length = 0;
 
         // Same tiebreaker logic as `main_chain_by_difficulty_inner`: strict `>`
         // keeps the first child on ties.
         for child in self.children.iter() {
-            let (child_diff, child_depth, child_len) =
-                child.main_chain_length_by_difficulty_inner();
-            let key = (child_diff, child_depth);
+            let key = child.main_chain_length_by_difficulty_inner();
 
             if key > best_key {
                 best_key = key;
-                best_length = child_len;
             }
         }
 
         let total_difficulty = self_difficulty + best_key.0;
         let total_depth = 1 + best_key.1;
-        (total_difficulty, total_depth, 1 + best_length)
+        (total_difficulty, total_depth)
     }
 
     /// Returns a `BlockTree` where the hash of the root block matches the provided `block_hash`

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -530,36 +530,7 @@ impl<Block: ChainBlock> BlockTree<Block> {
     ///
     /// Runs in O(n) time where n is the number of blocks in the tree.
     pub fn main_chain_length_by_difficulty(&self) -> usize {
-        self.main_chain_length_by_difficulty_inner().2
-    }
-
-    /// Bottom-up DFS returning (accumulated_difficulty, depth, main_chain_length).
-    fn main_chain_length_by_difficulty_inner(&self) -> (DifficultyBasedDepth, usize, usize) {
-        let self_difficulty = DifficultyBasedDepth::new(self.root.difficulty());
-
-        if self.children.is_empty() {
-            return (self_difficulty, 1, 1);
-        }
-
-        let mut best_key = (DifficultyBasedDepth::new(0), 0usize);
-        let mut best_length = 0;
-
-        // Same tiebreaker logic as `main_chain_by_difficulty_inner`: strict `>`
-        // keeps the first child on ties.
-        for child in self.children.iter() {
-            let (child_diff, child_depth, child_len) =
-                child.main_chain_length_by_difficulty_inner();
-            let key = (child_diff, child_depth);
-
-            if key > best_key {
-                best_key = key;
-                best_length = child_len;
-            }
-        }
-
-        let total_difficulty = self_difficulty + best_key.0;
-        let total_depth = 1 + best_key.1;
-        (total_difficulty, total_depth, 1 + best_length)
+        self.main_chain_by_difficulty_inner().1
     }
 
     /// Returns a `BlockTree` where the hash of the root block matches the provided `block_hash`

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -340,8 +340,8 @@ pub fn push(
 /// following Bitcoin's consensus rule. At each fork, the branch with the
 /// strictly highest accumulated difficulty is followed. When accumulated
 /// difficulties are tied, the longest branch (by block count) wins. If
-/// branches still tie on both criteria, the chain ends at the fork point
-/// (contested tip).
+/// branches still tie on both criteria, the branch that was received first
+/// is chosen.
 pub fn get_main_chain(blocks: &UnstableBlocks) -> BlockChain<'_, CachedBlock> {
     blocks.tree.main_chain_by_difficulty()
 }
@@ -790,7 +790,8 @@ mod test {
     // * -> 1
     // * -> 2
     //
-    // Both blocks 1 and 2 contest with each other -> main chain is empty.
+    // Both blocks 1 and 2 tie on (difficulty, depth). Block 1 was received
+    // first, so it wins. Main chain = [*, 1].
     #[test]
     fn get_main_chain_two_contesting_trees() {
         let block_0 = BlockBuilder::genesis().build();
@@ -804,7 +805,10 @@ mod test {
 
         push(&mut forest, &utxos, block_1.clone()).unwrap();
         push(&mut forest, &utxos, block_2.clone()).unwrap();
-        assert_eq!(get_main_chain(&forest), vec![block_0.clone()]);
+        assert_eq!(
+            get_main_chain(&forest),
+            vec![block_0.clone(), block_1.clone()]
+        );
 
         assert_eq!(
             (
@@ -878,8 +882,8 @@ mod test {
     // * -> 1 -> 2 -> 3
     //       \-> a -> b
     //
-    // "1" should be returned in this case, as its the longest chain
-    // without a contested tip.
+    // Block 2 was received before block a, so it wins the tie at block 1.
+    // Main chain = [*, 1, 2, 3].
     #[test]
     fn get_main_chain_fork_at_first_block() {
         let block_0 = BlockBuilder::genesis().build();
@@ -901,7 +905,12 @@ mod test {
         push(&mut forest, &utxos, block_b.clone()).unwrap();
         assert_eq!(
             get_main_chain(&forest),
-            vec![block_0.clone(), block_1.clone()]
+            vec![
+                block_0.clone(),
+                block_1.clone(),
+                block_2.clone(),
+                block_3.clone()
+            ]
         );
 
         assert_eq!(
@@ -937,11 +946,11 @@ mod test {
     //       \-> a -> b
     //   -> x -> y -> z
     //
-    // All blocks are contested.
+    // block_x is the first child of the root, and ties with block_1's
+    // subtree, so x wins. Main chain = [*, x, y, z].
     //
     // Then add block `c` that extends block `b`, at that point
-    // `1 -> a -> b -> c` becomes the only longest chain, and therefore
-    // the "main" chain.
+    // `1 -> a -> b -> c` has greater depth and becomes the main chain.
     #[test]
     fn get_main_chain_multiple_forks() {
         let block_0 = BlockBuilder::genesis().build();
@@ -959,15 +968,18 @@ mod test {
         let cache = TestBlocksCache::new(network);
         let mut forest = UnstableBlocks::new(cache, &utxos, 1, block_0.clone(), network);
 
-        push(&mut forest, &utxos, block_x).unwrap();
-        push(&mut forest, &utxos, block_y).unwrap();
-        push(&mut forest, &utxos, block_z).unwrap();
+        push(&mut forest, &utxos, block_x.clone()).unwrap();
+        push(&mut forest, &utxos, block_y.clone()).unwrap();
+        push(&mut forest, &utxos, block_z.clone()).unwrap();
         push(&mut forest, &utxos, block_1.clone()).unwrap();
         push(&mut forest, &utxos, block_2).unwrap();
         push(&mut forest, &utxos, block_3).unwrap();
         push(&mut forest, &utxos, block_a.clone()).unwrap();
         push(&mut forest, &utxos, block_b.clone()).unwrap();
-        assert_eq!(get_main_chain(&forest), vec![block_0.clone()]);
+        assert_eq!(
+            get_main_chain(&forest),
+            vec![block_0.clone(), block_x, block_y, block_z]
+        );
 
         // Now add block c to b.
         let block_c = BlockBuilder::with_prev_header(block_b.header()).build();
@@ -998,15 +1010,18 @@ mod test {
         let cache = TestBlocksCache::new(network);
         let mut forest = UnstableBlocks::new(cache, &utxos, 1, block_0.clone(), network);
 
-        push(&mut forest, &utxos, block_1).unwrap();
-        push(&mut forest, &utxos, block_2).unwrap();
-        push(&mut forest, &utxos, block_3).unwrap();
+        push(&mut forest, &utxos, block_1.clone()).unwrap();
+        push(&mut forest, &utxos, block_2.clone()).unwrap();
+        push(&mut forest, &utxos, block_3.clone()).unwrap();
         push(&mut forest, &utxos, block_a).unwrap();
         push(&mut forest, &utxos, block_b).unwrap();
         push(&mut forest, &utxos, block_x).unwrap();
         push(&mut forest, &utxos, block_y).unwrap();
         push(&mut forest, &utxos, block_z).unwrap();
-        assert_eq!(get_main_chain(&forest), vec![block_0]);
+        assert_eq!(
+            get_main_chain(&forest),
+            vec![block_0, block_1, block_2, block_3]
+        );
     }
 
     #[test]
@@ -1049,12 +1064,12 @@ mod test {
         assert_eq!(get_main_chain_length(&forest), 4);
     }
 
-    // Two children with equal difficulty and equal depth: contested.
+    // Two children with equal difficulty and equal depth: first child wins.
     //
     // * (d=5) -> A (d=10)
     //         -> B (d=10)
     //
-    // Main chain = [*], length 1.
+    // A was received first. Main chain = [*, A], length 2.
     #[test]
     fn get_main_chain_equal_difficulty_fork() {
         let block_0 = BlockBuilder::genesis().build_with_mock_difficulty(5);
@@ -1068,11 +1083,11 @@ mod test {
         let cache = TestBlocksCache::new(network);
         let mut forest = UnstableBlocks::new(cache, &utxos, 1, block_0.clone(), network);
 
-        push(&mut forest, &utxos, block_a).unwrap();
+        push(&mut forest, &utxos, block_a.clone()).unwrap();
         push(&mut forest, &utxos, block_b).unwrap();
 
-        assert_eq!(get_main_chain(&forest), vec![block_0]);
-        assert_eq!(get_main_chain_length(&forest), 1);
+        assert_eq!(get_main_chain(&forest), vec![block_0, block_a]);
+        assert_eq!(get_main_chain_length(&forest), 2);
     }
 
     // Difficulty-based main chain selection: the fork with higher accumulated
@@ -1185,13 +1200,13 @@ mod test {
         assert_eq!(get_main_chain_length(&forest), 3);
     }
 
-    // Contested fork with equal difficulty AND equal depth.
+    // Fork with equal difficulty AND equal depth: first child wins.
     //
     // * (d=1) -> A (d=50) -> C (d=10)
     //         -> B (d=20) -> D (d=40)
     //
     // A's branch: (diff=60, depth=2). B's branch: (diff=60, depth=2). Tied.
-    // Main chain = [*], length 1.
+    // A was received first. Main chain = [*, A, C], length 3.
     #[test]
     fn get_main_chain_difficulty_fully_contested() {
         let block_0 = BlockBuilder::genesis().build_with_mock_difficulty(1);
@@ -1209,13 +1224,13 @@ mod test {
         let cache = TestBlocksCache::new(network);
         let mut forest = UnstableBlocks::new(cache, &utxos, 1, block_0.clone(), network);
 
-        push(&mut forest, &utxos, block_a).unwrap();
+        push(&mut forest, &utxos, block_a.clone()).unwrap();
         push(&mut forest, &utxos, block_b).unwrap();
-        push(&mut forest, &utxos, block_c).unwrap();
+        push(&mut forest, &utxos, block_c.clone()).unwrap();
         push(&mut forest, &utxos, block_d).unwrap();
 
-        assert_eq!(get_main_chain(&forest), vec![block_0]);
-        assert_eq!(get_main_chain_length(&forest), 1);
+        assert_eq!(get_main_chain(&forest), vec![block_0, block_a, block_c]);
+        assert_eq!(get_main_chain_length(&forest), 3);
     }
 
     // Contested deeper in the tree: the main chain stops at the inner fork.
@@ -1223,7 +1238,8 @@ mod test {
     // * (d=5) -> A (d=10) -> B (d=20)
     //                     -> C (d=20)
     //
-    // At A, B and C tie on (diff=20, depth=1). Main chain = [*, A], length 2.
+    // At A, B and C tie on (diff=20, depth=1). First child B wins.
+    // Main chain = [*, A, B], length 3.
     #[test]
     fn get_main_chain_contested_deeper_fork() {
         let block_0 = BlockBuilder::genesis().build_with_mock_difficulty(5);
@@ -1240,11 +1256,11 @@ mod test {
         let mut forest = UnstableBlocks::new(cache, &utxos, 1, block_0.clone(), network);
 
         push(&mut forest, &utxos, block_a.clone()).unwrap();
-        push(&mut forest, &utxos, block_b).unwrap();
+        push(&mut forest, &utxos, block_b.clone()).unwrap();
         push(&mut forest, &utxos, block_c).unwrap();
 
-        assert_eq!(get_main_chain(&forest), vec![block_0, block_a]);
-        assert_eq!(get_main_chain_length(&forest), 2);
+        assert_eq!(get_main_chain(&forest), vec![block_0, block_a, block_b]);
+        assert_eq!(get_main_chain_length(&forest), 3);
     }
 
     // Longer branch wins on accumulated difficulty.
@@ -1417,7 +1433,7 @@ mod test {
     //   / | \
     //  A  B  C  (d=10, 10, 3)
     //
-    // A and B tie. Main chain = [*], length 1.
+    // A and B tie. First child A wins. Main chain = [*, A], length 2.
     #[test]
     fn get_main_chain_three_children_two_tie() {
         let block_0 = BlockBuilder::genesis().build_with_mock_difficulty(1);
@@ -1433,21 +1449,21 @@ mod test {
         let cache = TestBlocksCache::new(network);
         let mut forest = UnstableBlocks::new(cache, &utxos, 1, block_0.clone(), network);
 
-        push(&mut forest, &utxos, block_a).unwrap();
+        push(&mut forest, &utxos, block_a.clone()).unwrap();
         push(&mut forest, &utxos, block_b).unwrap();
         push(&mut forest, &utxos, block_c).unwrap();
 
-        assert_eq!(get_main_chain(&forest), vec![block_0]);
-        assert_eq!(get_main_chain_length(&forest), 1);
+        assert_eq!(get_main_chain(&forest), vec![block_0, block_a]);
+        assert_eq!(get_main_chain_length(&forest), 2);
     }
 
-    // Adding a block resolves a previously contested fork.
+    // Adding a block to a tied fork.
     //
     // Before:
     //   * (d=1) -> A (d=10)
     //           -> B (d=10)
     //
-    // Contested. Main chain = [*].
+    // A was received first, wins the tie. Main chain = [*, A], length 2.
     //
     // After extending A with C (d=5):
     //   * (d=1) -> A (d=10) -> C (d=5)
@@ -1471,8 +1487,11 @@ mod test {
         push(&mut forest, &utxos, block_a.clone()).unwrap();
         push(&mut forest, &utxos, block_b).unwrap();
 
-        assert_eq!(get_main_chain(&forest), vec![block_0.clone()]);
-        assert_eq!(get_main_chain_length(&forest), 1);
+        assert_eq!(
+            get_main_chain(&forest),
+            vec![block_0.clone(), block_a.clone()]
+        );
+        assert_eq!(get_main_chain_length(&forest), 2);
 
         let block_c =
             BlockBuilder::with_prev_header(block_a.header()).build_with_mock_difficulty(5);

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -992,7 +992,10 @@ mod test {
         );
     }
 
-    // Same as the above test, with a different insertion order.
+    // Same forest as the above test, but inserts 1 → 2 → 3 before x → y → z.
+    // The 1-subtree and the x-subtree tie on both accumulated difficulty and
+    // depth, so the tiebreak picks the earliest-received branch — now 1 → 2 → 3.
+    // Main chain = [*, 1, 2, 3].
     #[test]
     fn get_main_chain_multiple_forks_2() {
         let block_0 = BlockBuilder::genesis().build();

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -809,7 +809,7 @@ impl Fees {
 /// It is defined as the chain with the most accumulated proof-of-work (difficulty),
 /// following Bitcoin's consensus rule. When accumulated difficulties are tied,
 /// the longest branch (by block count) wins. If branches still tie on both
-/// criteria, the chain ends at the fork point (contested tip).
+/// criteria, the branch that was received first is chosen.
 #[derive(CandidType, Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct BlockchainInfo {
     /// The height of the main chain tip.


### PR DESCRIPTION
When two competing blocks appeared at the same height with equal accumulated difficulty and equal depth, the main chain selection algorithm truncated to the fork point (the "contested tip" behavior). This caused:
- the reported main chain height to decrease by 1
- `get_utxos` and `get_balance` to temporarily exclude transactions from both competing blocks

On mainnet, all blocks within a difficulty adjustment period share the same target difficulty, so every competing tip triggered this behavior. This is not rare — it happens roughly every few weeks when two miners find a block at approximately the same time.

Bitcoin Core handles ties by staying on whichever chain it was already following. The tip never regresses to the fork point.

The fix in this PR is as follows: remove the contested flag from `main_chain_by_difficulty_inner` and `main_chain_length_by_difficulty_inner`. When two children tie on `(accumulated_difficulty, depth)`, the first-received child wins.

This works because children are ordered by insertion time (`extend` appends via `push`), and using strict `>` in the comparison keeps the first child that set `best_key`. The tiebreaker only applies while branches are exactly equal — as soon as one branch pulls ahead on either difficulty or depth, it wins outright.