### PR TITLE
refactor: DEFI-2100: Setup struct to bundle PocketIC e2e test boilerplate

### DIFF
--- a/e2e-tests/scenario-1/tests/tests.rs
+++ b/e2e-tests/scenario-1/tests/tests.rs
@@ -1,9 +1,4 @@
-use e2e_test_utils::{
-    bitcoin_get_balance, bitcoin_get_balance_query, bitcoin_get_block_headers, bitcoin_get_utxos,
-    bitcoin_get_utxos_query, get_blockchain_info, install_bitcoin_canister,
-    install_canister_on_subnet, load_wasm, pocket_ic_with_bitcoin_subnet,
-    tick_until_main_chain_height, tick_until_stable_height, update_raw,
-};
+use e2e_test_utils::{update_raw, Setup};
 use ic_btc_interface::{
     GetBalanceRequest, GetBlockHeadersRequest, GetUtxosRequest, InitConfig, Network,
     NetworkInRequest,
@@ -29,27 +24,21 @@ fn utxos_req(address: &str) -> GetUtxosRequest {
 
 #[test]
 fn scenario_1() {
-    let source_wasm = load_wasm("E2E_SCENARIO_1_WASM_PATH", "scenario-1");
-    let btc_wasm = load_wasm("IC_BTC_CANISTER_WASM_PATH", "ic-btc-canister");
-    let (pic, bitcoin_subnet) = pocket_ic_with_bitcoin_subnet();
-    let source_id = install_canister_on_subnet(&pic, bitcoin_subnet, source_wasm, vec![]);
-    let btc_id = install_bitcoin_canister(
-        &pic,
-        bitcoin_subnet,
+    let setup = Setup::new(
+        "E2E_SCENARIO_1_WASM_PATH",
+        "scenario-1",
         InitConfig {
             stability_threshold: Some(2),
             network: Some(Network::Regtest),
-            blocks_source: Some(source_id),
             ..Default::default()
         },
-        btc_wasm,
     );
 
     // Wait until all 5 blocks have been ingested. The scenario-1 canister serves 7
     // GetSuccessors responses (one per heartbeat call); 500 ticks is a generous ceiling.
-    tick_until_main_chain_height(&pic, btc_id, 5, 500);
+    setup.tick_until_main_chain_height(5, 500);
 
-    let info = get_blockchain_info(&pic, btc_id);
+    let info = setup.get_blockchain_info();
     assert_eq!(
         info.height, 5,
         "expected blockchain height 5, got {}",
@@ -60,34 +49,27 @@ fn scenario_1() {
     // main_chain_height=5, blocks 1–3 should become stable. Stable ingestion happens
     // incrementally across heartbeats after the main chain advances, so a few dozen
     // ticks typically suffice; 200 is a generous ceiling.
-    tick_until_stable_height(&pic, btc_id, 3, 200);
+    setup.tick_until_stable_height(3, 200);
 
     // ADDRESS_1 has no balance: it transferred everything to ADDRESS_2 in block 2.
+    assert_eq!(setup.bitcoin_get_balance(balance_req(ADDRESS_1, None)), 0);
     assert_eq!(
-        bitcoin_get_balance(&pic, btc_id, balance_req(ADDRESS_1, None)),
-        0
-    );
-    assert_eq!(
-        bitcoin_get_balance_query(&pic, btc_id, balance_req(ADDRESS_1, None)),
+        setup.bitcoin_get_balance_query(balance_req(ADDRESS_1, None)),
         0
     );
 
     // ADDRESS_2 with min_confirmations=2: block 5's spend is excluded (only 1 confirmation at
     // tip), so it still shows the 50 BTC received in block 2.
     assert_eq!(
-        bitcoin_get_balance(&pic, btc_id, balance_req(ADDRESS_2, Some(2))),
+        setup.bitcoin_get_balance(balance_req(ADDRESS_2, Some(2))),
         5_000_000_000
     );
 
     // ADDRESS_2 UTXOs without filter: block 5 is included so all are spent.
+    assert_eq!(setup.bitcoin_get_utxos(utxos_req(ADDRESS_2)).utxos.len(), 0);
     assert_eq!(
-        bitcoin_get_utxos(&pic, btc_id, utxos_req(ADDRESS_2))
-            .utxos
-            .len(),
-        0
-    );
-    assert_eq!(
-        bitcoin_get_utxos_query(&pic, btc_id, utxos_req(ADDRESS_2))
+        setup
+            .bitcoin_get_utxos_query(utxos_req(ADDRESS_2))
             .utxos
             .len(),
         0
@@ -95,13 +77,12 @@ fn scenario_1() {
 
     // ADDRESS_5 has 10k UTXOs (received in block 5), but responses are capped at 1000.
     assert_eq!(
-        bitcoin_get_utxos(&pic, btc_id, utxos_req(ADDRESS_5))
-            .utxos
-            .len(),
+        setup.bitcoin_get_utxos(utxos_req(ADDRESS_5)).utxos.len(),
         1000
     );
     assert_eq!(
-        bitcoin_get_utxos_query(&pic, btc_id, utxos_req(ADDRESS_5))
+        setup
+            .bitcoin_get_utxos_query(utxos_req(ADDRESS_5))
             .utxos
             .len(),
         1000
@@ -109,8 +90,8 @@ fn scenario_1() {
 
     // Calling query-only methods as replicated (update) calls must be rejected.
     let err = update_raw(
-        &pic,
-        btc_id,
+        &setup.pic,
+        setup.btc_id,
         "bitcoin_get_utxos_query",
         utxos_req(ADDRESS_5),
     )
@@ -118,8 +99,8 @@ fn scenario_1() {
     assert_eq!(err.reject_code, RejectCode::CanisterReject);
 
     let err = update_raw(
-        &pic,
-        btc_id,
+        &setup.pic,
+        setup.btc_id,
         "bitcoin_get_balance_query",
         balance_req(ADDRESS_5, None),
     )
@@ -128,25 +109,21 @@ fn scenario_1() {
 
     // ADDRESS_5 balance.
     assert_eq!(
-        bitcoin_get_balance(&pic, btc_id, balance_req(ADDRESS_5, None)),
+        setup.bitcoin_get_balance(balance_req(ADDRESS_5, None)),
         5_000_000_000
     );
     assert_eq!(
-        bitcoin_get_balance_query(&pic, btc_id, balance_req(ADDRESS_5, None)),
+        setup.bitcoin_get_balance_query(balance_req(ADDRESS_5, None)),
         5_000_000_000
     );
 
     // Verify block headers. The scenario-1 canister chains 5 blocks onto the genesis block,
     // so get_block_headers returns 6 headers (genesis + blocks 1–5).
-    let headers_resp = bitcoin_get_block_headers(
-        &pic,
-        btc_id,
-        GetBlockHeadersRequest {
-            start_height: 0,
-            end_height: None,
-            network: NetworkInRequest::Regtest,
-        },
-    );
+    let headers_resp = setup.bitcoin_get_block_headers(GetBlockHeadersRequest {
+        start_height: 0,
+        end_height: None,
+        network: NetworkInRequest::Regtest,
+    });
     assert_eq!(headers_resp.tip_height, 5);
 
     // Expected headers are the raw 80-byte Bitcoin block headers, matching the blob literals

--- a/e2e-tests/scenario-2/tests/tests.rs
+++ b/e2e-tests/scenario-2/tests/tests.rs
@@ -1,60 +1,42 @@
-use e2e_test_utils::{
-    bitcoin_get_balance, bitcoin_get_utxos, get_blockchain_info, install_bitcoin_canister,
-    install_canister_on_subnet, load_wasm, pocket_ic_with_bitcoin_subnet,
-    tick_until_main_chain_height,
-};
+use e2e_test_utils::Setup;
 use ic_btc_interface::{GetBalanceRequest, GetUtxosRequest, InitConfig, Network, NetworkInRequest};
 use scenario_2::ADDRESS;
 
 #[test]
 fn scenario_2() {
-    let source_wasm = load_wasm("E2E_SCENARIO_2_WASM_PATH", "scenario-2");
-    let btc_wasm = load_wasm("IC_BTC_CANISTER_WASM_PATH", "ic-btc-canister");
-    let (pic, bitcoin_subnet) = pocket_ic_with_bitcoin_subnet();
-    let source_id = install_canister_on_subnet(&pic, bitcoin_subnet, source_wasm, vec![]);
-    let btc_id = install_bitcoin_canister(
-        &pic,
-        bitcoin_subnet,
+    let setup = Setup::new(
+        "E2E_SCENARIO_2_WASM_PATH",
+        "scenario-2",
         InitConfig {
             stability_threshold: Some(1),
             network: Some(Network::Regtest),
-            blocks_source: Some(source_id),
             ..Default::default()
         },
-        btc_wasm,
     );
 
     // The scenario-2 source canister populates 4 blocks, each with 10_000 transactions
     // sending 1 satoshi to ADDRESS. It serves one block per get_successors call, so the
     // bitcoin canister needs several heartbeats to ingest them all; 500 ticks is a
     // generous ceiling.
-    tick_until_main_chain_height(&pic, btc_id, 4, 500);
+    setup.tick_until_main_chain_height(4, 500);
 
-    assert_eq!(get_blockchain_info(&pic, btc_id).height, 4);
+    assert_eq!(setup.get_blockchain_info().height, 4);
 
     // 4 blocks * 10_000 transactions * 1 satoshi = 40_000.
     assert_eq!(
-        bitcoin_get_balance(
-            &pic,
-            btc_id,
-            GetBalanceRequest {
-                address: ADDRESS.to_string(),
-                network: NetworkInRequest::Regtest,
-                min_confirmations: None,
-            }
-        ),
+        setup.bitcoin_get_balance(GetBalanceRequest {
+            address: ADDRESS.to_string(),
+            network: NetworkInRequest::Regtest,
+            min_confirmations: None,
+        }),
         40_000
     );
 
     // ADDRESS has 40_000 UTXOs (one per transaction). Responses are capped at 1000.
-    let utxos_resp = bitcoin_get_utxos(
-        &pic,
-        btc_id,
-        GetUtxosRequest {
-            address: ADDRESS.to_string(),
-            network: NetworkInRequest::Regtest,
-            filter: None,
-        },
-    );
+    let utxos_resp = setup.bitcoin_get_utxos(GetUtxosRequest {
+        address: ADDRESS.to_string(),
+        network: NetworkInRequest::Regtest,
+        filter: None,
+    });
     assert_eq!(utxos_resp.utxos.len(), 1000);
 }

--- a/e2e-tests/scenario-3/tests/tests.rs
+++ b/e2e-tests/scenario-3/tests/tests.rs
@@ -1,49 +1,36 @@
-use e2e_test_utils::{
-    bitcoin_send_transaction, install_bitcoin_canister, install_canister_on_subnet, load_wasm,
-    pocket_ic_with_bitcoin_subnet, query, update_raw,
-};
+use e2e_test_utils::{query, update_raw, Setup};
 use ic_btc_interface::{InitConfig, Network, NetworkInRequest, SendTransactionRequest};
 use serde_bytes::ByteBuf;
 
 #[test]
 fn scenario_3() {
-    let source_wasm = load_wasm("E2E_SCENARIO_3_WASM_PATH", "scenario-3");
-    let btc_wasm = load_wasm("IC_BTC_CANISTER_WASM_PATH", "ic-btc-canister");
-    let (pic, bitcoin_subnet) = pocket_ic_with_bitcoin_subnet();
-    let source_id = install_canister_on_subnet(&pic, bitcoin_subnet, source_wasm, vec![]);
-    let btc_id = install_bitcoin_canister(
-        &pic,
-        bitcoin_subnet,
+    let setup = Setup::new(
+        "E2E_SCENARIO_3_WASM_PATH",
+        "scenario-3",
         InitConfig {
             stability_threshold: Some(2),
             network: Some(Network::Regtest),
-            blocks_source: Some(source_id),
             ..Default::default()
         },
-        btc_wasm,
     );
 
     // Send a valid (empty segwit-encoded) transaction. bitcoin_send_transaction awaits
     // the inter-canister call to bitcoin_send_transaction_internal on the source, so
     // by the time it returns LAST_TRANSACTION on the source has been updated.
     let valid_tx: Vec<u8> = vec![0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0];
-    bitcoin_send_transaction(
-        &pic,
-        btc_id,
-        SendTransactionRequest {
-            network: NetworkInRequest::Regtest,
-            transaction: valid_tx.clone(),
-        },
-    );
+    setup.bitcoin_send_transaction(SendTransactionRequest {
+        network: NetworkInRequest::Regtest,
+        transaction: valid_tx.clone(),
+    });
 
-    let last_tx: ByteBuf = query(&pic, source_id, "get_last_transaction", ());
+    let last_tx: ByteBuf = query(&setup.pic, setup.source_id, "get_last_transaction", ());
     assert_eq!(last_tx.as_slice(), valid_tx.as_slice());
 
     // Send an invalid transaction; the canister must reject with MalformedTransaction.
     let invalid_tx = b"12341234789789".to_vec();
     let reject = update_raw(
-        &pic,
-        btc_id,
+        &setup.pic,
+        setup.btc_id,
         "bitcoin_send_transaction",
         SendTransactionRequest {
             network: NetworkInRequest::Regtest,

--- a/e2e-tests/test-utils/src/lib.rs
+++ b/e2e-tests/test-utils/src/lib.rs
@@ -299,15 +299,6 @@ pub fn bitcoin_send_transaction(pic: &PocketIc, btc_id: Principal, req: SendTran
 
 // ---------- Setup ----------
 
-/// Bundles a PocketIC instance with a deployed bitcoin canister and its
-/// source canister, plus thin method wrappers around the most common
-/// bitcoin canister calls.
-///
-/// Fields are public so tests can still reach the underlying `PocketIc`
-/// and canister ids for things that don't fit the bitcoin-canister method
-/// surface — source-canister queries (e.g. scenario-3's
-/// `get_last_transaction`), and raw update calls that inspect the reject
-/// response (e.g. asserting on `MalformedTransaction`).
 pub struct Setup {
     pub pic: PocketIc,
     pub btc_id: Principal,

--- a/e2e-tests/test-utils/src/lib.rs
+++ b/e2e-tests/test-utils/src/lib.rs
@@ -317,8 +317,16 @@ pub struct Setup {
 impl Setup {
     /// Brings up a fresh PocketIC instance with a bitcoin subnet, installs
     /// the source canister, then installs the bitcoin canister with
-    /// `init.blocks_source` overridden to point at the source canister id.
+    /// `init.blocks_source` wired to the source canister id.
+    ///
+    /// Panics if `init.blocks_source` is `Some(_)`: the source canister id
+    /// is created inside this constructor, so a caller-provided value can
+    /// only be a mistake.
     pub fn new(source_wasm_env: &str, source_name: &str, init: InitConfig) -> Self {
+        assert!(
+            init.blocks_source.is_none(),
+            "Setup::new wires blocks_source itself; caller must leave it as None",
+        );
         let source_wasm = load_wasm(source_wasm_env, source_name);
         let btc_wasm = load_wasm("IC_BTC_CANISTER_WASM_PATH", "ic-btc-canister");
         let (pic, bitcoin_subnet) = pocket_ic_with_bitcoin_subnet();

--- a/e2e-tests/test-utils/src/lib.rs
+++ b/e2e-tests/test-utils/src/lib.rs
@@ -296,3 +296,85 @@ pub fn bitcoin_get_block_headers(
 pub fn bitcoin_send_transaction(pic: &PocketIc, btc_id: Principal, req: SendTransactionRequest) {
     update(pic, btc_id, "bitcoin_send_transaction", req)
 }
+
+// ---------- Setup ----------
+
+/// Bundles a PocketIC instance with a deployed bitcoin canister and its
+/// source canister, plus thin method wrappers around the most common
+/// bitcoin canister calls.
+///
+/// Fields are public so tests can still reach the underlying `PocketIc`
+/// and canister ids for things that don't fit the bitcoin-canister method
+/// surface — source-canister queries (e.g. scenario-3's
+/// `get_last_transaction`), and raw update calls that inspect the reject
+/// response (e.g. asserting on `MalformedTransaction`).
+pub struct Setup {
+    pub pic: PocketIc,
+    pub btc_id: Principal,
+    pub source_id: Principal,
+}
+
+impl Setup {
+    /// Brings up a fresh PocketIC instance with a bitcoin subnet, installs
+    /// the source canister, then installs the bitcoin canister with
+    /// `init.blocks_source` overridden to point at the source canister id.
+    pub fn new(source_wasm_env: &str, source_name: &str, init: InitConfig) -> Self {
+        let source_wasm = load_wasm(source_wasm_env, source_name);
+        let btc_wasm = load_wasm("IC_BTC_CANISTER_WASM_PATH", "ic-btc-canister");
+        let (pic, bitcoin_subnet) = pocket_ic_with_bitcoin_subnet();
+        let source_id = install_canister_on_subnet(&pic, bitcoin_subnet, source_wasm, vec![]);
+        let init = InitConfig {
+            blocks_source: Some(source_id),
+            ..init
+        };
+        let btc_id = install_bitcoin_canister(&pic, bitcoin_subnet, init, btc_wasm);
+        Self {
+            pic,
+            btc_id,
+            source_id,
+        }
+    }
+
+    pub fn get_blockchain_info(&self) -> BlockchainInfo {
+        get_blockchain_info(&self.pic, self.btc_id)
+    }
+
+    pub fn get_stable_height(&self) -> u32 {
+        get_stable_height(&self.pic, self.btc_id)
+    }
+
+    pub fn tick_until_main_chain_height(&self, target: u32, max_ticks: u32) {
+        tick_until_main_chain_height(&self.pic, self.btc_id, target, max_ticks)
+    }
+
+    pub fn tick_until_stable_height(&self, target: u32, max_ticks: u32) {
+        tick_until_stable_height(&self.pic, self.btc_id, target, max_ticks)
+    }
+
+    pub fn bitcoin_get_balance(&self, req: GetBalanceRequest) -> u64 {
+        bitcoin_get_balance(&self.pic, self.btc_id, req)
+    }
+
+    pub fn bitcoin_get_balance_query(&self, req: GetBalanceRequest) -> u64 {
+        bitcoin_get_balance_query(&self.pic, self.btc_id, req)
+    }
+
+    pub fn bitcoin_get_utxos(&self, req: GetUtxosRequest) -> GetUtxosResponse {
+        bitcoin_get_utxos(&self.pic, self.btc_id, req)
+    }
+
+    pub fn bitcoin_get_utxos_query(&self, req: GetUtxosRequest) -> GetUtxosResponse {
+        bitcoin_get_utxos_query(&self.pic, self.btc_id, req)
+    }
+
+    pub fn bitcoin_get_block_headers(
+        &self,
+        req: GetBlockHeadersRequest,
+    ) -> GetBlockHeadersResponse {
+        bitcoin_get_block_headers(&self.pic, self.btc_id, req)
+    }
+
+    pub fn bitcoin_send_transaction(&self, req: SendTransactionRequest) {
+        bitcoin_send_transaction(&self.pic, self.btc_id, req)
+    }
+}


### PR DESCRIPTION
Every e2e test currently repeats the same ~5-line bootstrap (load source WASM, load bitcoin canister WASM, build a PocketIC with a bitcoin subnet, install the source canister, install the bitcoin canister with blocks_source wired to the source) and threads `&pic, btc_id` through every bitcoin canister call. With three callers in place — and seven more shell tests still to migrate — the per-test boilerplate is worth extracting.

Setup owns the PocketIC instance plus the two canister ids and exposes thin method wrappers around the bitcoin canister surface (`get_blockchain_info`, `tick_until_*`, `bitcoin_get_balance{,_query}`, `bitcoin_get_utxos{,_query}`, `bitcoin_get_block_headers`, `bitcoin_send_transaction`). Fields are public so tests can still reach the underlying PocketIc for source-canister queries (scenario-3) and raw update calls that inspect the reject response (scenario-1 / scenario-3). The free functions stay exported and now delegate to the same code paths the methods call into.

scenario-1's test file shrinks from 199 → 175 lines, scenario-2 from 60 → 43, scenario-3 from 59 → 47, and the per-test InitConfig drops the blocks_source override since Setup::new wires it. No behavioural change.