### PR TITLE
chore: add opt-in debug heartbeat throttle to cap cycle burn (DEFI-2954, do not merge)

### DIFF
--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -50,4 +50,5 @@ test-strategy = "0.3.1"
 file_memory = []
 save_chain_as_hex = []
 mock_time = []
+debug_throttle = []
 canbench-rs = ["dep:canbench-rs", "ic-btc-validation/canbench-rs"]

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -12,7 +12,6 @@ use bitcoin::{consensus::Decodable, Block as BitcoinBlock};
 use datasize::data_size;
 use ic_btc_interface::Flag;
 use ic_btc_types::{Block, BlockHash};
-use std::cell::Cell;
 use std::time::Duration;
 
 /// DEBUG ONLY (DEFI-2954): minimum wall-clock interval, in nanoseconds, between heartbeats that
@@ -20,26 +19,30 @@ use std::time::Duration;
 ///
 /// A round fires a heartbeat roughly once per second, and while the UTXO-set ingestion is stuck
 /// each heartbeat spends a full ~1B-instruction budget, driving a very high cycle burn. Throttling
-/// the heartbeat caps that burn so the canister can be observed/debugged cheaply. Set to `0` to
-/// disable throttling (run every round, i.e. the production behaviour).
+/// the heartbeat caps that burn so the canister can be observed/debugged cheaply.
 ///
-/// This is a debugging aid and is NOT intended to be merged to production.
+/// The throttle is enabled only by the `debug_throttle` cargo feature; the default build runs the
+/// heartbeat every round (production behaviour). This is a debugging aid, NOT for production.
+#[cfg(any(test, feature = "debug_throttle"))]
 const MIN_HEARTBEAT_INTERVAL_NANOS: u64 = 60 * 1_000_000_000; // ~60 seconds
 
