### PR TITLE
perf: DEFI-2954: Avoid deep-cloning ingesting_block on every heartbeat

### DIFF
--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -327,7 +327,7 @@ mod test {
                 }
             }
 
-            state::ingest_stable_blocks_into_utxoset(state);
+            let _ = state::ingest_stable_blocks_into_utxoset(state);
         });
     }
 

--- a/canister/src/api/get_block_headers.rs
+++ b/canister/src/api/get_block_headers.rs
@@ -207,7 +207,7 @@ mod test {
         with_state_mut(|state| {
             insert_block(state, block1).unwrap();
             insert_block(state, block2).unwrap();
-            ingest_stable_blocks_into_utxoset(state);
+            let _ = ingest_stable_blocks_into_utxoset(state);
         });
     }
 
@@ -464,7 +464,7 @@ mod test {
             with_state_mut(|state| insert_block(state, block).unwrap());
         }
 
-        with_state_mut(ingest_stable_blocks_into_utxoset);
+        let _ = with_state_mut(ingest_stable_blocks_into_utxoset);
 
         blobs
     }

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -4,7 +4,7 @@ use crate::{
     state::{self, ResponseToProcess},
     types::{
         GetSuccessorsCompleteResponse, GetSuccessorsRequest, GetSuccessorsRequestInitial,
-        GetSuccessorsResponse,
+        GetSuccessorsResponse, Slicing,
     },
     with_state, with_state_mut,
 };
