### PR TITLE
chore: Only post canbench results on PRs, not on push to master

### DIFF
--- a/.github/workflows/canbench-post-comment.yml
+++ b/.github/workflows/canbench-post-comment.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   download-results:
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-benchmarks.outputs.matrix }}


### PR DESCRIPTION
Currently, the "Post Canbench results" CI jobs runs both on PRs and on pushes to master. The job posts the Canbench results to the PR, and it retrieves the PR number as part of the job. However, for pushes to master, there is no PR number, so posting the comment fails. This leads to a situation where up to half of the "Post Canbench results" jobs are [failing on CI](https://github.com/dfinity/bitcoin-canister/actions/workflows/canbench-post-comment.yml).

To address the issue, this PR proposes to skip the `download-results` job (which the subsequent `post-comment` job depends on) for non-PRs.