### PR TITLE
test: DEFI-2957: Add steady-state heartbeat canbench benchmark

### DIFF
--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1,9 +1,12 @@
 use bitcoin::consensus::Decodable;
 use bitcoin::constants::genesis_block;
 use bitcoin::{block::Header, consensus::Encodable, Block as BitcoinBlock};
-use canbench_rs::{bench, bench_fn, BenchResult};
+use canbench_rs::{bench, bench_fn, bench_scope, BenchResult};
 use ic_btc_canister::state::main_chain_height;
-use ic_btc_canister::{types::BlockHeaderBlob, with_state, with_state_mut};
+use ic_btc_canister::{
+    types::{BlockHeaderBlob, Slicing},
+    with_state, with_state_mut,
+};
 use ic_btc_interface::{
     GetBalanceRequest, GetBlockHeadersRequest, GetCurrentFeePercentilesRequest, GetUtxosRequest,
     InitConfig, Network, NetworkInRequest,
@@ -540,6 +543,64 @@ fn bitcoin_get_current_fee_percentiles() -> BenchResult {
                 network: NetworkInRequest::Regtest,
             },
         );
+    })
+}
+
+#[bench(raw)]
+fn heartbeat_steady_state_synced() -> BenchResult {
+    let blocks_to_insert: usize = 100;
+    let num_transactions_per_block: usize = 300;
+    let num_outputs_per_transaction: usize = 3;
+
+    ic_btc_canister::init(InitConfig {
+        network: Some(Network::Regtest),
+        stability_threshold: Some((blocks_to_insert * 2) as u128),
+        ..Default::default()
+    });
+
+    let address = parsed_address();
+    let genesis = genesis_block(bitcoin::Network::Regtest);
+    let mut counter = 1u64;
+    let chain = build_chain_from(
+        genesis.header,
+        blocks_to_insert,
+        num_transactions_per_block,
+        num_outputs_per_transaction,
+        0,
+        &address,
+        &mut counter,
+    );
+
+    with_state_mut(|s| {
+        for block in &chain {
+            ic_btc_canister::state::insert_block(s, block.clone()).unwrap();
+        }
+    });
+
+    assert_chain_height(blocks_to_insert);
+
+    bench_fn(|| {
+        {
+            let _s = bench_scope("collect_metrics_tip_depths");
+            with_state(|s| {
+                let _ = s.unstable_blocks.tip_depths();
+            });
+        }
+
+        {
+            let _s = bench_scope("ingest_no_op");
+            with_state_mut(|s| {
+                let slicing = ic_btc_canister::state::ingest_stable_blocks_into_utxoset(s);
+                assert!(matches!(slicing, Slicing::Done(false)));
+            });
+        }
+
+        {
+            let _s = bench_scope("build_get_successors_request");
+            with_state(|s| {
+                let _ = ic_btc_canister::state::get_block_hashes(s);
+            });
+        }
     })
 }
 

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -76,6 +76,28 @@ benches:
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
+  heartbeat_steady_state_synced:
+    total:
+      calls: 1
+      instructions: 809184
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes:
+      build_get_successors_request:
+        calls: 1
+        instructions: 707618
+        heap_increase: 0
+        stable_memory_increase: 0
+      collect_metrics_tip_depths:
+        calls: 1
+        instructions: 73672
+        heap_increase: 0
+        stable_memory_increase: 0
+      ingest_no_op:
+        calls: 1
+        instructions: 24741
+        heap_increase: 0
+        stable_memory_increase: 0
   insert_300_blocks:
     total:
       calls: 1


### PR DESCRIPTION
## Purpose

Follow-up to DEFI-2954. Once synced, the Bitcoin canister's steady-state cycle burn is ~2.8× higher under the deterministic memory tracker (DMT), and it was not yet known which part of the every-round heartbeat drives the ~0.65 T/hr of execution burn.

This adds a canbench benchmark, `heartbeat_steady_state_synced`, that reproduces a fully-synced heartbeat over a realistic ~100-block unstable block tree and uses canbench scopes to attribute the synchronous per-round work across its components (`collect_metrics`/`tip_depths`, the no-op `ingest`/`peek` path, and building the `get_successors` request). The goal is to target the dominant contributor before optimizing.

The benchmark immediately surfaces that building the `get_successors` request (`get_block_hashes`) dominates the synchronous cost (~87%), pointing at an O(n²) hash collection in `BlockTree::get_hashes` as the first optimization target.

## Notes / limitations

- Measures the **synchronous** heartbeat work only. The async fetch (inter-canister `bitcoin_get_successors` call) is excluded because canbench builds to wasm32, where the real call is compiled in (the test mock is `cfg(not(wasm32))`) and cannot execute under canbench.
- canbench reports **instructions**, not DMT page-access charges, and cannot model multi-heartbeat behaviour in a single message (see DEFI-2954). It identifies the expensive components and guards against regressions.