@@ -23,12 +23,20 @@ pub async fn heartbeat() {
     collect_metrics();
     maybe_burn_cycles();
 
-    if ingest_stable_blocks_into_utxoset() {
-        // Stable-block ingestion did work this round: it either finished a block
-        // or paused mid-block (time-sliced). Exit the heartbeat as a precaution to
-        // not exceed the instructions limit.
-        print("Ingested stable blocks (possibly paused mid-block). Exiting heartbeat.");
-        return;
+    match ingest_stable_blocks_into_utxoset() {
+        // Ingestion paused mid-block (time-sliced): a full budget was already spent, so
+        // exit the heartbeat as a precaution to not exceed the instructions limit.
+        Slicing::Paused(()) => {
+            print("Paused while ingesting a stable block. Exiting heartbeat.");
+            return;
+        }
+        // A stable block finished ingesting this round: exit for the same precaution.
+        Slicing::Done(true) => {
+            print("Done ingesting stable blocks. Exiting heartbeat.");
+            return;
+        }
+        // Nothing was ingested; carry on to fetching/processing.
+        Slicing::Done(false) => {}
     }
 
     if maybe_fetch_blocks().await {
@@ -193,7 +201,7 @@ async fn maybe_fetch_blocks() -> bool {
     true
 }
 
-fn ingest_stable_blocks_into_utxoset() -> bool {
+fn ingest_stable_blocks_into_utxoset() -> Slicing<(), bool> {
     with_state_mut(state::ingest_stable_blocks_into_utxoset)
 }
 

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -774,6 +774,11 @@ mod test {
         );
         // ...and ingestion made real progress into the stable UTXO set.
         assert!(with_state(|s| s.utxos.next_height()) > 0);
+
+        // Restore the shared (thread-local) performance-counter mock to its default so this
+        // test does not affect others that may run later on the same thread.
+        runtime::set_performance_counter_step(0);
+        runtime::performance_counter_reset();
     }
 
     #[async_std::test]

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -483,6 +483,12 @@ mod test {
         // Assert that the blocks have been ingested.
         assert_eq!(with_state(state::main_chain_height), 2);
 
+        // Number of `get_successors` calls issued so far (only the single fetch above).
+        // While stable blocks are still being ingested, the heartbeat must return early
+        // and must NOT issue a new `get_successors` request.
+        let fetches_after_processing =
+            runtime::GET_SUCCESSORS_RESPONSES_INDEX.with(|i| *i.borrow());
+
         // Ingest stable blocks.
         runtime::performance_counter_reset();
         heartbeat().await;
@@ -494,6 +500,12 @@ mod test {
         assert_eq!(partial_block.next_tx_idx, 2);
         assert_eq!(partial_block.next_input_idx, 1);
         assert_eq!(partial_block.next_output_idx, 0);
+        // The paused ingestion returned early without fetching new blocks.
+        assert_eq!(
+            runtime::GET_SUCCESSORS_RESPONSES_INDEX.with(|i| *i.borrow()),
+            fetches_after_processing,
+            "heartbeat fetched new blocks while a stable block was still being ingested",
+        );
 
         // Ingest more stable blocks.
         runtime::performance_counter_reset();
@@ -505,6 +517,12 @@ mod test {
         assert_eq!(partial_block.next_tx_idx, 5);
         assert_eq!(partial_block.next_input_idx, 1);
         assert_eq!(partial_block.next_output_idx, 0);
+        // Still ingesting, still no new fetch.
+        assert_eq!(
+            runtime::GET_SUCCESSORS_RESPONSES_INDEX.with(|i| *i.borrow()),
+            fetches_after_processing,
+            "heartbeat fetched new blocks while a stable block was still being ingested",
+        );
 
         // Only the genesis block has been fully processed, so the stable height is one.
         assert_eq!(with_state(|s| s.utxos.next_height()), 1);
@@ -521,6 +539,19 @@ mod test {
 
         // The stable height is now updated to include `block_1`.
         assert_eq!(with_state(|s| s.utxos.next_height()), 2);
+
+        // No heartbeat fetched new blocks while ingestion was ongoing, including the
+        // one that completed it.
+        assert_eq!(
+            runtime::GET_SUCCESSORS_RESPONSES_INDEX.with(|i| *i.borrow()),
+            fetches_after_processing,
+            "heartbeat fetched new blocks while ingesting stable blocks",
+        );
+
+        // Restore the shared (thread-local) performance-counter mock to its default so this
+        // test does not affect others that may run later on the same thread.
+        runtime::set_performance_counter_step(0);
+        runtime::performance_counter_reset();
     }
 
     #[async_std::test]
@@ -695,91 +726,6 @@ mod test {
             .unwrap(),
             tx_cardinality as u64 * 1000
         );
-    }
-
-    // While a stable block is still being ingested, the heartbeat must return early (via
-    // `ingest_stable_blocks_into_utxoset`) and must NOT issue a new `get_successors` request.
-    #[async_std::test]
-    async fn heartbeat_does_not_fetch_while_ingesting_a_stable_block() {
-        let network = Network::Regtest;
-        let btc_network = into_bitcoin_network(network);
-
-        init(InitConfig {
-            stability_threshold: Some(0),
-            network: Some(network),
-            ..Default::default()
-        });
-
-        let address: Address = random_p2pkh_address(btc_network).into();
-
-        // `block_1` carries several transactions so that its ingestion spans multiple slices;
-        // `block_2` is a successor so that `block_1` becomes stable.
-        let block_1 = build_block(genesis_block(network).header(), address.clone(), 6);
-        let block_2 = build_block(block_1.header(), address, 1);
-
-        let blocks: Vec<BlockBlob> = [block_1, block_2]
-            .iter()
-            .map(|block| {
-                let mut block_bytes = vec![];
-                block.consensus_encode(&mut block_bytes).unwrap();
-                block_bytes
-            })
-            .collect();
-
-        runtime::set_successors_response(GetSuccessorsReply::Ok(GetSuccessorsResponse::Complete(
-            GetSuccessorsCompleteResponse {
-                blocks,
-                next: vec![],
-            },
-        )));
-
-        // Fetch the blocks, then process the response (inserting them into the block tree).
-        heartbeat().await;
-        heartbeat().await;
-        assert_eq!(with_state(state::main_chain_height), 2);
-
-        // Number of `get_successors` calls issued so far (only the single fetch above).
-        let fetches_after_processing =
-            runtime::GET_SUCCESSORS_RESPONSES_INDEX.with(|i| *i.borrow());
-
-        // Force time-slicing so the stable blocks ingest over several heartbeats.
-        runtime::set_performance_counter_step(250_000_000);
-
-        // Start ingesting: this leaves a block partially ingested.
-        runtime::performance_counter_reset();
-        heartbeat().await;
-
-        // Every heartbeat that finds a block mid-ingestion must return early without fetching.
-        let mut ingesting_heartbeats = 0;
-        while with_state(|s| s.utxos.ingesting_block.is_some()) {
-            assert_eq!(
-                runtime::GET_SUCCESSORS_RESPONSES_INDEX.with(|i| *i.borrow()),
-                fetches_after_processing,
-                "heartbeat fetched new blocks while a stable block was still being ingested",
-            );
-            ingesting_heartbeats += 1;
-            runtime::performance_counter_reset();
-            heartbeat().await;
-        }
-
-        // The scenario must actually have exercised in-progress ingestion...
-        assert!(
-            ingesting_heartbeats > 0,
-            "expected at least one heartbeat with ingestion in progress"
-        );
-        // ...no heartbeat fetched while ingestion was ongoing (incl. the one that completed it)...
-        assert_eq!(
-            runtime::GET_SUCCESSORS_RESPONSES_INDEX.with(|i| *i.borrow()),
-            fetches_after_processing,
-            "heartbeat fetched new blocks while ingesting stable blocks",
-        );
-        // ...and ingestion made real progress into the stable UTXO set.
-        assert!(with_state(|s| s.utxos.next_height()) > 0);
-
-        // Restore the shared (thread-local) performance-counter mock to its default so this
-        // test does not affect others that may run later on the same thread.
-        runtime::set_performance_counter_step(0);
-        runtime::performance_counter_reset();
     }
 
     #[async_std::test]

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -24,9 +24,10 @@ pub async fn heartbeat() {
     maybe_burn_cycles();
 
     if ingest_stable_blocks_into_utxoset() {
-        // Exit the heartbeat if stable blocks had been ingested.
-        // This is a precaution to not exceed the instructions limit.
-        print("Done ingesting stable blocks.");
+        // Stable-block ingestion did work this round: it either finished a block
+        // or paused mid-block (time-sliced). Exit the heartbeat as a precaution to
+        // not exceed the instructions limit.
+        print("Ingested stable blocks (possibly paused mid-block). Exiting heartbeat.");
         return;
     }
 

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -438,7 +438,7 @@ mod test {
     }
 
     #[async_std::test]
-    async fn time_slices_large_blocks() {
+    async fn time_slices_large_blocks_without_fetching_while_ingesting() {
         let network = Network::Regtest;
         let btc_network = into_bitcoin_network(network);
 

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -696,6 +696,86 @@ mod test {
         );
     }
 
+    // While a stable block is still being ingested, the heartbeat must return early (via
+    // `ingest_stable_blocks_into_utxoset`) and must NOT issue a new `get_successors` request.
+    #[async_std::test]
+    async fn heartbeat_does_not_fetch_while_ingesting_a_stable_block() {
+        let network = Network::Regtest;
+        let btc_network = into_bitcoin_network(network);
+
+        init(InitConfig {
+            stability_threshold: Some(0),
+            network: Some(network),
+            ..Default::default()
+        });
+
+        let address: Address = random_p2pkh_address(btc_network).into();
+
+        // `block_1` carries several transactions so that its ingestion spans multiple slices;
+        // `block_2` is a successor so that `block_1` becomes stable.
+        let block_1 = build_block(genesis_block(network).header(), address.clone(), 6);
+        let block_2 = build_block(block_1.header(), address, 1);
+
+        let blocks: Vec<BlockBlob> = [block_1, block_2]
+            .iter()
+            .map(|block| {
+                let mut block_bytes = vec![];
+                block.consensus_encode(&mut block_bytes).unwrap();
+                block_bytes
+            })
+            .collect();
+
+        runtime::set_successors_response(GetSuccessorsReply::Ok(GetSuccessorsResponse::Complete(
+            GetSuccessorsCompleteResponse {
+                blocks,
+                next: vec![],
+            },
+        )));
+
+        // Fetch the blocks, then process the response (inserting them into the block tree).
+        heartbeat().await;
+        heartbeat().await;
+        assert_eq!(with_state(state::main_chain_height), 2);
+
+        // Number of `get_successors` calls issued so far (only the single fetch above).
+        let fetches_after_processing =
+            runtime::GET_SUCCESSORS_RESPONSES_INDEX.with(|i| *i.borrow());
+
+        // Force time-slicing so the stable blocks ingest over several heartbeats.
+        runtime::set_performance_counter_step(250_000_000);
+
+        // Start ingesting: this leaves a block partially ingested.
+        runtime::performance_counter_reset();
+        heartbeat().await;
+
+        // Every heartbeat that finds a block mid-ingestion must return early without fetching.
+        let mut ingesting_heartbeats = 0;
+        while with_state(|s| s.utxos.ingesting_block.is_some()) {
+            assert_eq!(
+                runtime::GET_SUCCESSORS_RESPONSES_INDEX.with(|i| *i.borrow()),
+                fetches_after_processing,
+                "heartbeat fetched new blocks while a stable block was still being ingested",
+            );
+            ingesting_heartbeats += 1;
+            runtime::performance_counter_reset();
+            heartbeat().await;
+        }
+
+        // The scenario must actually have exercised in-progress ingestion...
+        assert!(
+            ingesting_heartbeats > 0,
+            "expected at least one heartbeat with ingestion in progress"
+        );
+        // ...no heartbeat fetched while ingestion was ongoing (incl. the one that completed it)...
+        assert_eq!(
+            runtime::GET_SUCCESSORS_RESPONSES_INDEX.with(|i| *i.borrow()),
+            fetches_after_processing,
+            "heartbeat fetched new blocks while ingesting stable blocks",
+        );
+        // ...and ingestion made real progress into the stable UTXO set.
+        assert!(with_state(|s| s.utxos.next_height()) > 0);
+    }
+
     #[async_std::test]
     async fn fetches_and_processes_responses_paginated() {
         let network = Network::Regtest;

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -436,7 +436,7 @@ mod test {
         for block in blocks[1..].iter() {
             with_state_mut(|s| {
                 crate::state::insert_block(s, block.clone()).unwrap();
-                crate::state::ingest_stable_blocks_into_utxoset(s);
+                let _ = crate::state::ingest_stable_blocks_into_utxoset(s);
             });
         }
 
@@ -825,7 +825,7 @@ mod test {
         for block in blocks[1..].iter() {
             with_state_mut(|s| {
                 crate::state::insert_block(s, block.clone()).unwrap();
-                crate::state::ingest_stable_blocks_into_utxoset(s);
+                let _ = crate::state::ingest_stable_blocks_into_utxoset(s);
             });
         }
 

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -211,9 +211,15 @@ pub fn insert_block(state: &mut State, block: Block) -> Result<(), InsertBlockEr
 /// NOTE: This method does a form of time-slicing to stay within the instruction limit, and
 /// multiple calls may be required for all the stable blocks to be ingested.
 ///
-/// Returns `true` if any stable-block ingestion work was performed during this call
-/// (including a paused, time-sliced slice), or `false` if there was nothing to ingest.
-pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
+/// Returns:
+///   * `Slicing::Paused(())` if ingestion was time-sliced and paused mid-block, so
+///     further calls are needed to finish the current block.
+///   * `Slicing::Done(true)` if all stable blocks were ingested during this call.
+///   * `Slicing::Done(false)` if there was nothing to ingest.
+///
+/// The `bool` carried by `Done` reports whether any ingestion work happened, which the
+/// heartbeat uses to decide whether it may move on to fetching new blocks this round.
+pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> Slicing<(), bool> {
     fn pop_block(state: &mut State, ingested_block_hash: BlockHash) {
         let stable_height = state.stable_height();
         // Pop the stable block.
@@ -223,17 +229,17 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
         assert_eq!(popped_block.unwrap().block_hash(), &ingested_block_hash);
     }
 
-    // Tracks whether this call performed any stable-block ingestion work. A
-    // `Slicing::Paused` counts as work (matching the previous clone + `PartialEq`
-    // comparison) and is the safe choice: a paused slice has already spent a full
-    // ingestion budget, so the heartbeat must not also fetch/process this round.
+    // Tracks whether this call performed any stable-block ingestion work. Note that a
+    // `Slicing::Paused` slice returns early rather than setting this flag: a paused slice
+    // has already spent a full ingestion budget, so the heartbeat must not also
+    // fetch/process this round.
     let mut did_work = false;
 
     // Finish ingesting the stable block that's partially ingested, if that exists.
     print("Running ingest_block_continue...");
     match state.utxos.ingest_block_continue() {
         None => {} // No block to continue ingesting.
-        Some(Slicing::Paused(())) => return true,
+        Some(Slicing::Paused(())) => return Slicing::Paused(()),
         Some(Slicing::Done((ingested_block_hash, stats))) => {
             state.metrics.block_ingestion_stats = stats;
             pop_block(state, ingested_block_hash);
@@ -255,7 +261,7 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
             .insert_block(&block, state.utxos.next_height());
 
         match state.utxos.ingest_block(block) {
-            Slicing::Paused(()) => return true,
+            Slicing::Paused(()) => return Slicing::Paused(()),
             Slicing::Done((ingested_block_hash, stats)) => {
                 state.metrics.block_ingestion_stats = stats;
                 pop_block(state, ingested_block_hash);
@@ -264,7 +270,7 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
         }
     }
 
-    did_work
+    Slicing::Done(did_work)
 }
 
 pub fn insert_next_block_headers(state: &mut State, next_block_headers: &[BlockHeaderBlob]) {
@@ -553,7 +559,7 @@ mod test {
 
             for block in blocks[1..].iter() {
                 insert_block(&mut state, block.clone()).unwrap();
-                ingest_stable_blocks_into_utxoset(&mut state);
+                let _ = ingest_stable_blocks_into_utxoset(&mut state);
             }
 
             let mut bytes = vec![];
@@ -577,21 +583,30 @@ mod test {
         let mut state = State::new(cache, stability_threshold, network, blocks[0].clone());
 
         assert_eq!(state.stable_height(), 0);
-        // Nothing is stable yet (the genesis block has no successor) -> no work -> false.
-        assert!(!ingest_stable_blocks_into_utxoset(&mut state));
+        // Nothing is stable yet (the genesis block has no successor) -> nothing to ingest.
+        assert_eq!(
+            ingest_stable_blocks_into_utxoset(&mut state),
+            Slicing::Done(false)
+        );
 
         insert_block(&mut state, blocks[1].clone()).unwrap();
 
-        // The genesis block is now stable. Ingesting it does work -> true.
+        // The genesis block is now stable. Ingesting it fully completes in one call.
         let metrics_before = state.metrics.block_ingestion_stats.clone();
-        assert!(ingest_stable_blocks_into_utxoset(&mut state));
+        assert_eq!(
+            ingest_stable_blocks_into_utxoset(&mut state),
+            Slicing::Done(true)
+        );
         assert_eq!(state.stable_height(), 1);
 
         // Verify that the stats have been updated.
         assert_ne!(metrics_before, state.metrics.block_ingestion_stats);
 
-        // Nothing new is stable now -> no work -> false.
-        assert!(!ingest_stable_blocks_into_utxoset(&mut state));
+        // Nothing new is stable now -> nothing to ingest.
+        assert_eq!(
+            ingest_stable_blocks_into_utxoset(&mut state),
+            Slicing::Done(false)
+        );
 
         // Ingest the next block. This time, the performance counter is set so that
         // the ingestion is time-sliced.
@@ -600,10 +615,14 @@ mod test {
         insert_block(&mut state, blocks[2].clone()).unwrap();
         let metrics_before = state.metrics.block_ingestion_stats.clone();
         let mut num_rounds = 0;
+        let mut saw_paused = false;
         while state.stable_height() == 1 {
             assert_eq!(metrics_before, state.metrics.block_ingestion_stats);
-            // Each slice performed work, whether it paused mid-block or finished it -> true.
-            assert!(ingest_stable_blocks_into_utxoset(&mut state));
+            // Every slice either pauses mid-block or finishes the block on the final call.
+            match ingest_stable_blocks_into_utxoset(&mut state) {
+                Slicing::Paused(()) => saw_paused = true,
+                Slicing::Done(did_work) => assert!(did_work),
+            }
             crate::runtime::performance_counter_reset();
             num_rounds += 1;
         }
@@ -611,14 +630,18 @@ mod test {
         // Assert that the block has been ingested.
         assert_eq!(state.stable_height(), 2);
 
-        // Assert that the block ingestion has been time-sliced.
+        // Assert that the block ingestion has been time-sliced (paused at least once).
         assert!(num_rounds > 1);
+        assert!(saw_paused);
 
         // Assert the stats have been updated.
         assert_ne!(metrics_before, state.metrics.block_ingestion_stats);
 
-        // Everything stable has been ingested -> no work -> false.
-        assert!(!ingest_stable_blocks_into_utxoset(&mut state));
+        // Everything stable has been ingested -> nothing to ingest.
+        assert_eq!(
+            ingest_stable_blocks_into_utxoset(&mut state),
+            Slicing::Done(false)
+        );
 
         // Restore the shared (thread-local) performance-counter mock to its default so this
         // test does not affect others that may run later on the same thread.

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -211,7 +211,8 @@ pub fn insert_block(state: &mut State, block: Block) -> Result<(), InsertBlockEr
 /// NOTE: This method does a form of time-slicing to stay within the instruction limit, and
 /// multiple calls may be required for all the stable blocks to be ingested.
 ///
-/// Returns a bool indicating whether or not the state has changed.
+/// Returns `true` if any stable-block ingestion work was performed during this call
+/// (including a paused, time-sliced slice), or `false` if there was nothing to ingest.
 pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
     fn pop_block(state: &mut State, ingested_block_hash: BlockHash) {
         let stable_height = state.stable_height();
@@ -235,7 +236,7 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
     //
     // Returning `true` for every `Slicing::Paused` is equivalent to the old
     // behaviour: each paused slice mutates `ingesting_block` (via
-    // `stats.num_rounds` / `ins_total`), so the old comparison was always `true`
+    // `stats.num_rounds` / `stats.ins_total`), so the old comparison was always `true`
     // there too. It is also the safe choice: a paused slice has already consumed
     // a full ingestion budget, so the heartbeat must not additionally fetch or
     // process a response this round, or it risks exceeding the message

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -674,6 +674,11 @@ mod test {
         // Everything stable has been ingested -> no work -> false.
         crate::runtime::performance_counter_reset();
         assert!(!ingest_stable_blocks_into_utxoset(&mut state));
+
+        // Restore the shared (thread-local) performance-counter mock to its default so this
+        // test does not affect others that may run later on the same thread.
+        crate::runtime::set_performance_counter_step(0);
+        crate::runtime::performance_counter_reset();
     }
 
     #[test]

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -222,22 +222,35 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
         assert_eq!(popped_block.unwrap().block_hash(), &ingested_block_hash);
     }
 
-    let prev_state = (
-        state.utxos.next_height(),
-        &state.utxos.ingesting_block.clone(),
-    );
-    let has_state_changed = |state: &State| -> bool {
-        prev_state != (state.utxos.next_height(), &state.utxos.ingesting_block)
-    };
+    // Whether this call performed any stable-block ingestion work.
+    //
+    // Previously this was computed by cloning `ingesting_block` on entry and
+    // deep-comparing it (via `PartialEq`) afterwards. That clone + compare walks
+    // the whole `IngestingBlock`, including the accumulated `utxos_delta`, on
+    // every heartbeat. With the deterministic memory tracker (DMT) charging
+    // instructions per accessed page, that per-slice cost grows with the delta
+    // and can consume the self-slicing budget, starving forward progress so that
+    // a block never finishes ingesting and the heartbeat never resumes fetching
+    // (DEFI-2954). We track a cheap bool instead.
+    //
+    // Returning `true` for every `Slicing::Paused` is equivalent to the old
+    // behaviour: each paused slice mutates `ingesting_block` (via
+    // `stats.num_rounds` / `ins_total`), so the old comparison was always `true`
+    // there too. It is also the safe choice: a paused slice has already consumed
+    // a full ingestion budget, so the heartbeat must not additionally fetch or
+    // process a response this round, or it risks exceeding the message
+    // instruction limit.
+    let mut did_work = false;
 
     // Finish ingesting the stable block that's partially ingested, if that exists.
     print("Running ingest_block_continue...");
     match state.utxos.ingest_block_continue() {
         None => {} // No block to continue ingesting.
-        Some(Slicing::Paused(())) => return has_state_changed(state),
+        Some(Slicing::Paused(())) => return true,
         Some(Slicing::Done((ingested_block_hash, stats))) => {
             state.metrics.block_ingestion_stats = stats;
-            pop_block(state, ingested_block_hash)
+            pop_block(state, ingested_block_hash);
+            did_work = true;
         }
     }
 
@@ -255,15 +268,16 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
             .insert_block(&block, state.utxos.next_height());
 
         match state.utxos.ingest_block(block) {
-            Slicing::Paused(()) => return has_state_changed(state),
+            Slicing::Paused(()) => return true,
             Slicing::Done((ingested_block_hash, stats)) => {
                 state.metrics.block_ingestion_stats = stats;
-                pop_block(state, ingested_block_hash)
+                pop_block(state, ingested_block_hash);
+                did_work = true;
             }
         }
     }
 
-    has_state_changed(state)
+    did_work
 }
 
 pub fn insert_next_block_headers(state: &mut State, next_block_headers: &[BlockHeaderBlob]) {

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -223,24 +223,10 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
         assert_eq!(popped_block.unwrap().block_hash(), &ingested_block_hash);
     }
 
-    // Whether this call performed any stable-block ingestion work.
-    //
-    // Previously this was computed by cloning `ingesting_block` on entry and
-    // deep-comparing it (via `PartialEq`) afterwards. That clone + compare walks
-    // the whole `IngestingBlock`, including the accumulated `utxos_delta`, on
-    // every heartbeat. With the deterministic memory tracker (DMT) charging
-    // instructions per accessed page, that per-slice cost grows with the delta
-    // and can consume the self-slicing budget, starving forward progress so that
-    // a block never finishes ingesting and the heartbeat never resumes fetching
-    // (DEFI-2954). We track a cheap bool instead.
-    //
-    // Returning `true` for every `Slicing::Paused` is equivalent to the old
-    // behaviour: each paused slice mutates `ingesting_block` (via
-    // `stats.num_rounds` / `stats.ins_total`), so the old comparison was always `true`
-    // there too. It is also the safe choice: a paused slice has already consumed
-    // a full ingestion budget, so the heartbeat must not additionally fetch or
-    // process a response this round, or it risks exceeding the message
-    // instruction limit.
+    // Tracks whether this call performed any stable-block ingestion work. A
+    // `Slicing::Paused` counts as work (matching the previous clone + `PartialEq`
+    // comparison) and is the safe choice: a paused slice has already spent a full
+    // ingestion budget, so the heartbeat must not also fetch/process this round.
     let mut did_work = false;
 
     // Finish ingesting the stable block that's partially ingested, if that exists.

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -566,7 +566,7 @@ mod test {
     }
 
     #[test]
-    fn block_ingestion_stats_are_updated() {
+    fn ingest_stable_blocks_updates_stats_and_reports_work() {
         let stability_threshold = 0;
         let num_blocks = 3;
         let num_transactions_per_block = 10;

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -624,6 +624,57 @@ mod test {
         assert_ne!(metrics_before, state.metrics.block_ingestion_stats);
     }
 
+    // The return value must be `true` whenever a stable block was ingested (fully or as a
+    // time-sliced chunk) and `false` when there was nothing to ingest. The heartbeat relies
+    // on this to decide whether to keep ingesting or move on to fetching new blocks.
+    #[test]
+    fn ingest_stable_blocks_into_utxoset_reports_whether_work_was_done() {
+        let network = Network::Regtest;
+        // Enough transactions that a single block's ingestion spans multiple slices below.
+        let blocks = build_chain(network, 3, 20);
+
+        let cache = TestBlocksCache::new(network);
+        let mut state = State::new(cache, 0, network, blocks[0].clone());
+
+        // Nothing is stable yet (the genesis block has no successor) -> no work -> false.
+        assert!(!ingest_stable_blocks_into_utxoset(&mut state));
+        assert_eq!(state.stable_height(), 0);
+
+        // Inserting the next block makes the genesis block stable. Ingesting it does work -> true.
+        insert_block(&mut state, blocks[1].clone()).unwrap();
+        assert!(ingest_stable_blocks_into_utxoset(&mut state));
+        assert_eq!(state.stable_height(), 1);
+
+        // Nothing new is stable now -> no work -> false.
+        assert!(!ingest_stable_blocks_into_utxoset(&mut state));
+
+        // Insert a successor so that `blocks[1]` becomes stable, and force time-slicing so that
+        // its ingestion pauses partway through.
+        crate::runtime::set_performance_counter_step(100_000_000);
+        insert_block(&mut state, blocks[2].clone()).unwrap();
+
+        // A paused (partially ingested) slice still did work -> true, even though the block
+        // isn't fully ingested yet.
+        crate::runtime::performance_counter_reset();
+        assert!(ingest_stable_blocks_into_utxoset(&mut state));
+        assert!(
+            state.utxos.ingesting_block.is_some(),
+            "expected ingestion to be time-sliced (paused mid-block)"
+        );
+        assert_eq!(state.stable_height(), 1);
+
+        // Every subsequent slice reports work until the block is fully ingested.
+        while state.utxos.ingesting_block.is_some() {
+            crate::runtime::performance_counter_reset();
+            assert!(ingest_stable_blocks_into_utxoset(&mut state));
+        }
+        assert_eq!(state.stable_height(), 2);
+
+        // Everything stable has been ingested -> no work -> false.
+        crate::runtime::performance_counter_reset();
+        assert!(!ingest_stable_blocks_into_utxoset(&mut state));
+    }
+
     #[test]
     fn should_not_ingest_same_block_twice() {
         let stability_threshold = 0;

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -577,15 +577,21 @@ mod test {
         let mut state = State::new(cache, stability_threshold, network, blocks[0].clone());
 
         assert_eq!(state.stable_height(), 0);
+        // Nothing is stable yet (the genesis block has no successor) -> no work -> false.
+        assert!(!ingest_stable_blocks_into_utxoset(&mut state));
+
         insert_block(&mut state, blocks[1].clone()).unwrap();
 
-        // The genesis block is now stable. Ingest it.
+        // The genesis block is now stable. Ingesting it does work -> true.
         let metrics_before = state.metrics.block_ingestion_stats.clone();
-        ingest_stable_blocks_into_utxoset(&mut state);
+        assert!(ingest_stable_blocks_into_utxoset(&mut state));
         assert_eq!(state.stable_height(), 1);
 
         // Verify that the stats have been updated.
         assert_ne!(metrics_before, state.metrics.block_ingestion_stats);
+
+        // Nothing new is stable now -> no work -> false.
+        assert!(!ingest_stable_blocks_into_utxoset(&mut state));
 
         // Ingest the next block. This time, the performance counter is set so that
         // the ingestion is time-sliced.
@@ -596,7 +602,8 @@ mod test {
         let mut num_rounds = 0;
         while state.stable_height() == 1 {
             assert_eq!(metrics_before, state.metrics.block_ingestion_stats);
-            ingest_stable_blocks_into_utxoset(&mut state);
+            // Each slice performed work, whether it paused mid-block or finished it -> true.
+            assert!(ingest_stable_blocks_into_utxoset(&mut state));
             crate::runtime::performance_counter_reset();
             num_rounds += 1;
         }
@@ -609,56 +616,8 @@ mod test {
 
         // Assert the stats have been updated.
         assert_ne!(metrics_before, state.metrics.block_ingestion_stats);
-    }
-
-    // The return value must be `true` whenever a stable block was ingested (fully or as a
-    // time-sliced chunk) and `false` when there was nothing to ingest. The heartbeat relies
-    // on this to decide whether to keep ingesting or move on to fetching new blocks.
-    #[test]
-    fn ingest_stable_blocks_into_utxoset_reports_whether_work_was_done() {
-        let network = Network::Regtest;
-        // Enough transactions that a single block's ingestion spans multiple slices below.
-        let blocks = build_chain(network, 3, 20);
-
-        let cache = TestBlocksCache::new(network);
-        let mut state = State::new(cache, 0, network, blocks[0].clone());
-
-        // Nothing is stable yet (the genesis block has no successor) -> no work -> false.
-        assert!(!ingest_stable_blocks_into_utxoset(&mut state));
-        assert_eq!(state.stable_height(), 0);
-
-        // Inserting the next block makes the genesis block stable. Ingesting it does work -> true.
-        insert_block(&mut state, blocks[1].clone()).unwrap();
-        assert!(ingest_stable_blocks_into_utxoset(&mut state));
-        assert_eq!(state.stable_height(), 1);
-
-        // Nothing new is stable now -> no work -> false.
-        assert!(!ingest_stable_blocks_into_utxoset(&mut state));
-
-        // Insert a successor so that `blocks[1]` becomes stable, and force time-slicing so that
-        // its ingestion pauses partway through.
-        crate::runtime::set_performance_counter_step(100_000_000);
-        insert_block(&mut state, blocks[2].clone()).unwrap();
-
-        // A paused (partially ingested) slice still did work -> true, even though the block
-        // isn't fully ingested yet.
-        crate::runtime::performance_counter_reset();
-        assert!(ingest_stable_blocks_into_utxoset(&mut state));
-        assert!(
-            state.utxos.ingesting_block.is_some(),
-            "expected ingestion to be time-sliced (paused mid-block)"
-        );
-        assert_eq!(state.stable_height(), 1);
-
-        // Every subsequent slice reports work until the block is fully ingested.
-        while state.utxos.ingesting_block.is_some() {
-            crate::runtime::performance_counter_reset();
-            assert!(ingest_stable_blocks_into_utxoset(&mut state));
-        }
-        assert_eq!(state.stable_height(), 2);
 
         // Everything stable has been ingested -> no work -> false.
-        crate::runtime::performance_counter_reset();
         assert!(!ingest_stable_blocks_into_utxoset(&mut state));
 
         // Restore the shared (thread-local) performance-counter mock to its default so this

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -452,7 +452,10 @@ fn init_balances() -> StableBTreeMap<Address, u64, Memory> {
 
 /// A state for maintaining a stable block that is partially ingested into the UTXO set.
 /// Used for time slicing.
-#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, Eq)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq)]
+// `Clone` is only needed by tests; deriving it in production would invite the
+// kind of expensive deep clone this type is designed to avoid on the hot path.
+#[cfg_attr(test, derive(Clone))]
 pub struct IngestingBlock {
     pub block: Block,
     pub next_tx_idx: usize,

--- a/canister/src/validation.rs
+++ b/canister/src/validation.rs
@@ -177,7 +177,7 @@ mod test {
             // Insert all the blocks except the last block.
             for block in blocks[1..blocks.len() - 1].iter() {
                 insert_block(&mut state, block.clone()).unwrap();
-                ingest_stable_blocks_into_utxoset(&mut state);
+                let _ = ingest_stable_blocks_into_utxoset(&mut state);
             }
 
             // Try validating the last block header (which wasn't inserted above).


### PR DESCRIPTION
## Purpose

The Bitcoin mainnet-staging canister (`axowo`, subnet `io67a`) stopped making sync progress the moment its replica was upgraded to a build that enables the **deterministic memory tracker (DMT)**. DMT charges instructions for every page access — including reads — which the previous memory tracker did not.

`ingest_stable_blocks_into_utxoset` cloned and `PartialEq`-compared the entire `ingesting_block` on **every heartbeat**, purely to decide whether any ingestion work had happened. That structure is the full block (stored twice internally, no `Arc`) plus the monotonically growing `utxos_delta` — all heap data. Under the old tracker those reads were free; under DMT they are charged per accessed page, against the same instruction counter the ingestion loop uses to time-slice. The block half is constant across all slices of a block yet is re-cloned/compared every heartbeat.

This PR replaces the clone + deep-compare with a cheap boolean derived directly from the slicing results, removing that avoidable per-slice cost from the block-ingestion hot path.

## Notes

- Behaviour is unchanged: a paused slice always mutates `ingesting_block` (via the round counter), so the previous comparison already returned `true` in that case; returning `true` on a paused slice is also the safe choice for the self-imposed instruction-limit guard (the heartbeat then declines to also fetch/process in the same round).
- This is a low-risk first lever. Profiling suggests the clone/compare is a contributor (~10–25% of per-heartbeat page traffic) rather than the dominant cost, so it may not fully resolve the stall on its own; the remaining cost is the UTXO-set operations under DMT.
- Tracking / full analysis: DEFI-2954.
