### PR TITLE
perf: DEFI-2957: Cache unstable-block tip depths, refresh at push/pop

### DIFF
--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1,9 +1,12 @@
 use bitcoin::consensus::Decodable;
 use bitcoin::constants::genesis_block;
 use bitcoin::{block::Header, consensus::Encodable, Block as BitcoinBlock};
-use canbench_rs::{bench, bench_fn, BenchResult};
+use canbench_rs::{bench, bench_fn, bench_scope, BenchResult};
 use ic_btc_canister::state::main_chain_height;
-use ic_btc_canister::{types::BlockHeaderBlob, with_state, with_state_mut};
+use ic_btc_canister::{
+    types::{BlockHeaderBlob, Slicing},
+    with_state, with_state_mut,
+};
 use ic_btc_interface::{
     GetBalanceRequest, GetBlockHeadersRequest, GetCurrentFeePercentilesRequest, GetUtxosRequest,
     InitConfig, Network, NetworkInRequest,
@@ -540,6 +543,64 @@ fn bitcoin_get_current_fee_percentiles() -> BenchResult {
                 network: NetworkInRequest::Regtest,
             },
         );
+    })
+}
+
+#[bench(raw)]
+fn heartbeat_steady_state_synced() -> BenchResult {
+    let blocks_to_insert: usize = 100;
+    let num_transactions_per_block: usize = 300;
+    let num_outputs_per_transaction: usize = 3;
+
+    ic_btc_canister::init(InitConfig {
+        network: Some(Network::Regtest),
+        stability_threshold: Some((blocks_to_insert * 2) as u128),
+        ..Default::default()
+    });
+
+    let address = parsed_address();
+    let genesis = genesis_block(bitcoin::Network::Regtest);
+    let mut counter = 1u64;
+    let chain = build_chain_from(
+        genesis.header,
+        blocks_to_insert,
+        num_transactions_per_block,
+        num_outputs_per_transaction,
+        0,
+        &address,
+        &mut counter,
+    );
+
+    with_state_mut(|s| {
+        for block in &chain {
+            ic_btc_canister::state::insert_block(s, block.clone()).unwrap();
+        }
+    });
+
+    assert_chain_height(blocks_to_insert);
+
+    bench_fn(|| {
+        {
+            let _s = bench_scope("collect_metrics_tip_depths");
+            with_state(|s| {
+                let _ = s.unstable_blocks.tip_depths();
+            });
+        }
+
+        {
+            let _s = bench_scope("ingest_no_op");
+            with_state_mut(|s| {
+                let slicing = ic_btc_canister::state::ingest_stable_blocks_into_utxoset(s);
+                assert!(matches!(slicing, Slicing::Done(false)));
+            });
+        }
+
+        {
+            let _s = bench_scope("build_get_successors_request");
+            with_state(|s| {
+                let _ = ic_btc_canister::state::get_block_hashes(s);
+            });
+        }
     })
 }
 

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -79,7 +79,7 @@ benches:
   heartbeat_steady_state_synced:
     total:
       calls: 1
-      instructions: 119658
+      instructions: 46890
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
@@ -90,7 +90,7 @@ benches:
         stable_memory_increase: 0
       collect_metrics_tip_depths:
         calls: 1
-        instructions: 73672
+        instructions: 904
         heap_increase: 0
         stable_memory_increase: 0
       ingest_no_op:

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -76,6 +76,28 @@ benches:
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
+  heartbeat_steady_state_synced:
+    total:
+      calls: 1
+      instructions: 809184
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes:
+      build_get_successors_request:
+        calls: 1
+        instructions: 707618
+        heap_increase: 0
+        stable_memory_increase: 0
+      collect_metrics_tip_depths:
+        calls: 1
+        instructions: 73672
+        heap_increase: 0
+        stable_memory_increase: 0
+      ingest_no_op:
+        calls: 1
+        instructions: 24741
+        heap_increase: 0
+        stable_memory_increase: 0
   insert_300_blocks:
     total:
       calls: 1

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -79,13 +79,13 @@ benches:
   heartbeat_steady_state_synced:
     total:
       calls: 1
-      instructions: 809184
+      instructions: 119658
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_get_successors_request:
         calls: 1
