### PR TITLE
perf: DEFI-2957: Make BlockTree::get_hashes O(n) instead of O(n²)

### DIFF
--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1,9 +1,12 @@
 use bitcoin::consensus::Decodable;
 use bitcoin::constants::genesis_block;
 use bitcoin::{block::Header, consensus::Encodable, Block as BitcoinBlock};
-use canbench_rs::{bench, bench_fn, BenchResult};
+use canbench_rs::{bench, bench_fn, bench_scope, BenchResult};
 use ic_btc_canister::state::main_chain_height;
-use ic_btc_canister::{types::BlockHeaderBlob, with_state, with_state_mut};
+use ic_btc_canister::{
+    types::{BlockHeaderBlob, Slicing},
+    with_state, with_state_mut,
+};
 use ic_btc_interface::{
     GetBalanceRequest, GetBlockHeadersRequest, GetCurrentFeePercentilesRequest, GetUtxosRequest,
     InitConfig, Network, NetworkInRequest,
@@ -540,6 +543,64 @@ fn bitcoin_get_current_fee_percentiles() -> BenchResult {
                 network: NetworkInRequest::Regtest,
             },
         );
+    })
+}
+
+#[bench(raw)]
+fn heartbeat_steady_state_synced() -> BenchResult {
+    let blocks_to_insert: usize = 100;
+    let num_transactions_per_block: usize = 300;
+    let num_outputs_per_transaction: usize = 3;
+
+    ic_btc_canister::init(InitConfig {
+        network: Some(Network::Regtest),
+        stability_threshold: Some((blocks_to_insert * 2) as u128),
+        ..Default::default()
+    });
+
+    let address = parsed_address();
+    let genesis = genesis_block(bitcoin::Network::Regtest);
+    let mut counter = 1u64;
+    let chain = build_chain_from(
+        genesis.header,
+        blocks_to_insert,
+        num_transactions_per_block,
+        num_outputs_per_transaction,
+        0,
+        &address,
+        &mut counter,
+    );
+
+    with_state_mut(|s| {
+        for block in &chain {
+            ic_btc_canister::state::insert_block(s, block.clone()).unwrap();
+        }
+    });
+
+    assert_chain_height(blocks_to_insert);
+
+    bench_fn(|| {
+        {
+            let _s = bench_scope("collect_metrics_tip_depths");
+            with_state(|s| {
+                let _ = s.unstable_blocks.tip_depths();
+            });
+        }
+
+        {
+            let _s = bench_scope("ingest_no_op");
+            with_state_mut(|s| {
+                let slicing = ic_btc_canister::state::ingest_stable_blocks_into_utxoset(s);
+                assert!(matches!(slicing, Slicing::Done(false)));
+            });
+        }
+
+        {
+            let _s = bench_scope("build_get_successors_request");
+            with_state(|s| {
+                let _ = ic_btc_canister::state::get_block_hashes(s);
+            });
+        }
     })
 }
 

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -76,6 +76,28 @@ benches:
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
+  heartbeat_steady_state_synced:
+    total:
+      calls: 1
+      instructions: 809184
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes:
+      build_get_successors_request:
+        calls: 1
+        instructions: 707618
+        heap_increase: 0
+        stable_memory_increase: 0
+      collect_metrics_tip_depths:
+        calls: 1
+        instructions: 73672
+        heap_increase: 0
+        stable_memory_increase: 0
+      ingest_no_op:
+        calls: 1
+        instructions: 24741
+        heap_increase: 0
+        stable_memory_increase: 0
   insert_300_blocks:
     total:
       calls: 1

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -79,13 +79,13 @@ benches:
   heartbeat_steady_state_synced:
     total:
       calls: 1
-      instructions: 809184
+      instructions: 119658
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_get_successors_request:
         calls: 1
-        instructions: 707618
+        instructions: 17960
         heap_increase: 0
         stable_memory_increase: 0
       collect_metrics_tip_depths:

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -607,10 +607,16 @@ impl<Block: ChainBlock> BlockTree<Block> {
 
     /// Returns the hashes of all blocks in the tree.
     pub fn get_hashes(&self) -> Vec<BlockHash> {
-        let mut hashes = Vec::with_capacity(self.children.len() + 1);
-        hashes.push(*self.root.block_hash());
-        hashes.extend(self.children.iter().flat_map(|child| child.get_hashes()));
+        let mut hashes = Vec::new();
+        self.collect_hashes(&mut hashes);
         hashes
+    }
+
+    fn collect_hashes(&self, hashes: &mut Vec<BlockHash>) {
+        hashes.push(*self.root.block_hash());
+        for child in self.children.iter() {
+            child.collect_hashes(hashes);
+        }
     }
 
     /// Returns all blocks in the tree with their depths

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -985,6 +985,36 @@ mod test {
         assert_eq!(height_2_depth, 1);
     }
 
+    // The heartbeat pops index 0 as the anchor (`processed_block_hashes.remove(0)`), so
+    // `get_hashes` must return every block once in pre-order with the root first.
+    #[test]
+    fn get_hashes_is_preorder_with_root_first() {
+        // root -> a -> b
+        //    \--> c
+        let root = BlockBuilder::genesis().build();
+        let a = BlockBuilder::with_prev_header(root.header()).build();
+        let b = BlockBuilder::with_prev_header(a.header()).build();
+        let c = BlockBuilder::with_prev_header(root.header()).build();
+
+        let mut tree = test_tree(root.clone());
+        tree.extend_cached(a.clone(), BlockMetrics::default())
+            .unwrap();
+        tree.extend_cached(b.clone(), BlockMetrics::default())
+            .unwrap();
+        tree.extend_cached(c.clone(), BlockMetrics::default())
+            .unwrap();
+
+        assert_eq!(
+            tree.get_hashes(),
+            vec![
+                *root.block_hash(),
+                *a.block_hash(),
+                *b.block_hash(),
+                *c.block_hash(),
+            ]
+        );
+    }
+
     #[test]
     fn deserialize_very_deep_block_tree() {
         fn grow_tree(chain: Vec<Block>) -> BlockTree {


### PR DESCRIPTION
## Purpose

Follow-up to DEFI-2954, targeting the Bitcoin canister's elevated steady-state cycle burn under the deterministic memory tracker (DMT).

The `heartbeat_steady_state_synced` benchmark (added in the base PR #540) showed that building the `get_successors` request dominated the synchronous per-round heartbeat work (~87%). The cause is `BlockTree::get_hashes`: it recursed by returning a fresh `Vec` per node and concatenating it into the parent, re-copying each node's descendants' hashes at every level — O(n²) on a long chain. The heartbeat rebuilds this list every round, so DMT charges it repeatedly.

This rewrites `get_hashes` as a single depth-first traversal into one shared accumulator (O(n)), preserving the pre-order / root-first ordering the heartbeat relies on (it pops index 0 as the anchor), and adds a test locking that contract.

## Measured effect

Via `heartbeat_steady_state_synced`:

| scope | before | after | Δ |
|---|---|---|---|
| `build_get_successors_request` | 707.6K | 18.0K | **−97.5%** |
| total synchronous round | 809.2K | 119.7K | **−85.2%** |

(`collect_metrics`/`tip_depths`, now the largest remaining term at ~74K, is a separate follow-up.)

## Review notes

- Stacked on #540 (the benchmark). Base will be retargeted to `master` once #540 merges; the `canbench_results.yml` diff here then shows the improvement cleanly.
- canbench measures instructions, not DMT page-access charges.