### PR TITLE
chore: proposal to upgrade the Bitcoin canister to release/2026-07-27

### DIFF
--- a/deployment/mainnet/bitcoin_canister_upgrade_2026_07_31.md
+++ b/deployment/mainnet/bitcoin_canister_upgrade_2026_07_31.md
@@ -1,0 +1,50 @@
+# Proposal to upgrade the Bitcoin canister
+
+Repository: `https://github.com/dfinity/bitcoin-canister.git`
+
+Git hash: `e34f709551a9d0fbbd63002c0db1a730138f0de6`
+
+New compressed Wasm hash: `9aee15c892d1dbaa9c8daf6805ffbbef0ef09c0d7afd8079d8f4ad8cb85747f1`
+
+Upgrade args hash: `1c08f4660179db8e87a4a5060ca93ea2f476fed7c25a2bd92f9cf8375eff87d9`
+
+Target canister: `ghsi2-tqaaa-aaaan-aaaca-cai`
+
+Previous Bitcoin proposal: https://dashboard.internetcomputer.org/proposal/141982
+
+---
+
+## Motivation
+Reduce the number of instructions executed in the heartbeat by removing unnecessary reads. In particular:
+- Avoid deep-cloning ingesting_block on every heartbeat.
+- Make BlockTree::get_hashes O(n) instead of O(n²).
+- Cache unstable-block tip depths, refresh at push/pop.
+
+
+## Release Notes
+
+```
+git log --format='%C(auto) %h %s' 60a9338940034536957d50a85444419501b1ecc7..e34f709551a9d0fbbd63002c0db1a730138f0de6 -- canister
+e34f709 perf: DEFI-2957: Cache unstable-block tip depths, refresh at push/pop (#543)
+a9b9886 perf: DEFI-2957: Make BlockTree::get_hashes O(n) instead of O(n²) (#541)
+b15f421 perf: DEFI-2954: Avoid deep-cloning ingesting_block on every heartbeat (#538)
+ ```
+
+## Upgrade args
+
+```
+git fetch
+git checkout e34f709551a9d0fbbd63002c0db1a730138f0de6
+didc encode -d canister/candid.did -t '(canister_arg)' '(variant { upgrade })' | xxd -r -p | sha256sum
+```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout e34f709551a9d0fbbd63002c0db1a730138f0de6
+"./scripts/docker-build" "ic-btc-canister"
+sha256sum ./ic-btc-canister.wasm.gz
+```


### PR DESCRIPTION
This upgrade reduces the Bitcoin canister's steady-state cycle burn. After the replica enabled the deterministic memory tracker (DMT), which charges instructions for every page access including reads, work that was previously free became a significant recurring cost. Because the canister does a fixed amount of work on every heartbeat, any per-round walk over in-memory state is now paid for continuously — on the staging canister this initially stalled block sync entirely, and once synced it left the canister burning roughly 2.8× more cycles than before. The changes below remove the avoidable per-round work from the heartbeat path.

Stop re-copying block data on every heartbeat: The block-ingestion path duplicated and deep-compared the entire block currently being ingested on every heartbeat, purely to determine whether any ingestion work had happened. That comparison touched the full block plus its growing set of UTXO changes, and it did so once per heartbeat even though the block itself does not change between slices. The same answer is now derived directly from the ingestion result, with no change in behaviour.

Build the block-hash request in linear time: Each heartbeat asks the adapter for new blocks, and assembling that request required collecting the hashes of all unstable blocks. The collection re-copied every block's descendants at each level of the tree, making it quadratic in the number of unstable blocks, and it was rebuilt from scratch every round. It is now a single linear traversal, preserving the ordering the heartbeat depends on. This alone removed roughly 85% of the synchronous per-round work.

Cache tip depths instead of re-deriving them: The metrics collected on every heartbeat walked the entire unstable block tree to populate a diagnostic histogram, even though that tree only changes when a block is added (roughly every ten minutes) or removed. The depths are now cached and refreshed only when the tree changes, leaving the reported metrics and their cadence unchanged. The cache is carried across upgrades and rebuilt from existing state when upgrading from an older version. The traversal was also made iterative so that the deep unstable trees possible on testnet and regtest cannot exhaust the stack.

Together these bring the synchronous work per heartbeat down from roughly 809K to 47K instructions.