-        instructions: 707618
+        instructions: 17960
         heap_increase: 0
         stable_memory_increase: 0
       collect_metrics_tip_depths:

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -607,10 +607,16 @@ impl<Block: ChainBlock> BlockTree<Block> {
 
     /// Returns the hashes of all blocks in the tree.
     pub fn get_hashes(&self) -> Vec<BlockHash> {
-        let mut hashes = Vec::with_capacity(self.children.len() + 1);
-        hashes.push(*self.root.block_hash());
-        hashes.extend(self.children.iter().flat_map(|child| child.get_hashes()));
+        let mut hashes = Vec::new();
+        self.collect_hashes(&mut hashes);
         hashes
+    }
+
+    fn collect_hashes(&self, hashes: &mut Vec<BlockHash>) {
+        hashes.push(*self.root.block_hash());
+        for child in self.children.iter() {
+            child.collect_hashes(hashes);
+        }
     }
 
     /// Returns all blocks in the tree with their depths

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -326,14 +326,18 @@ impl<Block> BlockTree<Block> {
 
     /// Returns the depths of all tips in the tree.
     pub fn tip_depths(&self) -> Vec<usize> {
-        if self.children.is_empty() {
-            return vec![1]; // Leaf node, depth is 1
+        let mut depths = Vec::new();
+        let mut stack = vec![(self, 1usize)];
+        while let Some((node, depth)) = stack.pop() {
+            if node.children.is_empty() {
+                depths.push(depth);
+            } else {
+                for child in node.children.iter() {
+                    stack.push((child, depth + 1));
+                }
+            }
         }
-
-        self.children
-            .iter()
-            .flat_map(|child| child.tip_depths().into_iter().map(|d| d + 1))
-            .collect()
+        depths
     }
 
     fn get_child_blocks(&self) -> Vec<&Block> {

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -985,6 +985,36 @@ mod test {
         assert_eq!(height_2_depth, 1);
     }
 
+    // The heartbeat pops index 0 as the anchor (`processed_block_hashes.remove(0)`), so
+    // `get_hashes` must return every block once in pre-order with the root first.
+    #[test]
+    fn get_hashes_is_preorder_with_root_first() {
+        // root -> a -> b
+        //    \--> c
+        let root = BlockBuilder::genesis().build();
+        let a = BlockBuilder::with_prev_header(root.header()).build();
+        let b = BlockBuilder::with_prev_header(a.header()).build();
+        let c = BlockBuilder::with_prev_header(root.header()).build();
+
+        let mut tree = test_tree(root.clone());
+        tree.extend_cached(a.clone(), BlockMetrics::default())
+            .unwrap();
+        tree.extend_cached(b.clone(), BlockMetrics::default())
+            .unwrap();
+        tree.extend_cached(c.clone(), BlockMetrics::default())
+            .unwrap();
+
+        assert_eq!(
+            tree.get_hashes(),
+            vec![
+                *root.block_hash(),
+                *a.block_hash(),
+                *b.block_hash(),
+                *c.block_hash(),
+            ]
+        );
+    }
+
     #[test]
     fn deserialize_very_deep_block_tree() {
         fn grow_tree(chain: Vec<Block>) -> BlockTree {

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -281,6 +281,9 @@ pub fn post_upgrade(config_update: Option<SetConfigRequest>) {
     // even if the upgrade event interrupted the canister fetching state.
     with_state_mut(|state| {
         reset_syncing_state(state);
+
+        // Repopulate the tip-depths cache, which defaults to empty for older state.
+        state.unstable_blocks.refresh_tip_depths_cache();
     });
 
     // Update the state based on the provided configuration.

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -73,6 +73,9 @@ pub struct GenericUnstableBlocks<Tree> {
     network: Network,
     // The headers of the blocks that are expected to be received.
     next_block_headers: NextBlockHeaders,
+    // Cached depths of all tips in `tree`, refreshed on push/pop.
+    #[serde(default)]
+    tip_depths_cache: Vec<usize>,
 }
 
 impl<A> GenericUnstableBlocks<A> {
@@ -83,6 +86,7 @@ impl<A> GenericUnstableBlocks<A> {
             outpoints_cache,
             network,
             next_block_headers,
+            tip_depths_cache,
         } = self;
         GenericUnstableBlocks {
             stability_threshold,
@@ -90,6 +94,7 @@ impl<A> GenericUnstableBlocks<A> {
             outpoints_cache,
             network,
             next_block_headers,
+            tip_depths_cache,
         }
     }
 }
@@ -113,12 +118,15 @@ impl UnstableBlocks {
         let mut tree = BlockTree::new_with_cache(blocks_cache, anchor);
         tree.set_root_metrics(anchor_metrics);
 
+        let tip_depths_cache = tree.tip_depths();
+
         Self {
             stability_threshold,
             tree,
             outpoints_cache,
             network,
             next_block_headers: NextBlockHeaders::default(),
+            tip_depths_cache,
         }
     }
 
@@ -173,7 +181,12 @@ impl UnstableBlocks {
 
     /// Returns the depths of all tips in the tree.
     pub fn tip_depths(&self) -> Vec<usize> {
-        self.tree.tip_depths()
+        self.tip_depths_cache.clone()
+    }
+
+    /// Recomputes the cached tip depths from the current tree.
+    pub fn refresh_tip_depths_cache(&mut self) {
+        self.tip_depths_cache = self.tree.tip_depths();
     }
 
     fn get_network(&self) -> Network {
@@ -304,6 +317,8 @@ pub fn pop(blocks: &mut UnstableBlocks, stable_height: Height) -> Option<Block> 
 
     blocks.next_block_headers.remove_until_height(stable_height);
 
+    blocks.refresh_tip_depths_cache();
+
     // The block returned here is the previous anchor block. The new
     // anchor block was its child (see above).
     Some(tree.into_root_and_remove_from_cache())
@@ -330,6 +345,8 @@ pub fn push(
     parent_block_tree.extend_cached(block, metrics)?;
 
     blocks.next_block_headers.remove(&block_hash);
+
+    blocks.refresh_tip_depths_cache();
 
     Ok(())
 }
@@ -509,6 +526,42 @@ mod test {
         // children yet, so calling `pop` should return `None`.
         assert_eq!(peek(&forest), None);
         assert_eq!(pop(&mut forest, 0), None);
+    }
+
+    #[test]
+    fn tip_depths_cache_stays_consistent_through_push_and_pop() {
+        let block_0 = BlockBuilder::genesis().build();
+        let block_1 = BlockBuilder::with_prev_header(block_0.header()).build();
+        let block_2 = BlockBuilder::with_prev_header(block_1.header()).build();
+        let block_3 = BlockBuilder::with_prev_header(block_2.header()).build();
+        let fork = BlockBuilder::with_prev_header(block_0.header()).build();
+
+        let network = Network::Regtest;
+        let utxos = UtxoSet::new(network);
+        let cache = TestBlocksCache::new(network);
+        let mut forest = UnstableBlocks::new(cache, &utxos, 2, block_0.clone(), network);
+
+        let sorted_tip_depths = |forest: &UnstableBlocks| {
+            let mut depths = forest.tip_depths();
+            depths.sort_unstable();
+            depths
+        };
+
+        assert_eq!(sorted_tip_depths(&forest), vec![1]);
+
+        // `fork` branches off the anchor, so the tree then has tips at depths 4 and 2.
+        for (block, expected) in [
+            (block_1, vec![2]),
+            (block_2, vec![3]),
+            (block_3, vec![4]),
+            (fork, vec![2, 4]),
+        ] {
+            push(&mut forest, &utxos, block).unwrap();
+            assert_eq!(sorted_tip_depths(&forest), expected);
+        }
+
+        assert!(pop(&mut forest, 0).is_some());
+        assert_eq!(sorted_tip_depths(&forest), vec![3]);
     }
 
     #[test]


### PR DESCRIPTION
## Purpose

Follow-up to DEFI-2954, reducing the Bitcoin canister's steady-state cycle burn under the deterministic memory tracker (DMT).

`collect_metrics` runs on every heartbeat and walked the entire unstable block tree via `tip_depths`, purely to populate a diagnostic histogram. The unstable tree only changes when a block is pushed (~every 10 min) or popped, so that per-round O(n) walk re-derives the same values under DMT charging.

This caches the tip depths in `UnstableBlocks` and refreshes them only at push/pop. `tip_depths` now returns the cached value, so the per-round `collect_metrics` no longer walks the tree, while the every-round histogram cadence and values are preserved. The cache is serialized (`serde(default)` for backward-compatibility) and rebuilt from the tree in `post_upgrade` for state written by an older version.

`BlockTree::tip_depths` is also made iterative: it is now called on every push, and an unstable tree on testnet/regtest can be many hundreds of blocks deep, so a recursive walk would risk overflowing the stack (the per-heartbeat call already carried this latent risk).

## Measured effect

Via `heartbeat_steady_state_synced`:

| scope | before | after | Δ |
|---|---|---|---|
| `collect_metrics_tip_depths` | 73.7K | 0.9K | **−98.8%** |
| total synchronous round | 119.7K | 46.9K | **−60.8%** |

Combined with the `get_hashes` fix (base PR), the synchronous per-round heartbeat work is down from ~809K to ~47K instructions.

## Review notes

- Stacked on the `get_hashes` PR (#541), which is itself stacked on the benchmark PR #540. Bases will be retargeted to `master` as the stack merges bottom-up.
- New test `tip_depths_cache_stays_consistent_through_push_and_pop` locks the cache-vs-fresh-walk invariant; the serde round-trip and post-upgrade tests pass with the new field.
- canbench measures instructions, not DMT page-access charges.