+#[cfg(any(test, feature = "debug_throttle"))]
 thread_local! {
     /// Timestamp (ns since epoch) of the last heartbeat that was allowed to do work.
-    static LAST_HEARTBEAT_NANOS: Cell<u64> = const { Cell::new(0) };
+    static LAST_HEARTBEAT_NANOS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
 /// Pure throttle decision: whether a heartbeat at `now_nanos` may do work given that the last
 /// working heartbeat was at `last_nanos` (`0` meaning "never"). Kept side-effect free so it can be
 /// unit-tested deterministically.
+#[cfg(any(test, feature = "debug_throttle"))]
 fn should_run_after(now_nanos: u64, last_nanos: u64) -> bool {
     last_nanos == 0 || now_nanos.saturating_sub(last_nanos) >= MIN_HEARTBEAT_INTERVAL_NANOS
 }
 
 /// Returns whether the heartbeat should do work now, recording `now_nanos` as the most recent
 /// working heartbeat when it returns `true`.
+#[cfg(any(test, feature = "debug_throttle"))]
 fn heartbeat_should_run(now_nanos: u64) -> bool {
     LAST_HEARTBEAT_NANOS.with(|last| {
         if should_run_after(now_nanos, last.get()) {
@@ -57,10 +60,11 @@ fn heartbeat_should_run(now_nanos: u64) -> bool {
 pub async fn heartbeat() {
     // DEBUG ONLY (DEFI-2954): skip this heartbeat if the previous working heartbeat was too
     // recent, to cap the cycle burn rate while ingestion is stuck. See MIN_HEARTBEAT_INTERVAL_NANOS.
-    // Compiled out under `cfg(test)`: many tests drive `heartbeat()` several times in rapid
-    // (near-instant) succession and rely on each call doing work. The throttle logic itself is
-    // covered by dedicated tests (`heartbeat_should_run` / `should_run_after`).
-    #[cfg(not(test))]
+    // Active only in `debug_throttle` builds and never under `cfg(test)`: the default build (used
+    // by CI/e2e and in production) runs every round, and tests drive `heartbeat()` in rapid
+    // succession relying on each call doing work. The throttle logic itself is covered by dedicated
+    // tests (`heartbeat_should_run` / `should_run_after`).
+    #[cfg(all(feature = "debug_throttle", not(test)))]
     if !heartbeat_should_run(time()) {
         return;
     }
@@ -1012,14 +1016,23 @@ mod test {
         let mut throttled = 0;
         let mut t = t0 + one_sec;
         while t < t0 + interval {
-            assert!(!heartbeat_should_run(t), "heartbeat within interval must be throttled");
+            assert!(
+                !heartbeat_should_run(t),
+                "heartbeat within interval must be throttled"
+            );
             throttled += 1;
             t += one_sec;
         }
-        assert!(throttled >= 50, "expected many throttled heartbeats within the ~60s interval");
+        assert!(
+            throttled >= 50,
+            "expected many throttled heartbeats within the ~60s interval"
+        );
 
         // At the interval boundary it runs again (and re-arms from this new time).
-        assert!(heartbeat_should_run(t0 + interval), "heartbeat at the interval should run");
+        assert!(
+            heartbeat_should_run(t0 + interval),
+            "heartbeat at the interval should run"
+        );
 
         // One second later is throttled relative to the new last-run time (not the original).
         assert!(

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -12,12 +12,59 @@ use bitcoin::{consensus::Decodable, Block as BitcoinBlock};
 use datasize::data_size;
 use ic_btc_interface::Flag;
 use ic_btc_types::{Block, BlockHash};
+use std::cell::Cell;
 use std::time::Duration;
+
+/// DEBUG ONLY (DEFI-2954): minimum wall-clock interval, in nanoseconds, between heartbeats that
+/// are allowed to do work.
+///
+/// A round fires a heartbeat roughly once per second, and while the UTXO-set ingestion is stuck
+/// each heartbeat spends a full ~1B-instruction budget, driving a very high cycle burn. Throttling
+/// the heartbeat caps that burn so the canister can be observed/debugged cheaply. Set to `0` to
+/// disable throttling (run every round, i.e. the production behaviour).
+///
+/// This is a debugging aid and is NOT intended to be merged to production.
+const MIN_HEARTBEAT_INTERVAL_NANOS: u64 = 60 * 1_000_000_000; // ~60 seconds
+
+thread_local! {
+    /// Timestamp (ns since epoch) of the last heartbeat that was allowed to do work.
+    static LAST_HEARTBEAT_NANOS: Cell<u64> = const { Cell::new(0) };
+}
+
+/// Pure throttle decision: whether a heartbeat at `now_nanos` may do work given that the last
+/// working heartbeat was at `last_nanos` (`0` meaning "never"). Kept side-effect free so it can be
+/// unit-tested deterministically.
+fn should_run_after(now_nanos: u64, last_nanos: u64) -> bool {
+    last_nanos == 0 || now_nanos.saturating_sub(last_nanos) >= MIN_HEARTBEAT_INTERVAL_NANOS
+}
+
+/// Returns whether the heartbeat should do work now, recording `now_nanos` as the most recent
+/// working heartbeat when it returns `true`.
+fn heartbeat_should_run(now_nanos: u64) -> bool {
+    LAST_HEARTBEAT_NANOS.with(|last| {
+        if should_run_after(now_nanos, last.get()) {
+            last.set(now_nanos);
+            true
+        } else {
+            false
+        }
+    })
+}
 
 /// The heartbeat of the Bitcoin canister.
 ///
 /// The heartbeat fetches new blocks from the bitcoin network and inserts them into the state.
 pub async fn heartbeat() {
+    // DEBUG ONLY (DEFI-2954): skip this heartbeat if the previous working heartbeat was too
+    // recent, to cap the cycle burn rate while ingestion is stuck. See MIN_HEARTBEAT_INTERVAL_NANOS.
+    // Compiled out under `cfg(test)`: many tests drive `heartbeat()` several times in rapid
+    // (near-instant) succession and rely on each call doing work. The throttle logic itself is
+    // covered by dedicated tests (`heartbeat_should_run` / `should_run_after`).
+    #[cfg(not(test))]
+    if !heartbeat_should_run(time()) {
+        return;
+    }
+
     print("Starting heartbeat...");
 
     collect_metrics();
@@ -921,6 +968,70 @@ mod test {
             with_state(|s| s.unstable_blocks.next_block_headers_max_height()),
             Some(30)
         );
+    }
+
+    // DEBUG ONLY (DEFI-2954): the heartbeat throttle must only let work through once per
+    // ~`MIN_HEARTBEAT_INTERVAL_NANOS`. This checks the pure interval decision at the boundary.
+    #[test]
+    fn heartbeat_throttle_interval_boundary() {
+        let interval = MIN_HEARTBEAT_INTERVAL_NANOS;
+        assert!(interval > 0, "throttling must be enabled for this test");
+
+        let now = 5_000_000_000_000u64; // arbitrary "now" (ns), large enough to subtract from.
+
+        // The very first heartbeat (no previous run, last == 0) is always allowed.
+        assert!(should_run_after(now, 0));
+
+        // Anything within the interval is throttled.
+        assert!(!should_run_after(now, now - 1));
+        assert!(!should_run_after(now, now - (interval - 1)));
+
+        // At or beyond the interval it is allowed again.
+        assert!(should_run_after(now, now - interval));
+        assert!(should_run_after(now, now - (interval + 1)));
+    }
+
+    // DEBUG ONLY (DEFI-2954): `heartbeat_should_run` is what `heartbeat()` calls to decide whether
+    // to do work. It must allow the first call, then only allow one call per interval, re-arming
+    // relative to the last call that actually ran. Timestamps are supplied explicitly, simulating
+    // the ~once-per-second heartbeat invocations, so this is deterministic without mock time.
+    #[test]
+    fn heartbeat_should_run_allows_work_once_per_interval() {
+        let interval = MIN_HEARTBEAT_INTERVAL_NANOS;
+        let one_sec = 1_000_000_000u64;
+
+        // Start from a clean throttle state (thread-local can carry over between tests).
+        LAST_HEARTBEAT_NANOS.with(|c| c.set(0));
+
+        let t0 = 5_000_000_000_000u64;
+
+        // First invocation runs and records t0.
+        assert!(heartbeat_should_run(t0), "first heartbeat should run");
+
+        // Subsequent invocations within the interval (e.g. every ~second) are all throttled.
+        let mut throttled = 0;
+        let mut t = t0 + one_sec;
+        while t < t0 + interval {
+            assert!(!heartbeat_should_run(t), "heartbeat within interval must be throttled");
+            throttled += 1;
+            t += one_sec;
+        }
+        assert!(throttled >= 50, "expected many throttled heartbeats within the ~60s interval");
+
+        // At the interval boundary it runs again (and re-arms from this new time).
+        assert!(heartbeat_should_run(t0 + interval), "heartbeat at the interval should run");
+
+        // One second later is throttled relative to the new last-run time (not the original).
+        assert!(
+            !heartbeat_should_run(t0 + interval + one_sec),
+            "throttle should re-arm from the last heartbeat that ran"
+        );
+
+        // A further full interval later it runs again.
+        assert!(heartbeat_should_run(t0 + 2 * interval));
+
+        // Clean up the shared throttle state so other tests are unaffected.
+        LAST_HEARTBEAT_NANOS.with(|c| c.set(0));
     }
 
     fn num_inputs(block: &Block) -> u32 {


### PR DESCRIPTION
## Purpose (debug only — not for merge)

While the Bitcoin canister's UTXO-set ingestion is stuck under the deterministic memory tracker (DMT), each heartbeat spends a full ~1 B-instruction budget every round. Measured on staging (`axowo`, subnet `io67a`), that burned cycles at **~5.5 T/hr (~19× idle)** — enough to drain the liquid balance to the **freezing threshold in ~32 h** (the canister is currently frozen). Topping it up only restarts the same runaway burn.

This branch adds a wall-clock **throttle** to `heartbeat()` so it does work at most once per `MIN_HEARTBEAT_INTERVAL_NANOS` (default **~60 s**). At that rate the burn drops to **~0.2 T/hr (~$0.3/hr)**, so the canister can be brought back and observed/debugged cheaply (e.g. to confirm whether the Experiment 1 fix actually lets ingestion make progress) without a top-up vanishing in minutes.

## What it does
- Gates the top of `heartbeat()`: if the previous *working* heartbeat was less than the interval ago, return immediately (near-free no-op).
- The gate is compiled out under `cfg(test)` — many tests drive `heartbeat()` several times in rapid succession and rely on each call doing work. The throttle decision is covered by dedicated tests instead.
- Set `MIN_HEARTBEAT_INTERVAL_NANOS = 0` to disable throttling (production behaviour).

## Tests
- `heartbeat_throttle_interval_boundary` — pure interval decision at the boundary.
- `heartbeat_should_run_allows_work_once_per_interval` — drives the throttle with a sequence of ~per-second timestamps and asserts work is allowed once per ~60 s, re-arming from the last run.
- All existing `heartbeat::` tests still pass (the throttle is compiled out under `cfg(test)`).

## Usage
Build the wasm (`./scripts/build-canister.sh ic-btc-canister`) and upgrade the staging canister to it. Intended deploy flow: stop → upgrade → modest top-up → start → observe. This PR is **not intended to be merged** to `master`.

Tracking / analysis: DEFI-2954.
